### PR TITLE
fix(web): 日をまたぐ予定が時刻未設定予定の後ろに隠れて動かせない問題を修正

### DIFF
--- a/apps/api/drizzle.config.ts
+++ b/apps/api/drizzle.config.ts
@@ -5,6 +5,6 @@ export default defineConfig({
   out: "./drizzle",
   dialect: "postgresql",
   dbCredentials: {
-    url: process.env.MIGRATION_URL || "postgresql://postgres:postgres@127.0.0.1:54322/postgres",
+    url: process.env.MIGRATION_URL || "postgresql://postgres:postgres@127.0.0.1:55322/postgres",
   },
 });

--- a/apps/api/src/lib/env.ts
+++ b/apps/api/src/lib/env.ts
@@ -13,7 +13,7 @@ function withDefault(name: string, defaultValue: string): string {
 // Use getters so tests can stub process.env and have the changes reflected
 export const env = {
   get DATABASE_URL() {
-    return withDefault("DATABASE_URL", "postgresql://postgres:postgres@127.0.0.1:54322/postgres");
+    return withDefault("DATABASE_URL", "postgresql://postgres:postgres@127.0.0.1:55322/postgres");
   },
   get BETTER_AUTH_BASE_URL() {
     return withDefault("BETTER_AUTH_BASE_URL", "http://localhost:3000");

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,6 +1,6 @@
 # Supabase
-DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres
-MIGRATION_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres
+DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:55322/postgres
+MIGRATION_URL=postgresql://postgres:postgres@127.0.0.1:55322/postgres
 NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321
 NEXT_PUBLIC_SUPABASE_ANON_KEY=<supabase status で取得>
 SUPABASE_SERVICE_ROLE_KEY=<supabase status で取得>

--- a/apps/web/lib/__tests__/merge-timeline.test.ts
+++ b/apps/web/lib/__tests__/merge-timeline.test.ts
@@ -85,7 +85,11 @@ describe("buildMergedTimeline", () => {
     expect(result[2].type).toBe("crossDay");
   });
 
-  it("places all cross-day entries at end when all schedules have null startTime", () => {
+  it("places cross-day entries with endTime before schedules that have null startTime", () => {
+    // Why: schedules without startTime have no time anchor, so a cross-day
+    // entry with a known endTime should visually come first (it's a known
+    // past event). Otherwise users cannot place the schedule after the
+    // cross-day entry since timeline position is derived from times.
     const schedules = [
       makeSchedule({ id: "s1", startTime: undefined }),
       makeSchedule({ id: "s2", startTime: undefined }),
@@ -98,10 +102,32 @@ describe("buildMergedTimeline", () => {
     const result = buildMergedTimeline(schedules, crossDayEntries);
 
     expect(result).toHaveLength(4);
-    expect(result[0].type).toBe("schedule");
+    const ids = result.map((item) =>
+      item.type === "crossDay" ? item.entry.schedule.id : item.schedule.id,
+    );
+    expect(ids).toEqual(["c2", "c1", "s1", "s2"]);
+  });
+
+  it("places cross-day entry before a single schedule that has null startTime", () => {
+    const schedules = [makeSchedule({ id: "s1", startTime: undefined })];
+    const crossDayEntries = [makeCrossDayEntry({ id: "c1", endTime: "10:00" })];
+
+    const result = buildMergedTimeline(schedules, crossDayEntries);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].type).toBe("crossDay");
     expect(result[1].type).toBe("schedule");
-    expect(result[2].type).toBe("crossDay");
-    expect(result[3].type).toBe("crossDay");
+  });
+
+  it("keeps cross-day entry without endTime at the end even when schedules have null startTime", () => {
+    const schedules = [makeSchedule({ id: "s1", startTime: undefined })];
+    const crossDayEntries = [makeCrossDayEntry({ id: "c1", endTime: undefined })];
+
+    const result = buildMergedTimeline(schedules, crossDayEntries);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].type).toBe("schedule");
+    expect(result[1].type).toBe("crossDay");
   });
 
   it("handles multiple cross-day entries with different endTimes", () => {

--- a/apps/web/lib/__tests__/merge-timeline.test.ts
+++ b/apps/web/lib/__tests__/merge-timeline.test.ts
@@ -130,6 +130,22 @@ describe("buildMergedTimeline", () => {
     expect(result[1].type).toBe("crossDay");
   });
 
+  it("places cross-day with endTime before null-startTime schedule and keeps cross-day without endTime after it", () => {
+    const schedules = [makeSchedule({ id: "s1", startTime: undefined })];
+    const crossDayEntries = [
+      makeCrossDayEntry({ id: "c-with-end", endTime: "10:00" }),
+      makeCrossDayEntry({ id: "c-without-end", endTime: undefined }),
+    ];
+
+    const result = buildMergedTimeline(schedules, crossDayEntries);
+
+    expect(result).toHaveLength(3);
+    const ids = result.map((item) =>
+      item.type === "crossDay" ? item.entry.schedule.id : item.schedule.id,
+    );
+    expect(ids).toEqual(["c-with-end", "s1", "c-without-end"]);
+  });
+
   it("handles multiple cross-day entries with different endTimes", () => {
     const schedules = [
       makeSchedule({ id: "s1", startTime: "09:00" }),

--- a/apps/web/lib/merge-timeline.ts
+++ b/apps/web/lib/merge-timeline.ts
@@ -28,6 +28,7 @@ export function buildMergedTimeline(
     const scheduleTime = schedule.startTime?.slice(0, 5) ?? null;
 
     const toInsert: CrossDayEntry[] = [];
+    // Iterate in reverse so splice() doesn't shift the indices of unvisited entries.
     for (let j = remaining.length - 1; j >= 0; j--) {
       const entryTime = remaining[j].schedule.endTime?.slice(0, 5) ?? null;
       if (entryTime == null) continue;

--- a/apps/web/lib/merge-timeline.ts
+++ b/apps/web/lib/merge-timeline.ts
@@ -6,8 +6,12 @@ export type TimelineItem =
 
 /**
  * Build a merged timeline of schedules and cross-day entries.
- * Cross-day entries are placed before the first schedule whose startTime
- * is after the entry's endTime. Entries without endTime go to the end.
+ * Cross-day entries with endTime are placed before the first schedule whose
+ * startTime is after the entry's endTime. A schedule without startTime has
+ * no time anchor, so cross-day entries with endTime are placed before it as
+ * well — otherwise users cannot position the schedule after the cross-day
+ * entry since timeline order is derived from times. Entries without endTime
+ * fall through to the end.
  */
 export function buildMergedTimeline(
   schedules: ScheduleResponse[],
@@ -26,7 +30,8 @@ export function buildMergedTimeline(
     const toInsert: CrossDayEntry[] = [];
     for (let j = remaining.length - 1; j >= 0; j--) {
       const entryTime = remaining[j].schedule.endTime?.slice(0, 5) ?? null;
-      if (entryTime && scheduleTime && entryTime <= scheduleTime) {
+      if (entryTime == null) continue;
+      if (scheduleTime == null || entryTime <= scheduleTime) {
         toInsert.unshift(remaining[j]);
         remaining.splice(j, 1);
       }


### PR DESCRIPTION
## Summary

- タイムラインの merge ロジックを修正し、時刻未設定の予定 (startTime=null) があるとき日をまたぐ予定 (crossDay) が常に末尾に回ってしまう挙動を解消
- ローカル DB URL の fallback を 55322 (sugara 専用ポート) に合わせる修正漏れを回収
- endTime 有無混在の crossDay テストを追加、逆順ループの意図コメントを追加

## Why

ユーザー観察の症状: 「候補から予定を追加すると、ホテルのチェックアウト (crossDay) より前に入ってしまい、そこから動かせない」。

原因は `apps/web/lib/merge-timeline.ts` の条件 `entryTime && scheduleTime && entryTime <= scheduleTime` にあり、schedule の `startTime` が null だと条件が絶対に false になるため、endTime を持つ crossDay が常に末尾に回っていた。

修正後: startTime が null の schedule があるとき、endTime を持つ crossDay をその前に flush する。endTime を持たない crossDay は従来通り末尾に残す。

## 検証

- `@sugara/web` ユニットテスト: 493 passed
- `merge-timeline.test.ts`: 13 passed（新規 3 件追加）
- biome check / type-check: clean
- 実機 (chrome-devtools MCP): Day3 に新パターンを作成し `京都タワーホテル (endDayOffset=2)` + `ホテルグランヴィア京都 (endDayOffset=1)` + `二条城 (startTime=null)` を配置したとき、表示順が期待通り `グランヴィア 09:00 → 京都タワー 11:00 → 二条城` になることを確認

## Test plan

- [ ] Day1 にホテル (`endDayOffset=1`, endTime あり) を作成
- [ ] Day2 を開いて、候補から startTime 未設定の予定を追加
- [ ] チェックアウトが予定より **上** に表示されること
- [ ] 既存 trip（長期旅行、多数の crossDay がある trip）で表示順が壊れないこと

## Out of scope

以下は同じ調査で発見したが別 PR 扱い:
- candidate → schedule への assign 時に endDayOffset が trip 日数を超えないかのサーバー側バリデーション
- 予定追加フォームで最終日に翌日跨ぎが選べる `Math.max(1, ...)` バグ
- `batch-shift` の hotel 限定スキップを `endDayOffset > 0` 全般に拡張
- `getCrossDayEntries` の pattern フィルタ不足
- drag-and-drop の crossDay drop 位置計算 (問題 1・2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)