### PR TITLE
fix(api): batch-shift の日跨ぎスキップを全カテゴリに拡張

### DIFF
--- a/apps/api/src/__tests__/integration/schedules.integration.test.ts
+++ b/apps/api/src/__tests__/integration/schedules.integration.test.ts
@@ -551,7 +551,10 @@ describe("Schedules Integration", () => {
       expect(body.skippedCount).toBe(1);
     });
 
-    it("does not shift endTime when endDayOffset > 0", async () => {
+    it("skips transport with endDayOffset > 0 (overnight bus)", async () => {
+      // Why: shifting only startTime would fix the endTime in place and
+      // silently alter the duration. Treat any cross-day schedule as not
+      // shiftable, regardless of category.
       const overnight = await createSchedule("Night Bus", "transport", {
         startTime: "22:00",
         endTime: "06:00",
@@ -569,15 +572,43 @@ describe("Schedules Integration", () => {
 
       expect(res.status).toBe(200);
       const body = await res.json();
-      expect(body.updatedCount).toBe(1);
+      expect(body.updatedCount).toBe(0);
+      expect(body.skippedCount).toBe(1);
 
       const listRes = await app.request(
         `/api/trips/${tripId}/days/${dayId}/patterns/${patternId}/schedules`,
       );
       const list = await listRes.json();
       const bus = list.find((s: { id: string }) => s.id === overnight.id);
-      expect(bus.startTime).toBe("21:30:00");
+      expect(bus.startTime).toBe("22:00:00");
       expect(bus.endTime).toBe("06:00:00");
+    });
+
+    it("skips activity with endDayOffset > 0 (night cruise)", async () => {
+      const cruise = await createSchedule("Night Cruise", "activity", {
+        startTime: "22:00",
+        endTime: "02:00",
+        endDayOffset: 1,
+      });
+
+      const res = await app.request(batchShiftUrl(), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ scheduleIds: [cruise.id], deltaMinutes: 15 }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.updatedCount).toBe(0);
+      expect(body.skippedCount).toBe(1);
+
+      const listRes = await app.request(
+        `/api/trips/${tripId}/days/${dayId}/patterns/${patternId}/schedules`,
+      );
+      const list = await listRes.json();
+      const fetched = list.find((s: { id: string }) => s.id === cruise.id);
+      expect(fetched.startTime).toBe("22:00:00");
+      expect(fetched.endTime).toBe("02:00:00");
     });
   });
 });

--- a/apps/api/src/routes/schedules.ts
+++ b/apps/api/src/routes/schedules.ts
@@ -197,8 +197,10 @@ scheduleRoutes.post("/:tripId/days/:dayId/patterns/:patternId/schedules/batch-sh
   let skippedCount = 0;
 
   for (const schedule of targetSchedules) {
-    // Skip hotels spanning multiple days
-    if (schedule.category === "hotel" && schedule.endDayOffset && schedule.endDayOffset > 0) {
+    // Skip any schedule that spans multiple days, regardless of category.
+    // Shifting only startTime would leave endTime fixed and silently alter
+    // the duration (e.g. night bus 22:00→06:00 would collapse by 30min).
+    if (schedule.endDayOffset && schedule.endDayOffset > 0) {
       skippedCount++;
       continue;
     }
@@ -223,16 +225,11 @@ scheduleRoutes.post("/:tripId/days/:dayId/patterns/:patternId/schedules/batch-sh
     }
 
     if (!shouldSkip && schedule.endTime) {
-      // Don't shift endTime for cross-day schedules
-      if (schedule.endDayOffset && schedule.endDayOffset > 0) {
-        // Keep endTime as-is
+      const shifted = shiftTime(schedule.endTime, deltaMinutes);
+      if (shifted === null) {
+        shouldSkip = true;
       } else {
-        const shifted = shiftTime(schedule.endTime, deltaMinutes);
-        if (shifted === null) {
-          shouldSkip = true;
-        } else {
-          newEndTime = shifted;
-        }
+        newEndTime = shifted;
       }
     }
 


### PR DESCRIPTION
## Summary

- batch-shift が hotel 限定で日跨ぎをスキップしていたのを `endDayOffset > 0` 全般に拡張
- 夜行バス (transport) やナイトクルーズ (activity) など hotel 以外の日跨ぎ予定でも所要時間が歪まない
- デッドコードとなった endTime 据え置き分岐を削除
- integration test で transport/activity 両方の skip を検証

## Why

shift 操作は startTime と endTime を同量ずらすのが期待挙動だが、日跨ぎ予定は endTime が翌日に属するため旧実装は endTime を据え置きにしていた。しかしその skip 判定が hotel 限定だったため、transport/activity の日跨ぎでは endTime だけ据え置かれ所要時間が勝手に短縮/延長されていた。

## Test plan

- [ ] 夜行バス (transport, endDayOffset=1) を含む選択で batch-shift → 夜行バスがスキップ（skippedCount=1）
- [ ] ナイトクルーズ (activity, endDayOffset=1) でも同様に skip
- [ ] 通常の schedule は従来通り startTime/endTime が両方シフト

🤖 Generated with [Claude Code](https://claude.com/claude-code)