### PR TITLE
fix(web): ドロップ位置検出を closestCorners に変更

### DIFF
--- a/apps/web/lib/hooks/use-trip-drag-and-drop.test.ts
+++ b/apps/web/lib/hooks/use-trip-drag-and-drop.test.ts
@@ -27,7 +27,7 @@ vi.mock("@dnd-kit/core", () => ({
   useSensors: vi.fn((...sensors: unknown[]) => sensors),
   MouseSensor: class {},
   TouchSensor: class {},
-  pointerWithin: vi.fn(),
+  closestCorners: vi.fn(),
 }));
 
 vi.mock("@dnd-kit/sortable", () => ({

--- a/apps/web/lib/hooks/use-trip-drag-and-drop.ts
+++ b/apps/web/lib/hooks/use-trip-drag-and-drop.ts
@@ -1,9 +1,9 @@
 import {
+  closestCorners,
   type DragEndEvent,
   type DragOverEvent,
   type DragStartEvent,
   MouseSensor,
-  pointerWithin,
   TouchSensor,
   useSensor,
   useSensors,
@@ -99,7 +99,7 @@ export function useTripDragAndDrop({
     useSensor(TouchSensor, TOUCH_SENSOR_OPTIONS),
   );
 
-  const collisionDetection = pointerWithin;
+  const collisionDetection = closestCorners;
 
   function handleDragStart(event: DragStartEvent) {
     const { active } = event;


### PR DESCRIPTION
## Summary

- dnd-kit の collisionDetection を `pointerWithin` から `closestCorners` に変更
- 隣接カード間の隙間でも drop target が確定するようになり、意図した位置にドロップできる

## Why

`pointerWithin` はポインタが要素の内側に入らないと over を検出しないため、カードとカードの隙間で over=null になり drop 位置が外れることが多かった。ユーザー観察では crossDay を狙ったのに奥多摩湖が拾われる現象として表面化した。`closestCorners` は vertical sortable list の推奨で、ポインタに最も近い要素を常に target として選ぶ。

## Test plan

- [ ] 候補から schedule への drag で、crossDay の上半分/下半分を狙った通りに挿入できる
- [ ] schedule の並び替えで、狭いカード間隙間でも drop 位置が確定する
- [ ] タイムラインと候補エリアの境界付近でもゾーン判定が意図通り切り替わる

🤖 Generated with [Claude Code](https://claude.com/claude-code)