### PR TITLE
feat(web): cross-day anchor の merge / drop-position / drag 対応

### DIFF
--- a/apps/web/lib/__tests__/drop-position.test.ts
+++ b/apps/web/lib/__tests__/drop-position.test.ts
@@ -1,8 +1,10 @@
 import type { CrossDayEntry, ScheduleResponse } from "@sugara/shared";
 import { describe, expect, it } from "vitest";
 import {
+  computeCandidateDropResult,
   computeCandidateInsertIndex,
   computeScheduleReorderIndex,
+  computeScheduleReorderResult,
   type DropTarget,
   isOverUpperHalf,
 } from "../drop-position";
@@ -263,5 +265,87 @@ describe("computeScheduleReorderIndex", () => {
     const c = makeCrossDayEntry({ id: "c", endTime: "10:00" });
     const target: DropTarget = { kind: "schedule", overId: "cross-c", upperHalf: false };
     expect(computeScheduleReorderIndex([s1, s2], [c], "s1", target)).toBe(0);
+  });
+});
+
+describe("computeCandidateDropResult returns anchor info for crossDay drops", () => {
+  const s1 = makeSchedule({ id: "s1", startTime: "09:00", sortOrder: 0 });
+  const hotelCross = makeCrossDayEntry({ id: "hotel", endTime: "10:00" });
+
+  it("returns anchor=before when dropping on crossDay upper half", () => {
+    const target: DropTarget = {
+      kind: "schedule",
+      overId: "cross-hotel",
+      upperHalf: true,
+    };
+    const result = computeCandidateDropResult([s1], [hotelCross], target);
+    expect(result.anchor).toEqual({ anchor: "before", anchorSourceId: "hotel" });
+  });
+
+  it("returns anchor=after when dropping on crossDay lower half", () => {
+    const target: DropTarget = {
+      kind: "schedule",
+      overId: "cross-hotel",
+      upperHalf: false,
+    };
+    const result = computeCandidateDropResult([s1], [hotelCross], target);
+    expect(result.anchor).toEqual({ anchor: "after", anchorSourceId: "hotel" });
+  });
+
+  it("returns anchor=null when dropping on a regular schedule", () => {
+    const target: DropTarget = { kind: "schedule", overId: "s1", upperHalf: true };
+    const result = computeCandidateDropResult([s1], [hotelCross], target);
+    expect(result.anchor).toEqual({ anchor: null, anchorSourceId: null });
+  });
+
+  it("returns anchor=null when dropping on timeline / outside zones", () => {
+    expect(computeCandidateDropResult([s1], [hotelCross], { kind: "timeline" }).anchor).toEqual({
+      anchor: null,
+      anchorSourceId: null,
+    });
+    expect(computeCandidateDropResult([s1], [hotelCross], { kind: "outside" }).anchor).toEqual({
+      anchor: null,
+      anchorSourceId: null,
+    });
+  });
+
+  it("preserves the insertIndex computed by computeCandidateInsertIndex", () => {
+    const target: DropTarget = {
+      kind: "schedule",
+      overId: "cross-hotel",
+      upperHalf: false,
+    };
+    const directIdx = computeCandidateInsertIndex([s1], [hotelCross], target);
+    const result = computeCandidateDropResult([s1], [hotelCross], target);
+    expect(result.insertIndex).toBe(directIdx);
+  });
+});
+
+describe("computeScheduleReorderResult returns anchor info for crossDay drops", () => {
+  const s1 = makeSchedule({ id: "s1", startTime: "09:00", sortOrder: 0 });
+  const s2 = makeSchedule({ id: "s2", startTime: "12:00", sortOrder: 1 });
+  const hotelCross = makeCrossDayEntry({ id: "hotel", endTime: "10:00" });
+
+  it("returns anchor=before when reordering into crossDay upper half", () => {
+    const target: DropTarget = {
+      kind: "schedule",
+      overId: "cross-hotel",
+      upperHalf: true,
+    };
+    const result = computeScheduleReorderResult([s1, s2], [hotelCross], "s2", target);
+    expect(result).not.toBeNull();
+    expect(result?.anchor).toEqual({ anchor: "before", anchorSourceId: "hotel" });
+  });
+
+  it("returns anchor=null when moving to a non-crossDay position", () => {
+    const target: DropTarget = { kind: "schedule", overId: "s1", upperHalf: true };
+    const result = computeScheduleReorderResult([s1, s2], [hotelCross], "s2", target);
+    expect(result).not.toBeNull();
+    expect(result?.anchor).toEqual({ anchor: null, anchorSourceId: null });
+  });
+
+  it("returns null when underlying destination index is null (active not found)", () => {
+    const target: DropTarget = { kind: "timeline" };
+    expect(computeScheduleReorderResult([s1, s2], [hotelCross], "missing", target)).toBeNull();
   });
 });

