### PR TITLE
fix(api): requireAdmin の本番 username フォールバック拒否を解除

### DIFF
--- a/apps/api/src/middleware/require-admin.ts
+++ b/apps/api/src/middleware/require-admin.ts
@@ -3,13 +3,12 @@ import type { Context, Next } from "hono";
 import { db } from "../db/index";
 import { users } from "../db/schema";
 import { ERROR_MSG } from "../lib/constants";
-import { logger } from "../lib/logger";
 import type { AppEnv } from "../types";
 
 export async function requireAdmin(c: Context<AppEnv>, next: Next) {
   const user = c.get("user");
 
-  // Prefer ADMIN_USER_ID (immutable) over ADMIN_USERNAME (user-changeable).
+  // ADMIN_USER_ID is optional; when set it takes precedence for strict id-based auth.
   const adminUserId = process.env.ADMIN_USER_ID;
   if (adminUserId) {
     if (user.id !== adminUserId) {
@@ -17,14 +16,6 @@ export async function requireAdmin(c: Context<AppEnv>, next: Next) {
     }
     await next();
     return;
-  }
-
-  // In production, refuse the username fallback — usernames are user-editable, so relying on
-  // them as an authorization boundary risks self-lockout and social-engineering attacks.
-  // ADMIN_USER_ID must be set in prod.
-  if (process.env.NODE_ENV === "production") {
-    logger.error("requireAdmin: ADMIN_USER_ID is not configured in production");
-    return c.json({ error: ERROR_MSG.FORBIDDEN }, 403);
   }
 
   const adminUsername = process.env.ADMIN_USERNAME;


### PR DESCRIPTION
## Summary

- #18 で `requireAdmin` が本番環境で `ADMIN_USER_ID` 必須になっていたため、`ADMIN_USERNAME` だけが設定されている運用では admin が全員 403 → `/admin` が 404 → Service Worker の `no-response` エラーで UI がロードできない状態になっていた
- 運用方針として username ベースの判定を維持するため、本番での fallback 拒否を削除
- `ADMIN_USER_ID` は引き続き optional として残し、設定されていれば id ベース判定を優先する

## Background

本番で admin ページにアクセス不可になった障害の修正。Vercel ログで `/api/admin/stats` が 403、`/admin` が 404 を返していることから原因特定。

## Test plan

- [x] `bun run --filter @sugara/api test admin` で admin 関連 26 件 pass
- [ ] merge 後、本番デプロイを待ち `/admin` にアクセスできることを確認
- [ ] 非 admin ユーザーが `/admin` で 404 になることを確認