### PR TITLE
fix(ci): smoke test を安定 alias URL にプローブさせる

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -14,10 +14,13 @@ jobs:
     steps:
       - name: Probe /api/health
         env:
-          TARGET_URL: ${{ github.event.deployment_status.target_url }}
+          # Use the stable production alias, not github.event.deployment_status.target_url.
+          # The target_url is the per-deployment Vercel URL (e.g. sugara-<hash>-u-stem.vercel.app)
+          # which is protected by Vercel Deployment Protection and returns 401 to unauthenticated
+          # requests. The alias does not have that protection.
+          TARGET_URL: https://sugara.vercel.app
         run: |
           set -euo pipefail
-          : "${TARGET_URL:?Deployment status event is missing target_url}"
           echo "Probing $TARGET_URL/api/health"
           # Retry up to ~25s total: Vercel sometimes reports success slightly before the edge
           # cache flips to the new deployment. Sleep only between attempts (not after the


### PR DESCRIPTION
## Summary

- \`github.event.deployment_status.target_url\` は deployment ごとの URL (\`sugara-<hash>-u-stem.vercel.app\`) で Vercel Deployment Protection により未認証リクエストに 401 を返す
- production alias (\`https://sugara.vercel.app\`) には protection が掛からないため、そちらを対象に変更
- main への deployment 後に smoke test が継続失敗していた問題を解消

失敗していた run の例: attempt 1-6 が全て \`curl: (22) The requested URL returned error: 401\`

## Test plan

- [ ] マージ後、次の production deploy で smoke test が green になること
- [ ] \`curl -fsS https://sugara.vercel.app/api/health\` が \`{\"status\":\"ok\"}\` を返すこと (ローカルから手動確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)