### PR TITLE
chore(api): Vitest 実行時は pino を silent にする

### DIFF
--- a/apps/api/src/lib/logger.ts
+++ b/apps/api/src/lib/logger.ts
@@ -1,7 +1,7 @@
 import pino from "pino";
 
 export const logger = pino({
-  level: process.env.LOG_LEVEL ?? "info",
+  level: process.env.LOG_LEVEL ?? (process.env.VITEST ? "silent" : "info"),
   // Vercel adds timestamps automatically; avoid duplication
   timestamp: false,
   formatters: {


### PR DESCRIPTION
## Summary
- Vitest が自動セットする `VITEST` env var を検知し、pino を `silent` に切り替える
- `LOG_LEVEL` による明示指定は引き続き可能（例: `LOG_LEVEL=info bun run test` でデバッグ時に出力）

## Why
テストで意図的にエラー経路を検証する際（例: `returns 500 when upload fails` → `Storage error` を reject）、`logger.error` の出力が stderr に流れ、`post-stop` フックの `log-failure.sh` が失敗として誤検出していた。pino 公式でもテスト時は `silent` が推奨されている。

## Test plan
- [x] \`bun run --filter @sugara/api test\`: 626/626 pass、pino のエラーログが stderr に出ないことを確認
- [x] \`bun run check-types\`: green
- [x] \`bun run check\`: green