### PR TITLE
fix(web): manifest の share_target に enctype を明示

### DIFF
--- a/apps/web/app/manifest.ts
+++ b/apps/web/app/manifest.ts
@@ -3,6 +3,9 @@ import type { MetadataRoute } from "next";
 type ShareTarget = {
   action: string;
   method: string;
+  // Chrome warns when omitted; explicit value silences
+  // "Enctype should be set to either application/x-www-form-urlencoded or multipart/form-data".
+  enctype: "application/x-www-form-urlencoded" | "multipart/form-data";
   params: Record<string, string>;
 };
 
@@ -34,6 +37,7 @@ export default function manifest(): ManifestWithShareTarget {
     share_target: {
       action: "/share-target",
       method: "GET",
+      enctype: "application/x-www-form-urlencoded",
       params: {
         url: "url",
         title: "title",

--- a/apps/web/app/manifest.ts
+++ b/apps/web/app/manifest.ts
@@ -2,10 +2,11 @@ import type { MetadataRoute } from "next";
 
 type ShareTarget = {
   action: string;
-  method: string;
-  // Chrome warns when omitted; explicit value silences
-  // "Enctype should be set to either application/x-www-form-urlencoded or multipart/form-data".
-  enctype: "application/x-www-form-urlencoded" | "multipart/form-data";
+  method: "GET" | "POST";
+  // Per W3C Web Share Target spec, enctype is only meaningful for POST,
+  // but Chrome's manifest validator warns on any method when omitted.
+  // Keep it optional to reflect the spec, and set it explicitly where needed.
+  enctype?: "application/x-www-form-urlencoded" | "multipart/form-data";
   params: Record<string, string>;
 };
 


### PR DESCRIPTION
## Summary
\`apps/web/app/manifest.ts\` の \`share_target\` に \`enctype: \"application/x-www-form-urlencoded\"\` を追加。

## Why
Chrome の Web App Manifest バリデータが以下の警告を出していた:
\`\`\`
Manifest: Enctype should be set to either application/x-www-form-urlencoded
or multipart/form-data. It currently defaults to application/x-www-form-urlencoded
\`\`\`
share_target はテキストパラメータ (url/title/text) のみ扱うため、明示値はデフォルト相当の \`application/x-www-form-urlencoded\`。機能挙動は変わらず、警告のみ解消。

## Test plan
- [x] \`bun run check-types\`: green
- [ ] merge 後、Chrome DevTools コンソールに該当警告が出なくなることを確認