### PR TITLE
fix(web): リロード時のエラー表示フラッシュを解消

### DIFF
--- a/apps/web/app/(authenticated)/trips/[id]/_components/map-panel.test.tsx
+++ b/apps/web/app/(authenticated)/trips/[id]/_components/map-panel.test.tsx
@@ -21,6 +21,7 @@ vi.mock("@vis.gl/react-google-maps", () => ({
 
 vi.mock("@tanstack/react-query", () => ({
   useQuery: vi.fn(() => ({ data: undefined })),
+  useIsRestoring: vi.fn(() => false),
 }));
 
 const baseSchedule: ScheduleResponse = {

--- a/apps/web/components/discord-webhook-dialog.test.tsx
+++ b/apps/web/components/discord-webhook-dialog.test.tsx
@@ -18,6 +18,7 @@ vi.mock("@tanstack/react-query", () => ({
     invalidateQueries: mockInvalidateQueries,
     setQueryData: vi.fn(),
   })),
+  useIsRestoring: vi.fn(() => false),
 }));
 
 // ResponsiveDialog renders Dialog on desktop; stub useMobile to return false

--- a/apps/web/components/travel-time-separator.test.tsx
+++ b/apps/web/components/travel-time-separator.test.tsx
@@ -10,6 +10,7 @@ vi.mock("@/lib/api", () => ({
 
 vi.mock("@tanstack/react-query", () => ({
   useQuery: vi.fn(() => ({ data: undefined, isLoading: true })),
+  useIsRestoring: vi.fn(() => false),
 }));
 
 describe("TravelTimeSeparator", () => {

--- a/apps/web/components/ui/loading-boundary.test.tsx
+++ b/apps/web/components/ui/loading-boundary.test.tsx
@@ -2,8 +2,19 @@ import { act, cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { LoadingBoundary } from "./loading-boundary";
 
+const isRestoringMock = vi.hoisted(() => vi.fn(() => false));
+
+vi.mock("@tanstack/react-query", async () => {
+  const actual =
+    await vi.importActual<typeof import("@tanstack/react-query")>("@tanstack/react-query");
+  return { ...actual, useIsRestoring: isRestoringMock };
+});
+
 describe("LoadingBoundary", () => {
-  afterEach(cleanup);
+  afterEach(() => {
+    cleanup();
+    isRestoringMock.mockReturnValue(false);
+  });
 
   it("renders nothing during fast load (before 200ms delay)", () => {
     vi.useFakeTimers();
@@ -62,5 +73,26 @@ describe("LoadingBoundary", () => {
       </LoadingBoundary>,
     );
     expect(container.firstChild).toBeNull();
+  });
+
+  it("treats PersistQueryClientProvider restoring state as loading (prevents error flash)", async () => {
+    isRestoringMock.mockReturnValue(true);
+    vi.useFakeTimers();
+    render(
+      <LoadingBoundary
+        isLoading={false}
+        skeleton={<div>skeleton</div>}
+        errorFallback={<div>error ui</div>}
+      >
+        <div>content</div>
+      </LoadingBoundary>,
+    );
+    await act(async () => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(screen.getByText("skeleton")).toBeDefined();
+    expect(screen.queryByText("content")).toBeNull();
+    expect(screen.queryByText("error ui")).toBeNull();
+    vi.useRealTimers();
   });
 });

--- a/apps/web/components/ui/loading-boundary.tsx
+++ b/apps/web/components/ui/loading-boundary.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useIsRestoring } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import { useDelayedLoading } from "@/lib/hooks/use-delayed-loading";
 import { cn } from "@/lib/utils";
@@ -25,9 +26,15 @@ export function LoadingBoundary({
   className,
   delay = 200,
 }: LoadingBoundaryProps) {
-  const showSkeleton = useDelayedLoading(isLoading, delay);
+  // While PersistQueryClientProvider hydrates from IndexedDB, useQuery reports
+  // isLoading=false with data=undefined — callers that render an error fallback
+  // on "!data" would flash it on every reload. Treat restoring as loading so
+  // the skeleton covers that window.
+  const isRestoring = useIsRestoring();
+  const effectiveLoading = isLoading || isRestoring;
+  const showSkeleton = useDelayedLoading(effectiveLoading, delay);
 
-  if (isLoading && !showSkeleton) return null;
+  if (effectiveLoading && !showSkeleton) return null;
   if (showSkeleton) return <>{skeleton}</>;
   if (error) return errorFallback ?? null;
 


### PR DESCRIPTION
## 現象
旅行画面などをリロードすると「旅行の取得に失敗しました」が一瞬表示されてから正常なコンテンツに切り替わる。

## 原因
\`PersistQueryClientProvider\` が IndexedDB からキャッシュを復元している間、\`useQuery\` は \`isLoading=false\` かつ \`data=undefined\` を返す仕様（復元完了を待つため fetch を開始しない）。

各ページの呼び出し側は \`queryError || !trip ? <error /> : <content />\` でフォールバックを出しているため、**復元中の数十 ms だけエラー UI が素通り**していた。

## 対処
\`LoadingBoundary\` 内部で \`useIsRestoring()\` を合成し、\`isLoading || isRestoring\` でスケルトン表示を続ける。LoadingBoundary を使う 34 箇所に一括で効くため、各ページの改修は不要。

## 関連修正
\`@tanstack/react-query\` を完全 mock している既存テスト 3 件 (\`discord-webhook-dialog\`, \`map-panel\`, \`travel-time-separator\`) に \`useIsRestoring: () => false\` を追加。mock 漏れで \`useIsRestoring\` が undefined になり LoadingBoundary 経由のレンダリングで落ちていた。

## Test plan
- [x] \`loading-boundary.test.tsx\` に復元中のスケルトン維持テストを追加 (6/6 pass)
- [x] \`bun run --filter @sugara/web test\`: 491/491 pass
- [x] \`bun run check-types\`, \`bun run check\`: green
- [ ] merge 後、production で旅行画面をリロードして「取得失敗」が一瞬も出ないことを確認