--- a/apps/web/lib/__tests__/merge-timeline.test.ts
+++ b/apps/web/lib/__tests__/merge-timeline.test.ts
@@ -285,3 +285,92 @@ describe("buildMergedTimeline", () => {
     });
   });
 });
+
+describe("buildMergedTimeline with cross-day anchors", () => {
+  function makeAnchoredSchedule(
+    id: string,
+    anchor: "before" | "after",
+    sourceId: string | null,
+    overrides: Partial<ScheduleResponse> = {},
+  ): ScheduleResponse {
+    return makeSchedule({
+      id,
+      crossDayAnchor: anchor,
+      crossDayAnchorSourceId: sourceId,
+      ...overrides,
+    });
+  }
+
+  it("places anchor='after' schedule immediately after the matching crossDay", () => {
+    const hotelId = "hotel-day1";
+    const checkout = makeCrossDayEntry({ id: hotelId, endTime: "08:50" });
+    const schedules = [
+      makeAnchoredSchedule("hatonosu", "after", hotelId, { sortOrder: 0 }),
+      makeSchedule({ id: "okutama", startTime: "09:00", sortOrder: 1 }),
+    ];
+    const result = ids(buildMergedTimeline(schedules, [checkout]));
+    expect(result).toEqual([`c-${hotelId}`, "hatonosu", "okutama"]);
+  });
+
+  it("places anchor='before' schedule immediately before the matching crossDay", () => {
+    const hotelId = "hotel-day1";
+    const checkout = makeCrossDayEntry({ id: hotelId, endTime: "08:50" });
+    const schedules = [
+      makeAnchoredSchedule("before-check", "before", hotelId, { sortOrder: 0 }),
+      makeSchedule({ id: "okutama", startTime: "09:00", sortOrder: 1 }),
+    ];
+    const result = ids(buildMergedTimeline(schedules, [checkout]));
+    expect(result).toEqual(["before-check", `c-${hotelId}`, "okutama"]);
+  });
+
+  it("sorts multiple anchored schedules by sortOrder within the same position", () => {
+    const hotelId = "hotel-day1";
+    const checkout = makeCrossDayEntry({ id: hotelId, endTime: "08:50" });
+    const schedules = [
+      makeAnchoredSchedule("a2", "after", hotelId, { sortOrder: 2 }),
+      makeAnchoredSchedule("a1", "after", hotelId, { sortOrder: 1 }),
+      makeSchedule({ id: "okutama", startTime: "09:00", sortOrder: 3 }),
+    ];
+    const result = ids(buildMergedTimeline(schedules, [checkout]));
+    expect(result).toEqual([`c-${hotelId}`, "a1", "a2", "okutama"]);
+  });
+
+  it("falls back to time-based merge when anchorSourceId doesn't match any crossDay", () => {
+    const checkout = makeCrossDayEntry({ id: "hotel-a", endTime: "08:50" });
+    const schedules = [
+      makeAnchoredSchedule("orphan", "after", "hotel-b", {
+        sortOrder: 0,
+        startTime: "10:00",
+      }),
+    ];
+    const result = ids(buildMergedTimeline(schedules, [checkout]));
+    expect(result).toEqual(["c-hotel-a", "orphan"]);
+  });
+
+  it("falls back to time-based merge when anchorSourceId is null (partial anchor)", () => {
+    const checkout = makeCrossDayEntry({ id: "hotel-a", endTime: "08:50" });
+    const schedules = [
+      makeAnchoredSchedule("partial", "after", null, {
+        sortOrder: 0,
+        startTime: "10:00",
+      }),
+    ];
+    const result = ids(buildMergedTimeline(schedules, [checkout]));
+    expect(result).toEqual(["c-hotel-a", "partial"]);
+  });
+
+  it("keeps anchored 'before' schedules before time-based flushed crossDays", () => {
+    const hotelA = "hotel-a";
+    const hotelB = "hotel-b";
+    const schedules = [
+      makeAnchoredSchedule("anchored", "before", hotelA, { sortOrder: 0 }),
+      makeSchedule({ id: "s1", startTime: "12:00", sortOrder: 1 }),
+    ];
+    const entries = [
+      makeCrossDayEntry({ id: hotelA, endTime: "08:00" }),
+      makeCrossDayEntry({ id: hotelB, endTime: "11:00" }),
+    ];
+    const result = ids(buildMergedTimeline(schedules, entries));
+    expect(result).toEqual(["anchored", "c-hotel-a", "c-hotel-b", "s1"]);
+  });
+});

