### PR TITLE
fix(web): VAPID ローテーション後の push subscription を自動復旧

### DIFF
--- a/apps/web/lib/hooks/use-push-subscription.ts
+++ b/apps/web/lib/hooks/use-push-subscription.ts
@@ -10,21 +10,16 @@ function urlBase64ToUint8Array(base64String: string): Uint8Array<ArrayBuffer> {
   return new Uint8Array([...rawData].map((c) => c.charCodeAt(0))) as Uint8Array<ArrayBuffer>;
 }
 
-async function subscribeToVapid(registration: ServiceWorkerRegistration): Promise<void> {
-  const vapidPublicKey = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY;
-  if (!vapidPublicKey) return;
+function arrayBufferToBase64Url(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
 
-  const existing = await registration.pushManager.getSubscription();
-  if (existing) return;
-
-  const subscription = await registration.pushManager.subscribe({
-    userVisibleOnly: true,
-    applicationServerKey: urlBase64ToUint8Array(vapidPublicKey),
-  });
-
+async function postSubscription(subscription: PushSubscription): Promise<void> {
   const json = subscription.toJSON();
   if (!json.endpoint || !json.keys?.p256dh || !json.keys?.auth) return;
-
   await api("/api/push-subscriptions", {
     method: "POST",
     body: JSON.stringify({
@@ -33,6 +28,35 @@ async function subscribeToVapid(registration: ServiceWorkerRegistration): Promis
       auth: json.keys.auth,
     }),
   });
+}
+
+async function subscribeToVapid(registration: ServiceWorkerRegistration): Promise<void> {
+  const vapidPublicKey = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY;
+  if (!vapidPublicKey) return;
+
+  const existing = await registration.pushManager.getSubscription();
+  if (existing) {
+    // Compare the existing subscription's server key with the current VAPID public key.
+    // Mismatch means the server rotated its VAPID keypair (or this endpoint was issued under
+    // a prior key) — the browser-side subscription is unusable by the current server and must
+    // be replaced. `options.applicationServerKey` is null in some legacy browsers; we treat
+    // that as "can't verify, re-subscribe defensively".
+    const existingKey = existing.options.applicationServerKey;
+    const existingKeyBase64 = existingKey ? arrayBufferToBase64Url(existingKey) : null;
+    if (existingKeyBase64 === vapidPublicKey) {
+      // Already subscribed with the current key. Re-POST so the server can heal if it lost
+      // the row (e.g. VAPID rotation wiped push_subscriptions to drop stale endpoints).
+      await postSubscription(existing);
+      return;
+    }
+    await existing.unsubscribe();
+  }
+
+  const subscription = await registration.pushManager.subscribe({
+    userVisibleOnly: true,
+    applicationServerKey: urlBase64ToUint8Array(vapidPublicKey),
+  });
+  await postSubscription(subscription);
 }
 
 /**

--- a/apps/web/lib/hooks/use-push-subscription.ts
+++ b/apps/web/lib/hooks/use-push-subscription.ts
@@ -43,9 +43,13 @@ async function subscribeToVapid(registration: ServiceWorkerRegistration): Promis
     // that as "can't verify, re-subscribe defensively".
     const existingKey = existing.options.applicationServerKey;
     const existingKeyBase64 = existingKey ? arrayBufferToBase64Url(existingKey) : null;
-    if (existingKeyBase64 === vapidPublicKey) {
-      // Already subscribed with the current key. Re-POST so the server can heal if it lost
-      // the row (e.g. VAPID rotation wiped push_subscriptions to drop stale endpoints).
+    // Treat `null` as "key unknown, trust existing subscription". Some legacy Chrome versions
+    // return null from options.applicationServerKey even when the sub was created correctly
+    // (crbug.com/697099). Unsubscribing would loop forever on those browsers, so we only
+    // force a re-subscribe when we *know* the stored key differs from the current VAPID key.
+    if (existingKeyBase64 === null || existingKeyBase64 === vapidPublicKey) {
+      // Re-POST so the server can heal if it lost the row (e.g. VAPID rotation wiped
+      // push_subscriptions to drop stale endpoints).
       await postSubscription(existing);
       return;
     }


### PR DESCRIPTION
## Summary

既存の push subscription の applicationServerKey が現在の `NEXT_PUBLIC_VAPID_PUBLIC_KEY` と一致しない場合、自動で unsubscribe → resubscribe する。

## Context

本セッションで VAPID ペアをローテーションしたため、旧鍵で作成された subscription は新 private key で署名した push を検証できず届かない状態になっています。

従来の `use-push-subscription.ts` は `if (existing) return;` で短絡していたため、「UI は通知 ON だが実際は届かない」という乖離が発生します。

本 PR の修正で、ユーザが次にサイトを訪れた時点（3 秒のタイマー後）に自動的に subscription が巻き直されます。ユーザは何も操作しなくて済みます。

## Rollout 手順

1. 本 PR を merge
2. Vercel の自動デプロイ完了を確認 (smoke-test が green)
3. 本番で自分のアカウントで通知購読が自動復旧するか検証
4. Supabase SQL Editor で旧 subscription を一掃: `DELETE FROM push_subscriptions;`

## Test plan

- [x] `bun run check` / `bun run check-types` 通過
- [ ] 本番デプロイ後、旧鍵の subscription を持つユーザで自動巻き直しが動作することを手動確認