### PR TITLE
fix(security): share-token/rate-limit/admin/JSON-LD の脆弱性を解消

### DIFF
--- a/apps/api/src/__tests__/rate-limit.test.ts
+++ b/apps/api/src/__tests__/rate-limit.test.ts
@@ -82,4 +82,36 @@ describe("rateLimitByIp middleware", () => {
 
     expect(res.status).toBe(200);
   });
+
+  it("prefers x-real-ip over x-forwarded-for to prevent spoofing", async () => {
+    const app = new Hono();
+    app.use("*", rateLimitByIp({ window: 60, max: 1 }));
+    app.get("/test", (c) => c.json({ ok: true }));
+
+    await app.request("/test", {
+      headers: { "x-real-ip": "9.9.9.9", "x-forwarded-for": "1.1.1.1" },
+    });
+    // Client tries to evade by spoofing x-forwarded-for to a fresh value, but x-real-ip is still 9.9.9.9
+    const res = await app.request("/test", {
+      headers: { "x-real-ip": "9.9.9.9", "x-forwarded-for": "2.2.2.2" },
+    });
+
+    expect(res.status).toBe(429);
+  });
+
+  it("uses the last entry of x-forwarded-for (trusted proxy hop)", async () => {
+    const app = new Hono();
+    app.use("*", rateLimitByIp({ window: 60, max: 1 }));
+    app.get("/test", (c) => c.json({ ok: true }));
+
+    // Attacker controls the leftmost value; the trusted proxy appends the real client IP on the right.
+    await app.request("/test", {
+      headers: { "x-forwarded-for": "evil-spoof, 7.7.7.7" },
+    });
+    const res = await app.request("/test", {
+      headers: { "x-forwarded-for": "different-spoof, 7.7.7.7" },
+    });
+
+    expect(res.status).toBe(429);
+  });
 });

