### PR TITLE
fix(web): Realtime CLOSED ループの帯域浪費を止め、reason をログに出す

### DIFF
--- a/apps/web/lib/__tests__/use-trip-sync.test.ts
+++ b/apps/web/lib/__tests__/use-trip-sync.test.ts
@@ -85,28 +85,64 @@ describe("useTripSync SDK-managed reconnection", () => {
     expect(mockRemoveChannel).not.toHaveBeenCalled();
   });
 
-  it("recreates channel on CLOSED (SDK removes channel from list)", () => {
+  it("recreates channel on CLOSED after backoff (SDK removes channel from list)", () => {
     renderHook(() => useTripSync("trip-1", user, onSync));
     const firstChannel = mockChannels[0];
 
     act(() => firstChannel._emitStatus("CLOSED"));
+    // Reconnect is scheduled, not immediate.
+    expect(mockChannels).toHaveLength(1);
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
 
     expect(mockRemoveChannel).toHaveBeenCalledWith(firstChannel);
     expect(mockChannels).toHaveLength(2);
   });
 
-  it("ignores CLOSED from a stale channel after disconnect", () => {
+  it("applies exponential backoff on consecutive CLOSED events", () => {
+    renderHook(() => useTripSync("trip-1", user, onSync));
+
+    // attempt 1: delay 1000ms
+    act(() => mockChannels[0]._emitStatus("CLOSED"));
+    act(() => {
+      vi.advanceTimersByTime(999);
+    });
+    expect(mockChannels).toHaveLength(1);
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(mockChannels).toHaveLength(2);
+
+    // attempt 2: delay 2000ms
+    act(() => mockChannels[1]._emitStatus("CLOSED"));
+    act(() => {
+      vi.advanceTimersByTime(1999);
+    });
+    expect(mockChannels).toHaveLength(2);
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(mockChannels).toHaveLength(3);
+  });
+
+  it("ignores CLOSED from a stale channel after reconnect", () => {
     renderHook(() => useTripSync("trip-1", user, onSync));
     const firstChannel = mockChannels[0];
 
-    // Simulate: CLOSED fires for channel A, triggering connect() which creates channel B.
-    // Then removeChannel(A) re-fires CLOSED for A's subscribe callback.
-    // The stale CLOSED must not create a 3rd channel.
+    // First CLOSED schedules a reconnect; advance timer to create channel B.
     act(() => firstChannel._emitStatus("CLOSED"));
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
     expect(mockChannels).toHaveLength(2);
 
-    // Stale CLOSED from the old channel should be ignored
+    // Stale CLOSED from channel A must not create a 3rd channel even after backoff.
     act(() => firstChannel._emitStatus("CLOSED"));
+    act(() => {
+      vi.advanceTimersByTime(30_000);
+    });
     expect(mockChannels).toHaveLength(2);
   });
 

--- a/apps/web/lib/__tests__/use-trip-sync.test.ts
+++ b/apps/web/lib/__tests__/use-trip-sync.test.ts
@@ -299,4 +299,43 @@ describe("useTripSync cleanup", () => {
 
     expect(mockRemoveChannel).toHaveBeenCalledWith(channel);
   });
+
+  it("cancels pending backoff timer on unmount", () => {
+    const { unmount } = renderHook(() => useTripSync("trip-1", user, onSync));
+
+    // Schedule a reconnect via CLOSED
+    act(() => mockChannels[0]._emitStatus("CLOSED"));
+    // removeChannel from CLOSED handling + cleanup → 2 calls; channel count stays at 1
+    const channelsBeforeUnmount = mockChannels.length;
+
+    unmount();
+
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+
+    // No new channel should be created after unmount
+    expect(mockChannels).toHaveLength(channelsBeforeUnmount);
+  });
+
+  it("cancels pending backoff timer when online event fires mid-backoff", () => {
+    renderHook(() => useTripSync("trip-1", user, onSync));
+
+    // CLOSED → 1s backoff scheduled
+    act(() => mockChannels[0]._emitStatus("CLOSED"));
+    // Advance partway through backoff
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    // online event cancels pending timer and connects fresh
+    act(() => window.dispatchEvent(new Event("online")));
+    const channelsAfterOnline = mockChannels.length;
+
+    // Let the original backoff elapse — it must not create a 3rd channel
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(mockChannels).toHaveLength(channelsAfterOnline);
+  });
 });

--- a/apps/web/lib/hooks/use-trip-sync.ts
+++ b/apps/web/lib/hooks/use-trip-sync.ts
@@ -13,6 +13,10 @@ export type PresenceUser = {
 
 const SYNC_DEBOUNCE_MS = 300;
 const SYNC_JITTER_MS = 200;
+// Exponential backoff to prevent tight reconnect loops when subscribe flips
+// immediately to CLOSED (e.g. missing anon key, Realtime auth misconfiguration).
+const CLOSE_RECONNECT_MIN_MS = 1000;
+const CLOSE_RECONNECT_MAX_MS = 30_000;
 
 export function useTripSync(
   tripId: string,
@@ -30,6 +34,8 @@ export function useTripSync(
   const [isConnected, setIsConnected] = useState(false);
   const channelRef = useRef<RealtimeChannel | null>(null);
   const syncTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const closeAttemptsRef = useRef(0);
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const onSyncRef = useRef(onSync);
   onSyncRef.current = onSync;
   const userRef = useRef(user);
@@ -77,9 +83,14 @@ export function useTripSync(
           }
           setPresence(users);
         })
-        .subscribe((status) => {
+        .subscribe((status, err) => {
           setIsConnected(status === "SUBSCRIBED");
+          if (err) {
+            // Surface the underlying reason (auth failure, RLS, etc.) for diagnostics.
+            console.warn("[Realtime] subscribe error", { status, err });
+          }
           if (status === "SUBSCRIBED") {
+            closeAttemptsRef.current = 0;
             toast.dismiss("realtime-error");
             const u = userRef.current;
             const lp = lastPresenceRef.current;
@@ -91,10 +102,26 @@ export function useTripSync(
           if (status === "CHANNEL_ERROR" || status === "TIMED_OUT") {
             console.debug(`[Realtime] ${status} — SDK will auto-rejoin`);
           }
-          // CLOSED means SDK removed the channel; manual recovery needed
+          // CLOSED means SDK removed the channel; reconnect with exponential backoff
+          // so a persistent failure (bad key, blocked auth) doesn't hammer the server.
           if (status === "CLOSED" && channelRef.current === channel) {
-            console.warn("[Realtime] Channel closed, recreating");
-            connect();
+            const attempt = ++closeAttemptsRef.current;
+            const delay = Math.min(
+              CLOSE_RECONNECT_MIN_MS * 2 ** (attempt - 1),
+              CLOSE_RECONNECT_MAX_MS,
+            );
+            console.warn(
+              `[Realtime] Channel closed, recreating in ${delay}ms (attempt ${attempt})`,
+            );
+            if (closeTimerRef.current) {
+              clearTimeout(closeTimerRef.current);
+            }
+            closeTimerRef.current = setTimeout(() => {
+              closeTimerRef.current = null;
+              // Only reconnect if this closure's channel is still the live one —
+              // a later CLOSED or unmount may have already replaced it.
+              if (channelRef.current === channel) connect();
+            }, delay);
           }
         });
 
@@ -134,6 +161,10 @@ export function useTripSync(
       if (syncTimer.current) {
         clearTimeout(syncTimer.current);
         syncTimer.current = null;
+      }
+      if (closeTimerRef.current) {
+        clearTimeout(closeTimerRef.current);
+        closeTimerRef.current = null;
       }
       disconnect();
       setPresence([]);

--- a/apps/web/lib/hooks/use-trip-sync.ts
+++ b/apps/web/lib/hooks/use-trip-sync.ts
@@ -54,6 +54,11 @@ export function useTripSync(
 
   useEffect(() => {
     function connect() {
+      // Cancel any pending backoff timer so it does not fire against the new channel.
+      if (closeTimerRef.current) {
+        clearTimeout(closeTimerRef.current);
+        closeTimerRef.current = null;
+      }
       disconnect();
       // SECURITY: Supabase Realtime channels are accessible to anyone with the anon key.
       // tripId is a UUIDv4 (122-bit entropy), making brute-force impractical.
@@ -147,6 +152,9 @@ export function useTripSync(
     }
 
     function handleOnline() {
+      // Network recovery is a fresh start; reset attempt counter so the backoff
+      // log reports realistic "attempt N" values.
+      closeAttemptsRef.current = 0;
       connect();
       onSyncRef.current();
     }

--- a/apps/web/lib/supabase.ts
+++ b/apps/web/lib/supabase.ts
@@ -12,3 +12,16 @@ export const supabase = createClient(supabaseUrl, supabaseAnonKey || "", {
     worker: true,
   },
 });
+
+if (typeof window !== "undefined") {
+  // Surface transport-level close codes to diagnose Realtime reconnect storms.
+  // 1006 = abnormal close, 1008 = policy violation (auth), 4xxx = Phoenix-level.
+  // RealtimeClient has no public onClose/onError; stateChangeCallbacks is the
+  // documented extension point and is typed as a public field.
+  supabase.realtime.stateChangeCallbacks.close.push((e: CloseEvent) => {
+    console.warn(`[Realtime][socket] close code=${e?.code ?? "?"} reason=${e?.reason || "(none)"}`);
+  });
+  supabase.realtime.stateChangeCallbacks.error.push((e: Event) => {
+    console.warn("[Realtime][socket] error", e);
+  });
+}

--- a/apps/web/lib/supabase.ts
+++ b/apps/web/lib/supabase.ts
@@ -17,11 +17,19 @@ if (typeof window !== "undefined") {
   // Surface transport-level close codes to diagnose Realtime reconnect storms.
   // 1006 = abnormal close, 1008 = policy violation (auth), 4xxx = Phoenix-level.
   // RealtimeClient has no public onClose/onError; stateChangeCallbacks is the
-  // documented extension point and is typed as a public field.
-  supabase.realtime.stateChangeCallbacks.close.push((e: CloseEvent) => {
-    console.warn(`[Realtime][socket] close code=${e?.code ?? "?"} reason=${e?.reason || "(none)"}`);
-  });
-  supabase.realtime.stateChangeCallbacks.error.push((e: Event) => {
-    console.warn("[Realtime][socket] error", e);
-  });
+  // documented extension point. Guard against future supabase-js refactors that
+  // rename or drop the field — silent failure would leave us with no diagnostics.
+  const cbs = supabase.realtime.stateChangeCallbacks;
+  if (cbs?.close && cbs.error) {
+    cbs.close.push((e: CloseEvent) => {
+      console.warn(
+        `[Realtime][socket] close code=${e?.code ?? "?"} reason=${e?.reason || "(none)"}`,
+      );
+    });
+    cbs.error.push((e: Event) => {
+      console.warn("[Realtime][socket] error", e);
+    });
+  } else {
+    console.warn("[Realtime] stateChangeCallbacks unavailable — socket-level diagnostics disabled");
+  }
 }


### PR DESCRIPTION
## 現象
本番 (sugara.vercel.app) の旅行詳細画面で **「接続中...」が常時表示** され、DevTools コンソールに
\`\`\`
[Realtime] Channel closed, recreating
\`\`\`
が 31 + 4 + 2 + 2 + ... と連発する **再接続ストーム** が発生している。

WebSocket (wss://...supabase.co/realtime/v1/websocket) が subscribe 直後に CLOSED になり、\`use-trip-sync\` が即座に \`connect()\` を呼び直して無限ループに入っている状態。

## 原因の調査方針
bundle から anon key を辿って直接 WS 接続テストをしようとしたが、Supabase 関連コードは dynamic chunk に分割されており \`/\` のチャンクからは辿れなかった。
根本原因候補:
- Supabase anon key の legacy → new publishable key 移行
- Realtime の "Require RLS" 設定
- Vercel env の \`NEXT_PUBLIC_SUPABASE_ANON_KEY\` ドリフト

**次デプロイで詳細 reason をコンソールに出す**ためのログ追加と、**無限ループによる帯域/quota 消費を止める** 応急ガードをまず入れる。根本原因は production ログから確定させる。

## 変更
- \`use-trip-sync.ts\`: CLOSED → 即 connect() を指数 backoff (1s → 2s → 4s → ... max 30s) に置換
- \`use-trip-sync.ts\`: subscribe callback の第 2 引数 \`err\` を \`console.warn(\"[Realtime] subscribe error\", …)\` で表示
- \`supabase.ts\`: \`stateChangeCallbacks.close / error\` に subscriber を追加し、WS の close code / reason を \`[Realtime][socket] close code=1006 reason=…\` 形式で出力
- 既存 stale-CLOSED ガード (\`channelRef === channel\`) は backoff 後にも維持

## Test plan
- [x] \`bun run --filter @sugara/web test -- use-trip-sync\`: 13/13 pass（backoff / 指数増加 / stale CLOSED 無視の 3 ケース追加）
- [x] \`bun run check-types\`, \`bun run check\`: green
- [ ] merge 後、本番のコンソールで以下が出ることを確認:
  - \`[Realtime][socket] close code=XXXX reason=YYYY\` — WS レベルの切断理由
  - \`[Realtime] subscribe error\` — チャンネル購読時のエラー詳細
  - 再接続が指数的に間隔を広げること
- [ ] 上記ログから根本原因 (anon key / Realtime 認可 / RLS) を特定し、別 PR で修正