### PR TITLE
fix(api): PR #34 レビュー指摘に対応した anchor 書き込み制限

### DIFF
--- a/apps/api/src/__tests__/integration/candidates.integration.test.ts
+++ b/apps/api/src/__tests__/integration/candidates.integration.test.ts
@@ -16,7 +16,8 @@ vi.mock("../../lib/auth", () => ({
   },
 }));
 
-import { tripMembers } from "../../db/schema";
+import { eq } from "drizzle-orm";
+import { schedules, tripMembers } from "../../db/schema";
 import { candidateRoutes } from "../../routes/candidates";
 import { scheduleRoutes } from "../../routes/schedules";
 import { tripRoutes } from "../../routes/trips";
@@ -288,5 +289,85 @@ describe("Candidates Integration", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body).toHaveLength(1);
+  });
+
+  describe("anchors are stripped on candidates", () => {
+    it("POST ignores crossDayAnchor/crossDayAnchorSourceId and stores null", async () => {
+      // Create a hotel-with-endDayOffset in a pattern so the fake anchor source id is valid-looking.
+      const hotelRes = await app.request(
+        `/api/trips/${tripId}/days/${dayId}/patterns/${patternId}/schedules`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: "Hotel",
+            category: "hotel",
+            startTime: "15:00",
+            endTime: "10:00",
+            endDayOffset: 1,
+          }),
+        },
+      );
+      const hotel = await hotelRes.json();
+
+      const res = await app.request(`/api/trips/${tripId}/candidates`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: "Smuggled",
+          category: "sightseeing",
+          crossDayAnchor: "after",
+          crossDayAnchorSourceId: hotel.id,
+        }),
+      });
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body.crossDayAnchor).toBeNull();
+      expect(body.crossDayAnchorSourceId).toBeNull();
+    });
+
+    it("PATCH ignores crossDayAnchor/crossDayAnchorSourceId fields", async () => {
+      const hotelRes = await app.request(
+        `/api/trips/${tripId}/days/${dayId}/patterns/${patternId}/schedules`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: "Hotel",
+            category: "hotel",
+            startTime: "15:00",
+            endTime: "10:00",
+            endDayOffset: 1,
+          }),
+        },
+      );
+      const hotel = await hotelRes.json();
+
+      const candidateRes = await app.request(`/api/trips/${tripId}/candidates`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "Candidate", category: "sightseeing" }),
+      });
+      const candidate = await candidateRes.json();
+
+      const patchRes = await app.request(`/api/trips/${tripId}/candidates/${candidate.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: "Renamed",
+          crossDayAnchor: "before",
+          crossDayAnchorSourceId: hotel.id,
+        }),
+      });
+      expect(patchRes.status).toBe(200);
+
+      const db = getTestDb();
+      const stored = await db.query.schedules.findFirst({
+        where: eq(schedules.id, candidate.id),
+      });
+      expect(stored?.name).toBe("Renamed");
+      expect(stored?.crossDayAnchor).toBeNull();
+      expect(stored?.crossDayAnchorSourceId).toBeNull();
+    });
   });
 });

--- a/apps/api/src/__tests__/integration/schedules.integration.test.ts
+++ b/apps/api/src/__tests__/integration/schedules.integration.test.ts
@@ -760,7 +760,7 @@ describe("Schedules Integration", () => {
       expect(fetched.crossDayAnchorSourceId).toBeNull();
     });
 
-    it("trigger nulls cross_day_anchor when source_id is cleared directly (FK SET NULL simulation)", async () => {
+    it("trigger nulls cross_day_anchor when source_id is set to null via direct UPDATE", async () => {
       const hotel = await createReorderSchedule("Hotel Trigger", "hotel", {
         startTime: "15:00",
         endTime: "10:00",
@@ -891,6 +891,77 @@ describe("Schedules Integration", () => {
       const fetched = await fetchSchedule(target.id);
       expect(fetched.crossDayAnchor).toBeNull();
       expect(fetched.crossDayAnchorSourceId).toBeNull();
+    });
+
+    it("unassign clears anchor on the moved schedule (becomes a candidate)", async () => {
+      const hotel = await createReorderSchedule("Hotel Unassign", "hotel", {
+        startTime: "15:00",
+        endTime: "10:00",
+        endDayOffset: 1,
+      });
+      const target = await createReorderSchedule("Target Unassign", "sightseeing");
+      await app.request(
+        `/api/trips/${tripId}/days/${dayId}/patterns/${patternId}/schedules/reorder`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            scheduleIds: [hotel.id, target.id],
+            anchors: [{ scheduleId: target.id, anchor: "after", anchorSourceId: hotel.id }],
+          }),
+        },
+      );
+
+      const unassignRes = await app.request(
+        `/api/trips/${tripId}/schedules/${target.id}/unassign`,
+        { method: "POST" },
+      );
+      expect(unassignRes.status).toBe(200);
+      const unassigned = await unassignRes.json();
+      expect(unassigned.dayPatternId).toBeNull();
+      expect(unassigned.crossDayAnchor).toBeNull();
+      expect(unassigned.crossDayAnchorSourceId).toBeNull();
+    });
+
+    it("batch-unassign clears anchor on each moved schedule", async () => {
+      const hotel = await createReorderSchedule("Hotel Batch", "hotel", {
+        startTime: "15:00",
+        endTime: "10:00",
+        endDayOffset: 1,
+      });
+      const t1 = await createReorderSchedule("T1", "sightseeing");
+      const t2 = await createReorderSchedule("T2", "sightseeing");
+      await app.request(
+        `/api/trips/${tripId}/days/${dayId}/patterns/${patternId}/schedules/reorder`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            scheduleIds: [hotel.id, t1.id, t2.id],
+            anchors: [
+              { scheduleId: t1.id, anchor: "after", anchorSourceId: hotel.id },
+              { scheduleId: t2.id, anchor: "before", anchorSourceId: hotel.id },
+            ],
+          }),
+        },
+      );
+
+      const res = await app.request(`/api/trips/${tripId}/schedules/batch-unassign`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ scheduleIds: [t1.id, t2.id] }),
+      });
+      expect(res.status).toBe(200);
+
+      const testDb = getTestDb();
+      for (const id of [t1.id, t2.id]) {
+        const row = await testDb.query.schedules.findFirst({
+          where: eq(schedules.id, id),
+        });
+        expect(row?.dayPatternId).toBeNull();
+        expect(row?.crossDayAnchor).toBeNull();
+        expect(row?.crossDayAnchorSourceId).toBeNull();
+      }
     });
   });
 });

--- a/apps/api/src/__tests__/integration/schedules.integration.test.ts
+++ b/apps/api/src/__tests__/integration/schedules.integration.test.ts
@@ -792,6 +792,69 @@ describe("Schedules Integration", () => {
       expect(after?.crossDayAnchorSourceId).toBeNull();
     });
 
+    it("POST strips crossDayAnchor/crossDayAnchorSourceId from client payload", async () => {
+      const hotel = await createReorderSchedule("Hotel for create", "hotel", {
+        startTime: "15:00",
+        endTime: "10:00",
+        endDayOffset: 1,
+      });
+
+      // Client tries to smuggle anchor fields into create payload. They must be ignored.
+      const res = await app.request(
+        `/api/trips/${tripId}/days/${dayId}/patterns/${patternId}/schedules`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: "Smuggled",
+            category: "sightseeing",
+            crossDayAnchor: "after",
+            crossDayAnchorSourceId: hotel.id,
+          }),
+        },
+      );
+      expect(res.status).toBe(201);
+      const created = await res.json();
+      expect(created.crossDayAnchor).toBeNull();
+      expect(created.crossDayAnchorSourceId).toBeNull();
+    });
+
+    it("DELETE of anchor source clears referencing anchors via FK ON DELETE SET NULL + trigger", async () => {
+      const hotel = await createReorderSchedule("Hotel FK", "hotel", {
+        startTime: "15:00",
+        endTime: "10:00",
+        endDayOffset: 1,
+      });
+      const target = await createReorderSchedule("Target FK", "sightseeing");
+      await app.request(
+        `/api/trips/${tripId}/days/${dayId}/patterns/${patternId}/schedules/reorder`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            scheduleIds: [hotel.id, target.id],
+            anchors: [{ scheduleId: target.id, anchor: "after", anchorSourceId: hotel.id }],
+          }),
+        },
+      );
+
+      // Delete the hotel through the API. This triggers FK ON DELETE SET NULL on
+      // cross_day_anchor_source_id, which in turn fires the trigger that nulls the
+      // cross_day_anchor enum column.
+      const deleteRes = await app.request(
+        `/api/trips/${tripId}/days/${dayId}/patterns/${patternId}/schedules/${hotel.id}`,
+        { method: "DELETE" },
+      );
+      expect(deleteRes.status).toBe(200);
+
+      const testDb = getTestDb();
+      const after = await testDb.query.schedules.findFirst({
+        where: eq(schedules.id, target.id),
+      });
+      expect(after?.crossDayAnchor).toBeNull();
+      expect(after?.crossDayAnchorSourceId).toBeNull();
+    });
+
     it("clears all anchors when clearAnchors=true", async () => {
       const hotel = await createReorderSchedule("Hotel", "hotel", {
         startTime: "15:00",

--- a/apps/api/src/routes/candidates.ts
+++ b/apps/api/src/routes/candidates.ts
@@ -61,11 +61,15 @@ candidateRoutes.post("/:tripId/candidates", requireTripAccess("editor"), async (
       and(eq(schedules.tripId, tripId), isNull(schedules.dayPatternId)),
     );
 
+    // Anchors cannot be set on candidates (they have no dayPatternId and
+    // therefore no cross-day context). Strip if a client tries to smuggle them.
+    const { crossDayAnchor: _a, crossDayAnchorSourceId: _s, ...createData } = parsed.data;
+
     const [result] = await tx
       .insert(schedules)
       .values({
         tripId,
-        ...parsed.data,
+        ...createData,
         sortOrder: nextOrder,
       })
       .returning();
@@ -394,7 +398,12 @@ candidateRoutes.patch("/:tripId/candidates/:scheduleId", requireTripAccess("edit
     return c.json({ error: ERROR_MSG.CANDIDATE_NOT_FOUND }, 404);
   }
 
-  const { expectedUpdatedAt, ...updateData } = parsed.data;
+  const {
+    expectedUpdatedAt,
+    crossDayAnchor: _a,
+    crossDayAnchorSourceId: _s,
+    ...updateData
+  } = parsed.data;
 
   if (!hasChanges(existing, updateData)) {
     return c.json(existing);

--- a/apps/api/src/routes/schedules.ts
+++ b/apps/api/src/routes/schedules.ts
@@ -619,6 +619,7 @@ scheduleRoutes.post("/:tripId/schedules/batch-unassign", requireTripAccess("edit
     );
 
     const ids = parsed.data.scheduleIds;
+    // Candidates cannot have anchors (no dayPatternId → no cross-day context).
     await tx
       .update(schedules)
       .set({
@@ -627,6 +628,8 @@ scheduleRoutes.post("/:tripId/schedules/batch-unassign", requireTripAccess("edit
           ids.map((id, i) => sql`WHEN ${schedules.id} = ${id} THEN ${nextOrder + i}::integer`),
           sql` `,
         )} END`,
+        crossDayAnchor: null,
+        crossDayAnchorSourceId: null,
         updatedAt: new Date(),
       })
       .where(inArray(schedules.id, ids));