--- a/apps/api/src/__tests__/share-token.test.ts
+++ b/apps/api/src/__tests__/share-token.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from "vitest";
 import { generateShareToken } from "../lib/share-token";
 
 describe("generateShareToken", () => {
-  it("generates an 11-character token", () => {
+  it("generates a 43-character token (32 bytes base64url)", () => {
     const token = generateShareToken();
-    expect(token).toHaveLength(11);
+    expect(token).toHaveLength(43);
   });
 
   it("uses only base64url characters", () => {

--- a/apps/api/src/lib/share-token.ts
+++ b/apps/api/src/lib/share-token.ts
@@ -2,7 +2,8 @@ import crypto from "node:crypto";
 import { SEVEN_DAYS_MS } from "./constants";
 
 export function generateShareToken(): string {
-  return crypto.randomBytes(8).toString("base64url");
+  // 32 bytes → 43 base64url chars. 64 bit was too thin for public /api/shared/:token brute force.
+  return crypto.randomBytes(32).toString("base64url");
 }
 
 export function shareExpiresAt(): Date {

--- a/apps/api/src/middleware/rate-limit.ts
+++ b/apps/api/src/middleware/rate-limit.ts
@@ -30,9 +30,12 @@ export function rateLimitByIp(opts: { window: number; max: number }) {
   const storeRef = store;
 
   return async (c: Context, next: Next) => {
+    // Prefer x-real-ip (Vercel sets it from the upstream edge, not spoofable by clients).
+    // Fall back to the *last* entry of x-forwarded-for — the rightmost hop is the one added
+    // by the trusted proxy, so taking the leftmost lets clients spoof the source IP.
     const ip =
-      c.req.header("x-forwarded-for")?.split(",")[0]?.trim() ||
-      c.req.header("x-real-ip") ||
+      c.req.header("x-real-ip")?.trim() ||
+      c.req.header("x-forwarded-for")?.split(",").at(-1)?.trim() ||
       "unknown";
     const now = Date.now();
     const entry = storeRef.get(ip);

--- a/apps/api/src/middleware/require-admin.ts
+++ b/apps/api/src/middleware/require-admin.ts
@@ -3,12 +3,13 @@ import type { Context, Next } from "hono";
 import { db } from "../db/index";
 import { users } from "../db/schema";
 import { ERROR_MSG } from "../lib/constants";
+import { logger } from "../lib/logger";
 import type { AppEnv } from "../types";
 
 export async function requireAdmin(c: Context<AppEnv>, next: Next) {
   const user = c.get("user");
 
-  // Prefer ADMIN_USER_ID (immutable) over ADMIN_USERNAME (user-changeable)
+  // Prefer ADMIN_USER_ID (immutable) over ADMIN_USERNAME (user-changeable).
   const adminUserId = process.env.ADMIN_USER_ID;
   if (adminUserId) {
     if (user.id !== adminUserId) {
@@ -18,7 +19,14 @@ export async function requireAdmin(c: Context<AppEnv>, next: Next) {
     return;
   }
 
-  // Fallback: username-based check for backward compatibility
+  // In production, refuse the username fallback — usernames are user-editable, so relying on
+  // them as an authorization boundary risks self-lockout and social-engineering attacks.
+  // ADMIN_USER_ID must be set in prod.
+  if (process.env.NODE_ENV === "production") {
+    logger.error("requireAdmin: ADMIN_USER_ID is not configured in production");
+    return c.json({ error: ERROR_MSG.FORBIDDEN }, 403);
+  }
+
   const adminUsername = process.env.ADMIN_USERNAME;
   if (!adminUsername) {
     return c.json({ error: ERROR_MSG.FORBIDDEN }, 403);

--- a/apps/api/src/routes/trips.ts
+++ b/apps/api/src/routes/trips.ts
@@ -680,6 +680,7 @@ tripRoutes.post("/:id/duplicate", requireTripAccess("viewer", "id"), async (c) =
 
 // Upload cover image (editor+)
 tripRoutes.post("/:id/cover-image", requireTripAccess("editor", "id"), async (c) => {
+  const user = c.get("user");
   const tripId = getParam(c, "id");
 
   const body = await c.req.parseBody();
@@ -708,7 +709,10 @@ tripRoutes.post("/:id/cover-image", requireTripAccess("editor", "id"), async (c)
     const buffer = Buffer.from(await file.arrayBuffer());
     coverImageUrl = await uploadCoverImage(tripId, buffer, file.type);
   } catch (err) {
-    logger.error({ err }, "Cover image upload failed");
+    logger.error(
+      { err, tripId, userId: user.id, fileSize: file.size, fileType: file.type },
+      "Cover image upload failed",
+    );
     return c.json({ error: ERROR_MSG.INTERNAL_ERROR }, 500);
   }
 

--- a/apps/web/app/faq/page.tsx
+++ b/apps/web/app/faq/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { getLocale, getTranslations } from "next-intl/server";
 import { Logo } from "@/components/logo";
 import { pageTitle } from "@/lib/constants";
+import { stringifyJsonLd } from "@/lib/json-ld";
 import { FaqSearch } from "./_components/faq-search";
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -31,7 +32,7 @@ export default async function FaqPage() {
     <div className="flex min-h-screen flex-col">
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        dangerouslySetInnerHTML={{ __html: stringifyJsonLd(jsonLd) }}
       />
       <header className="container flex h-14 items-center">
         <Logo href="/" />

--- a/apps/web/app/news/[slug]/page.tsx
+++ b/apps/web/app/news/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { getLocale, getTranslations } from "next-intl/server";
 import Markdown from "react-markdown";
 import { Logo } from "@/components/logo";
 import { pageTitle } from "@/lib/constants";
+import { stringifyJsonLd } from "@/lib/json-ld";
 import { getAllNews, getNewsBySlug } from "@/lib/news";
 import { getSeason } from "@/lib/season";
 
@@ -68,7 +69,7 @@ export default async function NewsArticlePage({ params }: Props) {
     <div className="flex min-h-screen flex-col">
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        dangerouslySetInnerHTML={{ __html: stringifyJsonLd(jsonLd) }}
       />
       <header className="container flex h-14 items-center">
         <Logo href="/" />

--- a/apps/web/lib/json-ld.ts
+++ b/apps/web/lib/json-ld.ts
@@ -1,0 +1,9 @@
+// Stringify a JSON-LD payload for embedding inside <script type="application/ld+json">.
+// Browsers terminate the script element on the first "</script>" they see — even inside a
+// quoted JSON string — so we need to escape the closing tag. Also escape "<!--" so the
+// payload cannot open an HTML comment that hides following markup.
+export function stringifyJsonLd(value: unknown): string {
+  return JSON.stringify(value)
+    .replace(/<\/(script)/gi, "<\\/$1")
+    .replace(/<!--/g, "<\\!--");
+}

--- a/apps/web/lib/json-ld.ts
+++ b/apps/web/lib/json-ld.ts
@@ -1,9 +1,11 @@
 // Stringify a JSON-LD payload for embedding inside <script type="application/ld+json">.
 // Browsers terminate the script element on the first "</script>" they see — even inside a
-// quoted JSON string — so we need to escape the closing tag. Also escape "<!--" so the
-// payload cannot open an HTML comment that hides following markup.
+// quoted JSON string — so we need to escape the closing tag. Also escape "<!--" and "]]>"
+// so the payload cannot open an HTML comment or close a CDATA section that hides following
+// markup (JSON-LD is sometimes served as XHTML/CDATA by third-party indexers).
 export function stringifyJsonLd(value: unknown): string {
   return JSON.stringify(value)
     .replace(/<\/(script)/gi, "<\\/$1")
-    .replace(/<!--/g, "<\\!--");
+    .replace(/<!--/g, "<\\!--")
+    .replace(/]]>/g, "]]\\u003e");
 }


### PR DESCRIPTION
## Summary

本セッション初期のセキュリティ監査で発見された脆弱性の是正をまとめて適用します。

- **share-token** を 64bit → 256bit (`randomBytes(8)` → `randomBytes(32)`) に拡張し公開 URL のブルートフォース耐性を強化
- **rate-limit** で `x-real-ip` を最優先、`x-forwarded-for` は最右エントリを採用して IP 偽装を阻止
- **require-admin** で本番環境 (NODE_ENV=production) では ADMIN_USERNAME フォールバックを拒否し ADMIN_USER_ID 必須化
- **JSON-LD** で `</script>` と `<!--` をエスケープする `stringifyJsonLd` ユーティリティを導入し FAQ/News ページに適用
- **trips cover image** のエラーログに tripId/userId/fileSize/fileType を付与

## Test plan

- [x] `bun run check` / `bun run check-types` / `bun run test` 全 green
- [x] rate-limit は IP 偽装経路の新規テストを追加済み
- [x] share-token は 43 文字 (32 バイト base64url) の新しい期待値を反映