### PR TITLE
chore: lefthook pre-commit に main 直コミット拒否の branch-guard を追加

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -5,6 +5,17 @@
 pre-commit:
   parallel: true
   commands:
+    # main/master is protected by GitHub Branch Protection — direct push is rejected.
+    # Block commits locally so the mistake is caught before the work has to be moved.
+    branch-guard:
+      run: |
+        branch=$(git branch --show-current)
+        case "$branch" in
+          main|master)
+            echo "[branch-guard] $branch への直接コミットは禁止です。'git switch -c <type>/<topic>' で feature branch を作成してください。" >&2
+            exit 1
+            ;;
+        esac
     check:
       run: bun run check
       stage_fixed: true


### PR DESCRIPTION
## Summary
- `pre-commit` の先頭に `branch-guard` コマンドを追加
- `git branch --show-current` が `main` / `master` の場合、commit を拒否して feature branch 作成を促す
- `parallel: true` 下で他コマンドと並走（失敗時は lefthook が全体を失敗扱い）

## Why
`main` は GitHub Branch Protection で保護されており直 push が不可。main で作業してしまうと commit を feature branch に移し替える退避作業（branch 作成 → reset → switch → push）が発生する。ローカル時点で機械的に弾くことで、この手の作業ミスを早期に検知できる。

実際に 2026-04-20 に logger.ts の修正で main に直 commit してしまい、後処理が発生した (#22)。再発防止策。

## 動作確認
```
# feature branch: 通過
$ git branch --show-current
chore/block-commits-on-main
$ git commit  # branch-guard ✔️ pass (0.27s)

# main: 拒否想定 (ロジックをシミュレートで検証)
$ branch=main; case "$branch" in main|master) echo BLOCK; exit 1;; esac
BLOCK  # exit=1
```

## Test plan
- [x] feature branch で commit が通ることを確認 (本 PR 作成時に実経路で検証済み)
- [x] シミュレーションで main 時に exit 1 を返すことを確認
- [ ] merge 後、main で `git commit --allow-empty` を試行し拒否されることを確認