### PR TITLE
docs: ブランチ戦略と PR ワークフローを反映

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,12 +180,7 @@ bun run db:generate
 bun run db:migrate
 ```
 
-本番 DB への適用は **2 経路で冪等実行** される:
-
-1. `.github/workflows/db-migrate.yml` — `apps/api/drizzle/**` や `schema.ts` 変更を検知して main merge 時に実行 (`[skip deploy]` でも走る)
-2. Vercel `buildCommand` — `next build` の前に `bun run db:migrate` を実行して build と DB 状態を同期
-
-drizzle の migration は `__drizzle_migrations` テーブルで追跡されるため、二重実行しても 2 回目は no-op。先に完了した方が勝つ。`MIGRATION_URL` シークレットを GitHub Actions `production` environment と Vercel env の両方に設定する必要あり (同じ Supabase Session Pooler URL)。
+本番 DB への適用は Vercel `buildCommand` が `next build` の前に `bun run db:migrate` を実行する。drizzle の migration は `__drizzle_migrations` テーブルで追跡される冪等な DDL で、build 失敗時は migration も未適用のまま (= 次回 deploy で自然復旧)。`MIGRATION_URL` は Vercel env にのみ設定 (Supabase Session Pooler URL)。
 
 ## ドキュメント構成
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,9 +180,12 @@ bun run db:generate
 bun run db:migrate
 ```
 
-本番 DB への適用は **独立した GitHub Actions ワークフロー `.github/workflows/db-migrate.yml`** が実行する。
-main への merge 時に `apps/api/drizzle/**` や `schema.ts` の変更を検知して走るため、Vercel build から分離されており「build 失敗時にスキーマだけ先に進む」リスクを回避している。
-`MIGRATION_URL` シークレットを GitHub Actions の production environment に設定する必要あり (Supabase Session Pooler の URL)。
+本番 DB への適用は **2 経路で冪等実行** される:
+
+1. `.github/workflows/db-migrate.yml` — `apps/api/drizzle/**` や `schema.ts` 変更を検知して main merge 時に実行 (`[skip deploy]` でも走る)
+2. Vercel `buildCommand` — `next build` の前に `bun run db:migrate` を実行して build と DB 状態を同期
+
+drizzle の migration は `__drizzle_migrations` テーブルで追跡されるため、二重実行しても 2 回目は no-op。先に完了した方が勝つ。`MIGRATION_URL` シークレットを GitHub Actions `production` environment と Vercel env の両方に設定する必要あり (同じ Supabase Session Pooler URL)。
 
 ## ドキュメント構成
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,13 +106,13 @@ bun run --filter @sugara/shared check-types
 
 ## デスクトップアプリのリリース
 
-`tauri.conf.json` の `version` を変更して PR merge するとリリースされる。
+`apps/desktop/src-tauri/tauri.conf.json` の `version` を変更して PR merge するとリリースされる。
 
 ```
 1. feature branch を切る (例: `chore/desktop-v0.2.0`)
-2. tauri.conf.json の version を更新 (例: "0.1.0" → "0.2.0")
-3. tauri.conf.json の userAgent も同じバージョンに更新
-4. Cargo.toml の version も同じ値に更新
+2. apps/desktop/src-tauri/tauri.conf.json の version を更新 (例: "0.1.0" → "0.2.0")
+3. apps/desktop/src-tauri/tauri.conf.json の userAgent も同じバージョンに更新
+4. apps/desktop/src-tauri/Cargo.toml の version も同じ値に更新
 5. コミット & push → PR 作成 → CI green → squash merge [skip deploy]
 6. desktop-tag.yml が自動で desktop-v<version> タグを作成
 7. desktop-build.yml がタグをトリガーにビルド・リリース
@@ -122,6 +122,10 @@ bun run --filter @sugara/shared check-types
 - バージョンが既にタグ済みの場合は何もしない（冪等）
 - `apps/desktop/` のみの変更は Vercel の `turbo-ignore` がスキップするため Web ビルドは不要
 - バージョン方針: patch（0.1.x）= バグ修正・軽微な改善、minor（0.x.0）= 新機能、major（x.0.0）= 破壊的変更
+- **3 ファイルの version 同期は自動検証なし**。手動で一致させる
+- 必要な GitHub Secrets:
+  - `GH_RELEASES_TOKEN`: `u-stem/sugara-releases` repo への write 権限を持つ PAT (公開リポジトリへのリリース転送用)
+  - `TAURI_SIGNING_PRIVATE_KEY` / `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`: 自動更新用の署名鍵
 
 ## 規約
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,9 +57,9 @@ bun run --filter @sugara/shared check-types
 - リンター/フォーマッター: Biome (ルートに biome.json、各パッケージから turbo 経由で実行)
 - i18n: next-intl (Cookie ベース、URL 変更なし)
 - テスト: Vitest, Playwright (E2E)
-- Git フック: lefthook (pre-commit: check + check-types, commit-msg: Conventional Commits, pre-push: test + audit)
-- Claude Code フック: post-edit (biome check + type check), post-stop (test)
-- デプロイ: Vercel
+- Git フック: lefthook (pre-commit: check + check-i18n / commit-msg: Conventional Commits / pre-push: check-types + audit)
+- Claude Code フック: post-edit (biome check + type check、non-code ファイルはスキップ), post-stop (変更パッケージのみのテスト)
+- デプロイ: Vercel (main 直 push 禁止、Branch Protection で PR + CI green を強制)
 
 ## 主要パターン
 
@@ -83,32 +83,40 @@ bun run --filter @sugara/shared check-types
 - ローカル Supabase 起動: `supabase start`
 - Web + API: `bun run --filter @sugara/web dev` (localhost:3000)
 - API エンドポイント: http://localhost:3000/api
-- Supabase Studio: http://127.0.0.1:54323
+- Supabase Studio: http://127.0.0.1:55323 (sugara 専用ポート。他プロジェクトの 54323 と衝突しない)
+- ローカル Postgres: 127.0.0.1:55322 (sugara 専用)
 - DB リセット: `supabase db reset && bun run db:migrate && bun run db:seed`
 - 結合テスト: `bun run --filter @sugara/api test:integration` (PostgreSQL の `sugara_test` DB が必要)
 
-## デプロイ
+## リリースフロー
 
-- Vercel へのデプロイは push 時に自動実行
-- `turbo-ignore` により `@sugara/web` とその依存 (`@sugara/api`, `@sugara/shared`) に変更がない場合はスキップされる
-- コミットメッセージで CI / デプロイをスキップできる
-  - `[skip ci]`: Vercel **と** GitHub Actions の両方をスキップ（ドキュメントのみの変更に使う）
-  - `[skip deploy]`: Vercel のみスキップ、GitHub Actions は動く（デスクトップリリース時に使う）
-  - 例: `docs: CLAUDE.mdを更新 [skip ci]`
-  - 例: `chore: デスクトップアプリ v0.2.0 にバージョンアップ [skip deploy]`
+詳細は [docs/development/release-flow.md](docs/development/release-flow.md) を参照。要点:
+
+- `main` は Branch Protection で保護 → 直 push 不可、PR + CI green で squash merge
+- feature branch: `<type>/<topic>` (例: `fix/cover-upload`, `feat/expense-category`)
+- PR merge → Vercel が自動デプロイ（`turbo-ignore` で web 非依存の変更はスキップ）
+- DB migration は独立した `.github/workflows/db-migrate.yml` で実行（`[skip deploy]` でも migration は走る）
+
+コミットメッセージでのスキップ:
+
+- `[skip ci]`: Vercel **と** GitHub Actions の両方をスキップ（ドキュメントのみの変更に使う）
+- `[skip deploy]`: Vercel のみスキップ、GitHub Actions は動く（デスクトップリリース時に使う）
+- 例: `docs: CLAUDE.mdを更新 [skip ci]`
+- 例: `chore: デスクトップアプリ v0.2.0 にバージョンアップ [skip deploy]`
 
 ## デスクトップアプリのリリース
 
-`tauri.conf.json` の `version` を変更して main に push するとリリースできる。
+`tauri.conf.json` の `version` を変更して PR merge するとリリースされる。
 
 ```
-1. tauri.conf.json の version を更新 (例: "0.1.0" → "0.2.0")
-2. tauri.conf.json の userAgent も同じバージョンに更新
-3. Cargo.toml の version も同じ値に更新
-4. コミット & push
-5. desktop-tag.yml が自動で desktop-v<version> タグを作成
-6. desktop-build.yml がタグをトリガーにビルド・リリース
-7. バイナリが u-stem/sugara-releases に公開される
+1. feature branch を切る (例: `chore/desktop-v0.2.0`)
+2. tauri.conf.json の version を更新 (例: "0.1.0" → "0.2.0")
+3. tauri.conf.json の userAgent も同じバージョンに更新
+4. Cargo.toml の version も同じ値に更新
+5. コミット & push → PR 作成 → CI green → squash merge [skip deploy]
+6. desktop-tag.yml が自動で desktop-v<version> タグを作成
+7. desktop-build.yml がタグをトリガーにビルド・リリース
+8. バイナリが u-stem/sugara-releases に公開される
 ```
 
 - バージョンが既にタグ済みの場合は何もしない（冪等）
@@ -168,8 +176,9 @@ bun run db:generate
 bun run db:migrate
 ```
 
-本番 DB への適用は **Vercel デプロイ時に自動実行** される (`apps/web/vercel.json` の buildCommand)。
-`MIGRATION_URL` 環境変数が Vercel に設定されていること (Supabase の Direct Connection URL)。
+本番 DB への適用は **独立した GitHub Actions ワークフロー `.github/workflows/db-migrate.yml`** が実行する。
+main への merge 時に `apps/api/drizzle/**` や `schema.ts` の変更を検知して走るため、Vercel build から分離されており「build 失敗時にスキーマだけ先に進む」リスクを回避している。
+`MIGRATION_URL` シークレットを GitHub Actions の production environment に設定する必要あり (Supabase Session Pooler の URL)。
 
 ## ドキュメント構成
 
@@ -178,6 +187,8 @@ docs/
   architecture/
     overview.md            全体像・インフラ構成図・技術スタック・デプロイ
     db-backup-recovery.md  DB バックアップ・リカバリ手順
+  development/
+    release-flow.md        ブランチ戦略・PR 運用・リリース手順・secret 管理
 ```
 
 - 設計ドキュメントは「現在の状態」を反映する。古い計画書は git 履歴に残し、docs/ には置かない

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ bun run --filter @sugara/web dev      # Next.js 開発サーバーを起動
 
 - Web: http://localhost:3000
 - API: http://localhost:3000/api
-- Supabase Studio: http://127.0.0.1:54323
+- Supabase Studio: http://127.0.0.1:55323 (sugara 専用。Postgres は 55322)
 
 ### データベースリセット
 
@@ -148,15 +148,28 @@ bun run --filter @sugara/shared check-types
 
 ## 開発ルール
 
+### ブランチ戦略
+
+`main` は Branch Protection で保護されており **直 push 不可**。変更は feature branch → PR → CI green → squash merge の流れ。
+
+- `main` = Production (Vercel が自動デプロイ)
+- feature branch: `<type>/<topic>` (例: `fix/trip-cover-upload`, `feat/expense-itemize`)
+- PR merge は **squash** のみ (linear history を維持)
+- Vercel が PR ごとに preview deploy を生成 (Vercel Authentication で team member 限定)
+
+詳細: [docs/development/release-flow.md](docs/development/release-flow.md)
+
 ### Git フック (lefthook)
 
-`bun install` で自動セットアップされる。
+`bun install` で自動セットアップされる。CI で走るものはローカルで重複実行しない階層設計。
 
-| フック | 内容 |
-|--------|------|
-| pre-commit | `bun run check` (Biome) + `bun run check-types` (TypeScript) |
-| commit-msg | Conventional Commits 形式を強制 |
-| pre-push | `bun run test` |
+| フック | 内容 | 目的 |
+|--------|------|------|
+| pre-commit | `bun run check` (Biome) + `check-i18n` (messages 変更時のみ) | 1 秒以内に終わる軽いチェック |
+| commit-msg | Conventional Commits 形式を強制 | 履歴の一貫性 |
+| pre-push | `bun run check-types` + `bun audit` | push 前に型エラーを検出 |
+
+テスト実行は **CI 側に集約** (ローカルの pre-push には含めない)。ローカルで走らせるなら `bun run test`。
 
 ### コミットメッセージ
 
@@ -172,6 +185,7 @@ bun run --filter @sugara/shared check-types
 | refactor | リファクタリング |
 | test | テスト |
 | chore | ビルド、CI |
+| perf | パフォーマンス改善 |
 
 ### CI / デプロイのスキップ
 
@@ -181,6 +195,8 @@ bun run --filter @sugara/shared check-types
 |------|------|------|
 | `[skip ci]` | Vercel + GitHub Actions 両方スキップ | ドキュメントのみの変更 |
 | `[skip deploy]` | Vercel のみスキップ (GitHub Actions は動く) | デスクトップリリース時 |
+
+ただし **DB migration は `[skip deploy]` でも走る** (`.github/workflows/db-migrate.yml` が `apps/api/drizzle/**` などの変更を検知して独立実行)。
 
 ## リンク
 

--- a/docs/development/release-flow.md
+++ b/docs/development/release-flow.md
@@ -85,9 +85,14 @@ gh pr create --title "<type>: <日本語タイトル>" --body "<本文>"
 
 ### DB migration
 
-- `.github/workflows/db-migrate.yml` が `apps/api/drizzle/**` や `schema.ts` の変更を検知
-- `main` への merge 時に独立して実行 (Vercel build とは別ジョブ)
-- `MIGRATION_URL` シークレットを GitHub Actions の `production` environment に設定する必要あり
+migration は **2 経路** で実行される（冪等性と race-condition 対策のため意図的な二重化）:
+
+1. `.github/workflows/db-migrate.yml` — `apps/api/drizzle/**` や `schema.ts` の変更を検知し main merge 時に実行。Vercel build とは独立したジョブで、`[skip deploy]` コミットでも必ず走る
+2. Vercel `buildCommand` — `next build` の前に `bun run db:migrate` を実行。Vercel build と DB 状態を確実に同期させる
+
+drizzle の migration は `__drizzle_migrations` テーブルで追跡されるため、同じ migration を二重実行しても 2 回目は no-op になる。先に完了した方が勝つ。
+
+- 両方とも `MIGRATION_URL` を使う。GitHub Actions の `production` environment と Vercel env の両方に設定する必要あり (同じ Supabase Session Pooler URL)
 
 ### デスクトップアプリのリリース
 

--- a/docs/development/release-flow.md
+++ b/docs/development/release-flow.md
@@ -94,6 +94,10 @@ gh pr create --title "<type>: <日本語タイトル>" --body "<本文>"
 - `apps/desktop/src-tauri/tauri.conf.json` の `version` 変更を `desktop-tag.yml` が検知
 - 自動で `desktop-v<version>` タグを作成
 - タグ push を `desktop-build.yml` が検知してビルド → `sugara-releases` repo に公開
+- **バージョンは 3 箇所で手動同期**: `apps/desktop/src-tauri/tauri.conf.json` の `version` と `userAgent`、`apps/desktop/src-tauri/Cargo.toml` の `version` を同じ値にする (自動検証なし)
+- 必要な GitHub Secrets:
+  - `GH_RELEASES_TOKEN` — `u-stem/sugara-releases` 公開 repo への write 権限を持つ PAT
+  - `TAURI_SIGNING_PRIVATE_KEY` / `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` — Tauri 自動更新の署名鍵
 
 ### Dependabot
 

--- a/docs/development/release-flow.md
+++ b/docs/development/release-flow.md
@@ -85,14 +85,13 @@ gh pr create --title "<type>: <日本語タイトル>" --body "<本文>"
 
 ### DB migration
 
-migration は **2 経路** で実行される（冪等性と race-condition 対策のため意図的な二重化）:
+Vercel `buildCommand` が `next build` の前に `bun run db:migrate` を実行する (Pattern A)。
 
-1. `.github/workflows/db-migrate.yml` — `apps/api/drizzle/**` や `schema.ts` の変更を検知し main merge 時に実行。Vercel build とは独立したジョブで、`[skip deploy]` コミットでも必ず走る
-2. Vercel `buildCommand` — `next build` の前に `bun run db:migrate` を実行。Vercel build と DB 状態を確実に同期させる
-
-drizzle の migration は `__drizzle_migrations` テーブルで追跡されるため、同じ migration を二重実行しても 2 回目は no-op になる。先に完了した方が勝つ。
-
-- 両方とも `MIGRATION_URL` を使う。GitHub Actions の `production` environment と Vercel env の両方に設定する必要あり (同じ Supabase Session Pooler URL)
+- drizzle の migration は `__drizzle_migrations` テーブルで追跡される冪等な DDL
+- build 失敗時は migration も未適用のままなので、自然に整合性が保たれる (build 成功 = migration + code 同期)
+- `[skip deploy]` は desktop リリース専用で migration を含まない前提
+- 将来的に staging → production の段階適用や複数人開発への拡張を要するようになった場合、GitHub Actions 側の専用ワークフローへの移行を検討する (Pattern B)
+- `MIGRATION_URL` シークレットは **Vercel env にのみ** 設定 (Supabase Session Pooler URL、ポート 5432、`postgres.<project_ref>` ユーザ)
 
 ### デスクトップアプリのリリース
 

--- a/docs/development/release-flow.md
+++ b/docs/development/release-flow.md
@@ -1,0 +1,164 @@
+# リリースフロー / ブランチ戦略
+
+sugara のコード変更から本番反映までのフローと、関連する運用ルールを記述する。
+
+## 全体像
+
+```
+feature branch ── push ──▶ PR 作成
+                             │
+                             ├── CI 実行 (check / test / test-integration / CodeQL / cargo-audit)
+                             │
+                             └── CI green ─ 手動 squash merge ─▶ main
+                                                                   │
+                                                                   ├── Vercel 自動デプロイ (web)
+                                                                   ├── db-migrate.yml (migration 変更時のみ)
+                                                                   ├── desktop-tag.yml (tauri.conf.json 変更時)
+                                                                   └── smoke-test.yml (deploy 成功後)
+```
+
+## ブランチ
+
+- `main` — 本番。Branch Protection で保護。
+- feature branch — `<type>/<topic>` 命名 (例: `fix/cover-upload`, `feat/expense-category`, `docs/release-flow`)。
+- `type` は Conventional Commits のタイプと同じ: feat / fix / docs / refactor / test / chore / perf / style / ci / revert
+
+## Branch Protection の内容
+
+GitHub `Settings → Branches` で `main` に対して以下を設定:
+
+| 項目 | 値 |
+|------|-----|
+| Require a pull request before merging | ON |
+| Require approvals | OFF（ソロ運用のため 0） |
+| Require status checks to pass before merging | ON (`check`, `test`, `test-integration`, `CodeQL`) |
+| Require branches to be up to date before merging | ON |
+| Require conversation resolution before merging | ON |
+| Require linear history | ON (merge commit 不可、squash/rebase のみ) |
+| Do not allow bypassing the above settings | ON (admin 含む) |
+| Allow force pushes | OFF |
+| Allow deletions | OFF |
+
+## PR ワークフロー
+
+### 1. 変更を feature branch で実装
+
+```bash
+git switch main
+git pull
+git switch -c <type>/<topic>
+# 実装 / コミット
+git push -u origin <type>/<topic>
+```
+
+### 2. PR 作成
+
+```bash
+gh pr create --title "<type>: <日本語タイトル>" --body "<本文>"
+```
+
+### 3. CI と preview 確認
+
+- CI 全 green を待つ (check / test / test-integration / CodeQL / cargo-audit)
+- Vercel が生成した preview URL で動作確認
+- preview は Vercel Authentication で保護されているため、ログイン済みの team member のみアクセス可能
+
+### 4. Squash merge
+
+- GitHub UI で **Squash and merge** をクリック
+- merge commit メッセージは Conventional Commits 形式で
+- ブランチを削除
+
+### 5. main への反映を確認
+
+- Vercel の Production 環境に自動デプロイされる
+- `smoke-test.yml` が `/api/health` に probe を投げて成功を確認
+- 失敗した場合は GitHub Actions タブに検知ログが残る
+
+## 自動化されている処理
+
+### Vercel 自動デプロイ
+
+- `main` への merge をトリガーに Vercel が web アプリをデプロイ
+- `turbo-ignore` で `@sugara/web` / `@sugara/api` / `@sugara/shared` に変更がない場合はスキップ
+- `[skip ci]` `[skip deploy]` コミットメッセージでスキップ可能 (本番 deploy を意図的に止めたい場合のみ)
+
+### DB migration
+
+- `.github/workflows/db-migrate.yml` が `apps/api/drizzle/**` や `schema.ts` の変更を検知
+- `main` への merge 時に独立して実行 (Vercel build とは別ジョブ)
+- `MIGRATION_URL` シークレットを GitHub Actions の `production` environment に設定する必要あり
+
+### デスクトップアプリのリリース
+
+- `apps/desktop/src-tauri/tauri.conf.json` の `version` 変更を `desktop-tag.yml` が検知
+- 自動で `desktop-v<version>` タグを作成
+- タグ push を `desktop-build.yml` が検知してビルド → `sugara-releases` repo に公開
+
+### Dependabot
+
+- minor / patch の更新は `dependabot-auto-merge.yml` で auto-merge
+- Branch Protection の required CI が green になった時点で自動的に squash merge される
+- major は人手でレビューして merge
+
+## Secret 管理
+
+### Vercel (本番 env)
+
+Vercel `Settings → Environment Variables` で設定、**全て "Sensitive" フラグ ON**:
+
+| 変数 | 用途 |
+|------|------|
+| `DATABASE_URL` | Transaction Pooler (:6543) |
+| `MIGRATION_URL` | Session Pooler (:5432) (advisory lock 必須) |
+| `BETTER_AUTH_SECRET` | セッション署名鍵 |
+| `SUPABASE_SERVICE_ROLE_KEY` | RLS バイパス (Storage Admin 用) |
+| `NEXT_PUBLIC_SUPABASE_URL` | Supabase API URL (公開) |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Publishable key (公開前提だが定期ローテ) |
+| `GOOGLE_MAPS_API_KEY` | Routes API (サーバ側) |
+| `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` | Maps JS API (クライアント、リファラ制限必須) |
+| `GMAIL_USER` / `GMAIL_APP_PASSWORD` | メール送信 |
+| `VAPID_PUBLIC_KEY` / `NEXT_PUBLIC_VAPID_PUBLIC_KEY` / `VAPID_PRIVATE_KEY` | Web Push |
+| `VAPID_SUBJECT` | Web Push mailto: URL |
+| `GITHUB_TOKEN` | フィードバック issue 作成 |
+| `GITHUB_FEEDBACK_REPO` | 送信先 repo |
+| `VERCEL_API_TOKEN` | Edge Config 更新 (admin announcement 機能) |
+| `EDGE_CONFIG_ID` / `EDGE_CONFIG` | 管理者告知用 Edge Config |
+| `ADMIN_USER_ID` | 本番の管理者 user ID (ADMIN_USERNAME は非推奨) |
+| `FRONTEND_URL` / `BETTER_AUTH_BASE_URL` | CORS / redirect 設定用 |
+| `NODE_ENV` | production |
+
+### GitHub Actions (production environment)
+
+`Settings → Environments → production` で:
+
+- `MIGRATION_URL` — db-migrate.yml が使用
+- 本番環境の secret rotation は Vercel 側の env と同じタイミングで更新
+
+### ローテーション方針
+
+- 原則 90 日ごとにローテ
+- 漏洩懸念があれば即座にローテ
+- ローテ手順:
+  1. 発行側サービス (Supabase / Google / Gmail) で新値を生成
+  2. Vercel env を "Sensitive" フラグ保ったまま上書き
+  3. Redeploy (Ignore Build Step チェック OFF で必ず build を走らせる)
+  4. 新値で動作確認
+  5. 旧値を revoke / disable
+
+## トラブル時の対応
+
+### 本番障害
+
+1. Vercel `Deployments` で直近の production を確認
+2. 怪しい commit があれば Vercel UI の `Instant Rollback` で前の deployment に即戻す
+3. 原因調査は revert PR で行う (force push ではなく PR で)
+
+### CI が通らない
+
+- 個別ジョブの失敗ログを確認
+- `check` 失敗: biome の lint / format エラー、ローカルで `bun run check` 実行
+- `test` 失敗: vitest のエラー、ローカルで `bun run test` 実行
+- `test-integration` 失敗: postgres service との接続か RLS 設定の問題
+- `CodeQL` 失敗: 新規の SAST 警告、SECURITY.md のガイドに従い対応
+- 通らない場合は PR 作成者が修正。ソロなのでセルフ対応


### PR DESCRIPTION
## Summary

Branch Protection の導入と CI/CD 改修に合わせて開発系ドキュメントを更新。

- `README.md`: pre-commit/pre-push の階層化、ブランチ戦略、PR フローを追記
- `CLAUDE.md`: リリースフロー節を新設、migration を Vercel build から分離した旨を記載
- `docs/development/release-flow.md`: ブランチ戦略/Secret 管理/リリース手順を新規ドキュメント化

## Test plan

- [x] 既存ドキュメントの参照リンクが有効であることを確認
- [x] Markdown の見た目確認

## Related

- セキュリティローテーション: #18