@@ -667,11 +670,14 @@ scheduleRoutes.post(
       and(eq(schedules.tripId, tripId), isNull(schedules.dayPatternId)),
     );
 
+    // Candidates cannot have anchors (no dayPatternId → no cross-day context).
     const [updated] = await db
       .update(schedules)
       .set({
         dayPatternId: null,
         sortOrder: nextOrder,
+        crossDayAnchor: null,
+        crossDayAnchorSourceId: null,
         updatedAt: new Date(),
       })
       .where(eq(schedules.id, scheduleId))

--- a/apps/api/src/routes/schedules.ts
+++ b/apps/api/src/routes/schedules.ts
@@ -84,12 +84,16 @@ scheduleRoutes.post("/:tripId/days/:dayId/patterns/:patternId/schedules", async 
       eq(schedules.dayPatternId, patternId),
     );
 
+    // Anchors are never set on create — they can only be set via the reorder
+    // endpoint after the schedule has a stable id to reference.
+    const { crossDayAnchor: _a, crossDayAnchorSourceId: _s, ...createData } = parsed.data;
+
     const [result] = await tx
       .insert(schedules)
       .values({
         tripId,
         dayPatternId: patternId,
-        ...parsed.data,
+        ...createData,
         sortOrder: nextOrder,
       })
       .returning();


### PR DESCRIPTION
## Summary

- **Blocker 1**: candidate の PATCH で `crossDayAnchor` / `crossDayAnchorSourceId` が書き込めていた問題を修正。candidate は `dayPatternId=null` のため cross-day context を持てない
- **Blocker 2**: schedule / candidate の POST で anchor フィールドが書き込めた問題を修正。anchor は reorder 経由でのみセット可能 (stable id 確定後にしか指せない)
- **Blocker 3**: FK \`ON DELETE SET NULL\` + trigger の実経路 (DELETE API) を踏む統合テストを追加。既存テストは UPDATE 直打ちで cascade path を踏んでいなかった
- candidates に anchor を密輸しようとしても null になる回帰テストを追加

## Test plan

- [x] \`bun run --filter @sugara/api test:integration\` (113 pass)
- [x] \`bun run --filter @sugara/api check\`
- [x] \`bun run --filter @sugara/api check-types\`
- [ ] マージ後 smoke test が green になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)