### PR TITLE
refactor(web): LoadingBoundary 内でエラーとデータなしを分離判定

### DIFF
--- a/apps/web/app/(authenticated)/polls/[id]/page.tsx
+++ b/apps/web/app/(authenticated)/polls/[id]/page.tsx
@@ -103,9 +103,9 @@ export default function QuickPollDetailPage() {
       </Link>
 
       <LoadingBoundary isLoading={isLoading} skeleton={<DetailSkeleton />}>
-        {error || !poll ? (
+        {error ? (
           <p className="text-center text-destructive">{tm("quickPollNotFound")}</p>
-        ) : (
+        ) : poll ? (
           <div className="space-y-6">
             {/* Header */}
             <div className="flex items-start justify-between gap-2">
@@ -193,7 +193,7 @@ export default function QuickPollDetailPage() {
               </Button>
             </div>
           </div>
-        )}
+        ) : null}
       </LoadingBoundary>
     </div>
   );

--- a/apps/web/app/(authenticated)/trips/[id]/export/page.tsx
+++ b/apps/web/app/(authenticated)/trips/[id]/export/page.tsx
@@ -415,11 +415,11 @@ export default function TripExportPage() {
 
   return (
     <LoadingBoundary isLoading={isLoading} skeleton={<ExportSkeleton />}>
-      {error || !trip ? (
+      {error ? (
         <div className="flex min-h-[50vh] items-center justify-center">
           <p className="text-destructive">{tm("tripFetchFailed")}</p>
         </div>
-      ) : (
+      ) : trip ? (
         <div className="mt-4 grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.5fr)]">
           {/* Settings */}
           <div className="rounded-lg border p-5 space-y-6 self-start">
@@ -759,7 +759,7 @@ export default function TripExportPage() {
             </div>
           </div>
         </div>
-      )}
+      ) : null}
     </LoadingBoundary>
   );
 }

--- a/apps/web/app/(authenticated)/trips/[id]/page.tsx
+++ b/apps/web/app/(authenticated)/trips/[id]/page.tsx
@@ -845,9 +845,9 @@ export default function TripDetailPage() {
       isLoading={isLoading || (!!pollId && isPollLoading)}
       skeleton={<TripDetailSkeleton />}
     >
-      {queryError || !trip ? (
+      {queryError ? (
         <p className="text-destructive">{tm("tripFetchFailed")}</p>
-      ) : (
+      ) : trip ? (
         <MapsProvider enabled={trip.mapsEnabled}>
           <SelectionProvider value={selectionValue}>
             <div className="mt-4">
@@ -1112,7 +1112,7 @@ export default function TripDetailPage() {
             </div>
           </SelectionProvider>
         </MapsProvider>
-      )}
+      ) : null}
       <ReactionOverlay reactions={reactions} onAnimationEnd={removeReaction} />
     </LoadingBoundary>
   );

--- a/apps/web/app/(authenticated)/trips/[id]/page.tsx
+++ b/apps/web/app/(authenticated)/trips/[id]/page.tsx
@@ -241,7 +241,7 @@ export default function TripDetailPage() {
   const queryClient = useQueryClient();
 
   const {
-    data: trip = null,
+    data: trip,
     isLoading,
     error: queryError,
   } = useQuery({

--- a/apps/web/app/(authenticated)/trips/[id]/print/page.tsx
+++ b/apps/web/app/(authenticated)/trips/[id]/print/page.tsx
@@ -78,11 +78,11 @@ export default function TripPrintPage() {
 
   return (
     <LoadingBoundary isLoading={isLoading} skeleton={<PrintSkeleton />}>
-      {error || !trip ? (
+      {error ? (
         <div className="flex min-h-screen items-center justify-center">
           <p className="text-destructive">{tm("tripFetchFailed")}</p>
         </div>
-      ) : (
+      ) : trip ? (
         <div className="mx-auto max-w-3xl px-6 py-8 print:max-w-none print:px-0 print:py-0">
           <header className="mb-6 print:mb-4">
             <div className="flex items-center justify-between gap-4">
@@ -112,7 +112,7 @@ export default function TripPrintPage() {
             })}
           </div>
         </div>
-      )}
+      ) : null}
     </LoadingBoundary>
   );
 }

--- a/apps/web/app/(sp)/sp/polls/[id]/page.tsx
+++ b/apps/web/app/(sp)/sp/polls/[id]/page.tsx
@@ -103,9 +103,9 @@ export default function SpQuickPollDetailPage() {
       </Link>
 
       <LoadingBoundary isLoading={isLoading} skeleton={<DetailSkeleton />}>
-        {error || !poll ? (
+        {error ? (
           <p className="text-center text-destructive">{tm("quickPollNotFound")}</p>
-        ) : (
+        ) : poll ? (
           <div className="space-y-6">
             {/* Header */}
             <div className="flex items-start justify-between gap-2">
@@ -193,7 +193,7 @@ export default function SpQuickPollDetailPage() {
               </Button>
             </div>
           </div>
-        )}
+        ) : null}
       </LoadingBoundary>
     </div>
   );

--- a/apps/web/app/(sp)/sp/trips/[id]/export/page.tsx
+++ b/apps/web/app/(sp)/sp/trips/[id]/export/page.tsx
@@ -371,11 +371,11 @@ export default function SpTripExportPage() {
 
   return (
     <LoadingBoundary isLoading={isLoading} skeleton={<ExportSkeleton />}>
-      {error || !trip ? (
+      {error ? (
         <div className="flex min-h-[50vh] items-center justify-center">
           <p className="text-destructive">{tm("tripFetchFailed")}</p>
         </div>
-      ) : (
+      ) : trip ? (
         <div className="px-4 pt-4 pb-24 space-y-6">
           <div className="flex items-center gap-2">
             <Link href={`/sp/trips/${tripId}`} className="shrink-0 text-muted-foreground">
@@ -706,7 +706,7 @@ export default function SpTripExportPage() {
             </div>
           )}
         </div>
-      )}
+      ) : null}
     </LoadingBoundary>
   );
 }

--- a/apps/web/app/(sp)/sp/trips/[id]/page.tsx
+++ b/apps/web/app/(sp)/sp/trips/[id]/page.tsx
@@ -523,9 +523,9 @@ export default function SpTripDetailPage() {
   return (
     <>
       <LoadingBoundary isLoading={isLoading || (!!pollId && isPollLoading)} skeleton={skeleton}>
-        {queryError || !trip ? (
+        {queryError ? (
           <p className="text-destructive">{tm("tripFetchFailed")}</p>
-        ) : (
+        ) : trip ? (
           <MapsProvider enabled={trip.mapsEnabled}>
             <SelectionProvider value={selectionValue}>
               <div className="mt-4">
@@ -604,7 +604,7 @@ export default function SpTripDetailPage() {
               </div>
             </SelectionProvider>
           </MapsProvider>
-        )}
+        ) : null}
         <ReactionOverlay reactions={reactions} onAnimationEnd={removeReaction} />
       </LoadingBoundary>
 

--- a/apps/web/app/(sp)/sp/trips/[id]/page.tsx
+++ b/apps/web/app/(sp)/sp/trips/[id]/page.tsx
@@ -92,7 +92,7 @@ export default function SpTripDetailPage() {
   const { data: session } = useSession();
   const queryClient = useQueryClient();
   const {
-    data: trip = null,
+    data: trip,
     isLoading,
     error: queryError,
   } = useQuery({

--- a/apps/web/app/(sp)/sp/trips/[id]/print/page.tsx
+++ b/apps/web/app/(sp)/sp/trips/[id]/print/page.tsx
@@ -79,11 +79,11 @@ export default function SpTripPrintPage() {
 
   return (
     <LoadingBoundary isLoading={isLoading} skeleton={<PrintSkeleton />}>
-      {error || !trip ? (
+      {error ? (
         <div className="flex min-h-screen items-center justify-center">
           <p className="text-destructive">{tm("tripFetchFailed")}</p>
         </div>
-      ) : (
+      ) : trip ? (
         <div className="mx-auto max-w-3xl px-6 py-8 print:max-w-none print:px-0 print:py-0">
           <header className="mb-6 print:mb-4">
             <div className="flex items-center gap-2">
@@ -121,7 +121,7 @@ export default function SpTripPrintPage() {
             })}
           </div>
         </div>
-      )}
+      ) : null}
     </LoadingBoundary>
   );
 }

--- a/apps/web/app/(sp)/sp/users/[userId]/page.tsx
+++ b/apps/web/app/(sp)/sp/users/[userId]/page.tsx
@@ -53,10 +53,12 @@ export default function SpProfilePage() {
       }
     >
       <div className="mx-auto mt-4 max-w-2xl">
-        {error || !profile ? (
-          <ErrorMessage message={error ?? tup("userNotFound")} />
-        ) : (
+        {error ? (
+          <ErrorMessage message={error} />
+        ) : profile ? (
           <ProfileContent profile={profile} userId={userId ?? ""} />
+        ) : (
+          <ErrorMessage message={tup("userNotFound")} />
         )}
       </div>
     </LoadingBoundary>

--- a/apps/web/app/p/[token]/_components/quick-poll-client.tsx
+++ b/apps/web/app/p/[token]/_components/quick-poll-client.tsx
@@ -86,12 +86,12 @@ export function QuickPollClient({ token }: { token: string }) {
         </div>
       </header>
       <LoadingBoundary isLoading={isLoading} skeleton={<PollSkeleton />} delay={0}>
-        {error || !poll ? (
+        {error ? (
           <div className="container flex max-w-lg flex-col items-center py-16 text-center">
             <Vote className="mb-4 h-12 w-12 text-muted-foreground" />
             <p className="text-lg font-medium text-destructive">{tm("quickPollNotFound")}</p>
           </div>
-        ) : (
+        ) : poll ? (
           <div className="container max-w-lg py-8 space-y-6">
             <h1 className="break-words text-xl font-bold">{poll.question}</h1>
 
@@ -167,7 +167,7 @@ export function QuickPollClient({ token }: { token: string }) {
               <p className="text-center text-sm text-muted-foreground">{tp("pollClosed")}</p>
             )}
           </div>
-        )}
+        ) : null}
         <SharedFooter />
       </LoadingBoundary>
     </div>

--- a/apps/web/app/polls/shared/[token]/_components/shared-poll-client.tsx
+++ b/apps/web/app/polls/shared/[token]/_components/shared-poll-client.tsx
@@ -72,13 +72,13 @@ export function SharedPollClient({ token }: { token: string }) {
     <div className="min-h-screen">
       <SharedPollHeader />
       <LoadingBoundary isLoading={isLoading} skeleton={<SharedPollBodySkeleton />}>
-        {error || !poll ? (
+        {error ? (
           <div className="container flex max-w-3xl flex-col items-center py-16 text-center">
             <Calendar className="mb-4 h-12 w-12 text-muted-foreground" />
             <p className="text-lg font-medium text-destructive">{tm("pollSharedNotFound")}</p>
             <p className="mt-2 text-sm text-muted-foreground">{tp("checkLinkOrContact")}</p>
           </div>
-        ) : (
+        ) : poll ? (
           <div className="container max-w-3xl py-8 space-y-6">
             <div>
               <h1 className="break-words text-xl font-bold sm:text-2xl">{poll.title}</h1>
@@ -126,7 +126,7 @@ export function SharedPollClient({ token }: { token: string }) {
               </p>
             )}
           </div>
-        )}
+        ) : null}
         <SharedFooter />
       </LoadingBoundary>
     </div>


### PR DESCRIPTION
## Summary
11 ファイルで `queryError || !data ? <Error /> : <Content />` の統合判定を `queryError ? <Error /> : data ? <Content /> : null` に分離。

## ⚠️ マージ順序の依存

**#25 をマージしてから本 PR をマージしてください。**

PR #27 単体で main にマージすると、`PersistQueryClientProvider` の IndexedDB ハイドレーション中 (`isLoading=false`, `data=undefined` の瞬間) に `null` が描画され、`delay=200ms` のスケルトンも出ない空白が一瞬発生します。これは #25 の `useIsRestoring` がスケルトンを維持することで吸収される設計です。

## Why
#25 のレビュー指摘「データなしとエラーを区別せずエラー UI に倒す設計は別途問題になりえる」への対応。

復元中フラッシュの実害は #25 で LoadingBoundary 側が吸収しているため既に解決済みだが:

1. **意味の明確化**: 「取得失敗」と「データなし」は本来別の状態。型 narrowing も明示的になる
2. **拡張余地**: 将来エラーと 404 で UI を分けたくなったときの土台
3. **改善例** (`(sp)/sp/users/[userId]`): profile 欠落時に汎用エラーではなく `"userNotFound"` を出すよう挙動改善

## 対象 11 ファイル

**旅行詳細系 (6)**
- `(authenticated)/trips/[id]/page.tsx`, `export/page.tsx`, `print/page.tsx`
- `(sp)/sp/trips/[id]/page.tsx`, `export/page.tsx`, `print/page.tsx`

**投票系 (4)**
- `(authenticated)/polls/[id]/page.tsx`, `(sp)/sp/polls/[id]/page.tsx`
- `polls/shared/[token]/_components/shared-poll-client.tsx`
- `p/[token]/_components/quick-poll-client.tsx`

**ユーザープロフィール (1)**
- `(sp)/sp/users/[userId]/page.tsx` — error 時と profile 欠落時で別メッセージを出すよう分離

## レビュー反映 (追加コミット)
trip のデフォルト値 (`data: trip = null`) を削除し、他ページと同じく `TripResponse | undefined` の narrowing に統一。

## Test plan
- [x] `bun run check-types`: green
- [x] `bun run check`: green
- [x] `bun run --filter @sugara/web test`: 490/490 pass（既存テスト維持、挙動変更なし）
- [ ] #25 merge 後、本 PR をマージ
- [ ] 本番で旅行/投票画面のリロード時に「取得失敗」フラッシュが出ないこと（#25 で解決済みだが再確認）
- [ ] 404 な user profile で "userNotFound" が出ること（改善点）