--- a/apps/web/lib/__tests__/merge-timeline.test.ts
+++ b/apps/web/lib/__tests__/merge-timeline.test.ts
@@ -359,6 +359,18 @@ describe("buildMergedTimeline with cross-day anchors", () => {
     expect(result).toEqual(["c-hotel-a", "partial"]);
   });
 
+  it("places both 'before' and 'after' anchors around the same crossDay in correct order", () => {
+    const hotelId = "hotel";
+    const checkout = makeCrossDayEntry({ id: hotelId, endTime: "09:00" });
+    const schedules = [
+      makeAnchoredSchedule("b1", "before", hotelId, { sortOrder: 0 }),
+      makeAnchoredSchedule("a1", "after", hotelId, { sortOrder: 1 }),
+      makeSchedule({ id: "plain", startTime: "12:00", sortOrder: 2 }),
+    ];
+    const result = ids(buildMergedTimeline(schedules, [checkout]));
+    expect(result).toEqual(["b1", `c-${hotelId}`, "a1", "plain"]);
+  });
+
   it("keeps anchored 'before' schedules before time-based flushed crossDays", () => {
     const hotelA = "hotel-a";
     const hotelB = "hotel-b";

--- a/apps/web/lib/drop-position.ts
+++ b/apps/web/lib/drop-position.ts
@@ -109,3 +109,60 @@ export function computeScheduleReorderIndex(
   const insert = computeCandidateInsertIndex(without, crossDayEntries, target);
   return insert;
 }
+
+export type AnchorUpdate = {
+  anchor: "before" | "after" | null;
+  anchorSourceId: string | null;
+};
+
+export type CandidateDropResult = {
+  insertIndex: number;
+  anchor: AnchorUpdate;
+};
+
+/**
+ * Like `computeCandidateInsertIndex`, but also returns the anchor update that
+ * should be written to the inserted schedule. When the drop target is a
+ * crossDay sortable (id prefixed with `cross-`), the anchor is set to
+ * 'before' / 'after' with the source schedule id extracted from the prefix.
+ * For any other drop (regular schedule, timeline zone, outside), the anchor
+ * is cleared.
+ */
+export function computeCandidateDropResult(
+  schedules: ScheduleResponse[],
+  crossDayEntries: CrossDayEntry[] | undefined,
+  target: DropTarget,
+): CandidateDropResult {
+  return {
+    insertIndex: computeCandidateInsertIndex(schedules, crossDayEntries, target),
+    anchor: extractAnchor(target),
+  };
+}
+
+/**
+ * Like `computeScheduleReorderIndex` but also returns the anchor update.
+ * Returns null when the underlying index computation returns null (active id
+ * not found or same-over no-op).
+ */
+export function computeScheduleReorderResult(
+  schedules: ScheduleResponse[],
+  crossDayEntries: CrossDayEntry[] | undefined,
+  activeId: string,
+  target: DropTarget,
+): { destIndex: number; anchor: AnchorUpdate } | null {
+  const destIndex = computeScheduleReorderIndex(schedules, crossDayEntries, activeId, target);
+  if (destIndex === null) return null;
+  return { destIndex, anchor: extractAnchor(target) };
+}
+
+function extractAnchor(target: DropTarget): AnchorUpdate {
+  if (target.kind !== "schedule") {
+    return { anchor: null, anchorSourceId: null };
+  }
+  const match = /^cross-(.+)$/.exec(target.overId);
+  if (!match) return { anchor: null, anchorSourceId: null };
+  return {
+    anchor: target.upperHalf ? "before" : "after",
+    anchorSourceId: match[1],
+  };
+}

--- a/apps/web/lib/hooks/use-trip-drag-and-drop.ts
+++ b/apps/web/lib/hooks/use-trip-drag-and-drop.ts
@@ -21,8 +21,8 @@ import { useState } from "react";
 import { toast } from "sonner";
 import { ApiError, api } from "@/lib/api";
 import {
-  computeCandidateInsertIndex,
-  computeScheduleReorderIndex,
+  computeCandidateDropResult,
+  computeScheduleReorderResult,
   type DropTarget,
   isOverUpperHalf,
 } from "@/lib/drop-position";
@@ -195,18 +195,17 @@ export function useTripDragAndDrop({
         if (activeIdx === -1) return;
 
         const target = buildDropTarget(event, savedLastOverZone);
-        const destIdx = computeScheduleReorderIndex(
+        const reorderResult = computeScheduleReorderResult(
           currentSchedules,
           crossDayEntries,
           activeId,
           target,
         );
-        if (destIdx === null) return;
-        // arrayMove: from `activeIdx`, insert at `destIdx` in the post-removal
-        // array. Skip when the destination is a no-op.
-        if (destIdx === activeIdx) return;
+        if (reorderResult === null) return;
+        const { destIndex, anchor } = reorderResult;
+        if (destIndex === activeIdx) return;
 
-        const reordered = arrayMove(currentSchedules, activeIdx, destIdx);
+        const reordered = arrayMove(currentSchedules, activeIdx, destIndex);
         setLocalSchedules(reordered);
 
         const scheduleIds = reordered.map((s) => s.id);
@@ -215,7 +214,16 @@ export function useTripDragAndDrop({
             `/api/trips/${tripId}/days/${currentDayId}/patterns/${currentPatternId}/schedules/reorder`,
             {
               method: "PATCH",
-              body: JSON.stringify({ scheduleIds }),
+              body: JSON.stringify({
+                scheduleIds,
+                anchors: [
+                  {
+                    scheduleId: activeId,
+                    anchor: anchor.anchor,
+                    anchorSourceId: anchor.anchorSourceId,
+                  },
+                ],
+              }),
             },
           );
           onDone();
@@ -283,7 +291,11 @@ export function useTripDragAndDrop({
         setLocalCandidates(currentCandidates.filter((c) => c.id !== active.id));
 
         const target = buildDropTarget(event, savedLastOverZone);
-        const insertIdx = computeCandidateInsertIndex(currentSchedules, crossDayEntries, target);
+        const { insertIndex: insertIdx, anchor } = computeCandidateDropResult(
+          currentSchedules,
+          crossDayEntries,
+          target,
+        );
 
         const newSchedule: ScheduleResponse = {
           id: candidate.id,
@@ -300,6 +312,8 @@ export function useTripDragAndDrop({
           transportMethod: candidate.transportMethod,
           color: candidate.color,
           endDayOffset: candidate.endDayOffset,
+          crossDayAnchor: anchor.anchor,
+          crossDayAnchorSourceId: anchor.anchorSourceId,
           latitude: candidate.latitude,
           longitude: candidate.longitude,
           placeId: candidate.placeId,
@@ -327,19 +341,30 @@ export function useTripDragAndDrop({
         }
 
         try {
-          if (overType === "schedule") {
-            const scheduleIds = [...currentSchedules.map((s) => s.id)];
-            scheduleIds.splice(insertIdx, 0, String(active.id));
-            await api(
-              `/api/trips/${tripId}/days/${currentDayId}/patterns/${currentPatternId}/schedules/reorder`,
-              {
-                method: "PATCH",
-                body: JSON.stringify({ scheduleIds }),
-              },
-            );
-          }
+          // Always write reorder + anchors after assign so the anchor is
+          // persisted even when dropping into the timeline zone (overType
+          // "timeline") — the previous branch-by-overType only persisted
+          // order on overType === "schedule", which was fine for sortOrder
+          // but would drop the anchor silently.
+          const scheduleIds = [...currentSchedules.map((s) => s.id)];
+          scheduleIds.splice(insertIdx, 0, String(active.id));
+          await api(
+            `/api/trips/${tripId}/days/${currentDayId}/patterns/${currentPatternId}/schedules/reorder`,
+            {
+              method: "PATCH",
+              body: JSON.stringify({
+                scheduleIds,
+                anchors: [
+                  {
+                    scheduleId: String(active.id),
+                    anchor: anchor.anchor,
+                    anchorSourceId: anchor.anchorSourceId,
+                  },
+                ],
+              }),
+            },
+          );
         } catch {
-          // assign succeeded but reorder failed — refetch to sync
           onDone();
           return;
         }
@@ -394,11 +419,16 @@ export function useTripDragAndDrop({
     setLocalSchedules(reordered);
 
     try {
+      // Keyboard reorder doesn't know the anchor intent — treat it as a
+      // deliberate manual repositioning that overrides any previous anchor.
       await api(
         `/api/trips/${tripId}/days/${currentDayId}/patterns/${currentPatternId}/schedules/reorder`,
         {
           method: "PATCH",
-          body: JSON.stringify({ scheduleIds: reordered.map((s) => s.id) }),
+          body: JSON.stringify({
+            scheduleIds: reordered.map((s) => s.id),
+            anchors: [{ scheduleId: id, anchor: null, anchorSourceId: null }],
+          }),
         },
       );
       onDone();

--- a/apps/web/lib/hooks/use-trip-drag-and-drop.ts
+++ b/apps/web/lib/hooks/use-trip-drag-and-drop.ts
@@ -203,7 +203,15 @@ export function useTripDragAndDrop({
         );
         if (reorderResult === null) return;
         const { destIndex, anchor } = reorderResult;
-        if (destIndex === activeIdx) return;
+        // Same-position drop with no anchor change is a true no-op. If the
+        // anchor actually changed (e.g. dropping on the crossDay boundary of
+        // the same slot toggles before/after), still send the reorder so the
+        // new anchor is persisted.
+        const activeSchedule = currentSchedules[activeIdx];
+        const anchorChanged =
+          (activeSchedule.crossDayAnchor ?? null) !== anchor.anchor ||
+          (activeSchedule.crossDayAnchorSourceId ?? null) !== anchor.anchorSourceId;
+        if (destIndex === activeIdx && !anchorChanged) return;
 
         const reordered = arrayMove(currentSchedules, activeIdx, destIndex);
         setLocalSchedules(reordered);

--- a/apps/web/lib/merge-timeline.ts
+++ b/apps/web/lib/merge-timeline.ts
@@ -7,17 +7,16 @@ export type TimelineItem =
 /**
  * Build a merged timeline of schedules and cross-day entries.
  *
- * Cross-day entries (with endTime) are flushed before the first time-having
- * schedule whose startTime is >= the entry's endTime. Schedules without a
- * startTime have no time anchor and therefore do not trigger a flush — they
- * flow around cross-day entries by sortOrder. Remaining cross-day entries
- * (including all entries without endTime) fall through to the end, sorted
- * by endTime; null-endTime entries keep their original order after those.
- *
- * Consequence: a null-startTime schedule placed before a time-having schedule
- * in sortOrder will render before the cross-day entry that the time-having
- * schedule triggers. Reordering the null-startTime schedule around the
- * time-having schedule lets users move it across the cross-day entry.
+ * Schedules with a valid cross-day anchor (both `crossDayAnchor` and
+ * `crossDayAnchorSourceId` set, and the source id matching one of the
+ * crossDayEntries) are placed immediately before/after their target crossDay
+ * and sorted by sortOrder within that slot. All other schedules (including
+ * schedules with a broken/stale anchor whose source doesn't match any
+ * crossDay) flow through the time-based merge: time-having schedules flush
+ * pending crossDays whose endTime is <= the schedule's startTime, and
+ * null-startTime schedules do not flush. Remaining crossDays fall through to
+ * the end (endTime-having entries sorted by endTime, then null-endTime
+ * entries).
  */
 export function buildMergedTimeline(
   schedules: ScheduleResponse[],
@@ -27,6 +26,61 @@ export function buildMergedTimeline(
     return schedules.map((schedule) => ({ type: "schedule", schedule }));
   }
 
+  const validSourceIds = new Set(crossDayEntries.map((e) => e.schedule.id));
+
+  const anchoredBefore: ScheduleResponse[] = [];
+  const anchoredAfter: ScheduleResponse[] = [];
+  const plainSchedules: ScheduleResponse[] = [];
+
+  for (const schedule of schedules) {
+    const anchor = schedule.crossDayAnchor;
+    const sourceId = schedule.crossDayAnchorSourceId;
+    if (anchor && sourceId && validSourceIds.has(sourceId)) {
+      if (anchor === "before") anchoredBefore.push(schedule);
+      else anchoredAfter.push(schedule);
+    } else {
+      plainSchedules.push(schedule);
+    }
+  }
+
+  const sortBySortOrder = (a: ScheduleResponse, b: ScheduleResponse) => a.sortOrder - b.sortOrder;
+  anchoredBefore.sort(sortBySortOrder);
+  anchoredAfter.sort(sortBySortOrder);
+
+  const merged = timeBasedMerge(plainSchedules, crossDayEntries);
+
+  for (const entry of crossDayEntries) {
+    const sourceId = entry.schedule.id;
+    const before = anchoredBefore.filter((s) => s.crossDayAnchorSourceId === sourceId);
+    const after = anchoredAfter.filter((s) => s.crossDayAnchorSourceId === sourceId);
+    if (before.length === 0 && after.length === 0) continue;
+
+    const pos = merged.findIndex((item) => item.type === "crossDay" && item.entry === entry);
+    if (pos === -1) continue;
+
+    if (after.length > 0) {
+      merged.splice(
+        pos + 1,
+        0,
+        ...after.map((s): TimelineItem => ({ type: "schedule", schedule: s })),
+      );
+    }
+    if (before.length > 0) {
+      merged.splice(
+        pos,
+        0,
+        ...before.map((s): TimelineItem => ({ type: "schedule", schedule: s })),
+      );
+    }
+  }
+
+  return merged;
+}
+
+function timeBasedMerge(
+  schedules: ScheduleResponse[],
+  crossDayEntries: CrossDayEntry[],
+): TimelineItem[] {
   const merged: TimelineItem[] = [];
   const remaining = [...crossDayEntries];
 
@@ -35,7 +89,6 @@ export function buildMergedTimeline(
 
     if (scheduleTime != null) {
       const toInsert: CrossDayEntry[] = [];
-      // Iterate in reverse so splice() doesn't shift the indices of unvisited entries.
       for (let j = remaining.length - 1; j >= 0; j--) {
         const entryTime = remaining[j].schedule.endTime?.slice(0, 5) ?? null;
         if (entryTime == null) continue;
@@ -57,8 +110,6 @@ export function buildMergedTimeline(
     merged.push({ type: "schedule", schedule });
   }
 
-  // Trailing cross-day entries: sort entries with endTime by endTime, then
-  // append entries without endTime in their original order.
   const withEnd: CrossDayEntry[] = [];
   const withoutEnd: CrossDayEntry[] = [];
   for (const entry of remaining) {

--- a/apps/web/lib/merge-timeline.ts
+++ b/apps/web/lib/merge-timeline.ts
@@ -89,6 +89,7 @@ function timeBasedMerge(
 
     if (scheduleTime != null) {
       const toInsert: CrossDayEntry[] = [];
+      // Iterate in reverse so splice() doesn't shift the indices of unvisited entries.
       for (let j = remaining.length - 1; j >= 0; j--) {
         const entryTime = remaining[j].schedule.endTime?.slice(0, 5) ?? null;
         if (entryTime == null) continue;


### PR DESCRIPTION
## Summary

PR #34 で追加した cross-day anchor (schedule が crossDay の前後どちらに置くかを保存する仕組み) を web 側に繋ぎ込む。ユーザーが候補をチェックアウトの前に置くといった操作が永続化されるようになる。

- **merge-timeline**: \`buildMergedTimeline\` を anchor 対応に拡張。valid な anchor を持つ schedule は時刻 merge ではなく anchor slot (before/after) に配置し、同スロット内は sortOrder で並べる。stale/broken anchor (source id が表示中 pattern の crossDay にない) は従来の時刻 merge に fallback
- **drop-position**: \`computeCandidateDropResult\` / \`computeScheduleReorderResult\` を追加。crossDay sortable (\`cross-<id>\`) への drop から anchor を導出する
- **use-trip-drag-and-drop**: drag-end で anchor を reorder API に送信。candidate → timeline では timeline zone への drop でも reorder + anchors を発行して anchor 永続化を確実に行う。キーボード reorder は anchor=null を送って手動並べ替えを優先扱いに

## Test plan

- [x] \`bun run --filter @sugara/web test\` (556 pass — merge-timeline 30, drop-position 41, use-trip-drag-and-drop 6 を含む)
- [x] \`bun run --filter @sugara/web check-types\`
- [x] \`bun run --filter @sugara/web check\`
- [ ] 実機確認: 鳩ノ巣渓谷シナリオで候補をチェックアウト前に drop → reload 後も位置が保持される
- [ ] 実機確認: 時刻付き schedule を crossDay にまたぐように並べ替えても anchor で固定される

## 残り
- PR C: 時刻順ソートボタンの clearAnchors 送信、E2E 回帰、News / FAQ 更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)