### PR TITLE
fix(web): SP の予定並び替えで一瞬古い順序に戻る snap-back を解消

### DIFF
--- a/.claude/hooks/post-edit.sh
+++ b/.claude/hooks/post-edit.sh
@@ -12,7 +12,6 @@ set -euo pipefail
 
 cd "${CLAUDE_PROJECT_DIR:-.}"
 
-LOG_FAILURE="/Users/mikiya/ws/claude-settings/hooks/log-failure.sh"
 LOG_FILE="${CLAUDE_PROJECT_DIR:-.}/.claude/failure-log.jsonl"
 
 # Read stdin once (hook framework pipes JSON with tool_input)
@@ -38,20 +37,51 @@ case "$file_path" in
   *) exit 0 ;; # Files outside packages (root config, docs, etc.)
 esac
 
-# Drop stale entries for this package+category from the log before recording fresh state.
+# Drop stale entries matching this package+category from the log before recording fresh state.
+# Filters on dedicated `pkg` and `category` fields rather than fuzzy-matching the error string —
+# the legacy approach (startswith on `.error`) broke when turbo/bun output didn't lead with the
+# package name, prune-leaking errors from other packages or failing to reset resolved ones.
 prune_log() {
   local category="$1"
   [ -f "$LOG_FILE" ] || return 0
   local tmp
   tmp=$(mktemp)
-  jq -c --arg pkg "$pkg" --arg cat "$category" \
-    'select(.category != $cat or (.error | startswith($pkg + " ") | not))' \
-    "$LOG_FILE" > "$tmp" 2>/dev/null || cp "$LOG_FILE" "$tmp"
-  if [ -s "$tmp" ]; then
-    mv "$tmp" "$LOG_FILE"
+  if jq -c --arg pkg "$pkg" --arg cat "$category" \
+      'select(.pkg != $pkg or .category != $cat)' \
+      "$LOG_FILE" > "$tmp" 2>/dev/null; then
+    if [ -s "$tmp" ]; then
+      mv "$tmp" "$LOG_FILE"
+    else
+      rm -f "$LOG_FILE"
+      rm -f "$tmp"
+    fi
   else
-    rm -f "$LOG_FILE" "$tmp"
+    # Malformed JSONL — leave the log untouched so a human can inspect it.
+    rm -f "$tmp"
   fi
+}
+
+# Append a fresh failure entry. Schema: {ts, pkg, category, error} where `error` is the first
+# meaningful line extracted from the captured output. Self-contained (does not call out to
+# log-failure.sh) so the pkg field is always set and the prune filter above stays sound.
+append_failure() {
+  local category="$1"
+  local output_text="$2"
+  local first_error
+  first_error=$(printf '%s\n' "$output_text" | grep -E '(error|Error|ERROR|FAIL|✗)' | head -1 | sed 's/^[[:space:]]*//')
+  if [ -z "$first_error" ]; then
+    first_error=$(printf '%s\n' "$output_text" | head -1 | sed 's/^[[:space:]]*//')
+  fi
+  local ts
+  ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  mkdir -p "$(dirname "$LOG_FILE")"
+  jq -nc \
+    --arg ts "$ts" \
+    --arg pkg "$pkg" \
+    --arg category "$category" \
+    --arg error "$first_error" \
+    '{ts: $ts, pkg: $pkg, category: $category, error: $error}' \
+    >> "$LOG_FILE"
 }
 
 run_check() {
@@ -65,7 +95,7 @@ run_check() {
   prune_log "$category"
   if [ $rc -ne 0 ]; then
     errors="${errors}${output}\n"
-    [ -x "$LOG_FAILURE" ] && echo "$output" | "$LOG_FAILURE" "$category"
+    append_failure "$category" "$output"
   fi
 }
 
@@ -74,6 +104,6 @@ run_check check       check
 run_check check-types check-types
 
 if [ -n "$errors" ]; then
-  echo -e "$errors" >&2
+  printf '%b' "$errors" >&2
   exit 2
 fi

--- a/.claude/hooks/post-edit.sh
+++ b/.claude/hooks/post-edit.sh
@@ -4,11 +4,16 @@
 # Skips files that don't affect lint/type-check (docs, data, config, SQL migrations) to avoid
 # wasted work and false positives from the post-Edit transient state (e.g. a follow-up Edit
 # that consumes a just-added import hasn't fired yet).
+#
+# failure-log.jsonl is treated as CURRENT state (not append-only history): before appending new
+# failures we prune entries for this package+category. Stop hook blocks on any remaining entry,
+# so the log must accurately reflect unresolved failures.
 set -euo pipefail
 
 cd "${CLAUDE_PROJECT_DIR:-.}"
 
 LOG_FAILURE="/Users/mikiya/ws/claude-settings/hooks/log-failure.sh"
+LOG_FILE="${CLAUDE_PROJECT_DIR:-.}/.claude/failure-log.jsonl"
 
 # Read stdin once (hook framework pipes JSON with tool_input)
 input=$(cat)
@@ -25,29 +30,50 @@ case "$file_path" in
     exit 0 ;;
 esac
 
-# Map file path to package filter
+# Map file path to package filter + package name
 case "$file_path" in
-  */apps/web/*)        filter="--filter @sugara/web" ;;
-  */apps/api/*)        filter="--filter @sugara/api" ;;
-  */packages/shared/*) filter="--filter @sugara/shared" ;;
+  */apps/web/*)        filter="--filter @sugara/web";    pkg="@sugara/web" ;;
+  */apps/api/*)        filter="--filter @sugara/api";    pkg="@sugara/api" ;;
+  */packages/shared/*) filter="--filter @sugara/shared"; pkg="@sugara/shared" ;;
   *) exit 0 ;; # Files outside packages (root config, docs, etc.)
 esac
 
+# Drop stale entries for this package+category from the log before recording fresh state.
+prune_log() {
+  local category="$1"
+  [ -f "$LOG_FILE" ] || return 0
+  local tmp
+  tmp=$(mktemp)
+  jq -c --arg pkg "$pkg" --arg cat "$category" \
+    'select(.category != $cat or (.error | startswith($pkg + " ") | not))' \
+    "$LOG_FILE" > "$tmp" 2>/dev/null || cp "$LOG_FILE" "$tmp"
+  if [ -s "$tmp" ]; then
+    mv "$tmp" "$LOG_FILE"
+  else
+    rm -f "$LOG_FILE" "$tmp"
+  fi
+}
+
+run_check() {
+  local category="$1"
+  local cmd="$2"
+  local output rc
+  set +e
+  output=$(bun run $filter $cmd 2>&1)
+  rc=$?
+  set -e
+  prune_log "$category"
+  if [ $rc -ne 0 ]; then
+    errors="${errors}${output}\n"
+    [ -x "$LOG_FAILURE" ] && echo "$output" | "$LOG_FAILURE" "$category"
+  fi
+}
+
 errors=""
-
-# Biome check (lint + format) on the affected package
-output=$(bun run $filter check 2>&1) || {
-  errors="${errors}${output}\n"
-  [ -x "$LOG_FAILURE" ] && echo "$output" | "$LOG_FAILURE" check
-}
-
-# TypeScript type check on the affected package
-output=$(bun run $filter check-types 2>&1) || {
-  errors="${errors}${output}\n"
-  [ -x "$LOG_FAILURE" ] && echo "$output" | "$LOG_FAILURE" check-types
-}
+run_check check       check
+run_check check-types check-types
 
 if [ -n "$errors" ]; then
-  echo "$errors" >&2
+  echo -e "$errors" >&2
   exit 2
 fi

--- a/.claude/hooks/post-stop.sh
+++ b/.claude/hooks/post-stop.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# Post-stop hook: run tests *for the packages touched in this session* when Claude stops.
+# Post-stop hook: gate 1 — block Stop if failure-log has unresolved entries.
+#                 gate 2 — run tests for packages touched in this session.
 # Success: silent (exit 0). Failure: output errors (exit 2).
 #
 # Full-monorepo `bun run test` on every stop was ~13s for a ~1100-test suite and ran even when
@@ -10,14 +11,29 @@ set -euo pipefail
 cd "${CLAUDE_PROJECT_DIR:-.}"
 
 LOG_FAILURE="/Users/mikiya/ws/claude-settings/hooks/log-failure.sh"
+LOG_FILE="${CLAUDE_PROJECT_DIR:-.}/.claude/failure-log.jsonl"
 
-# Short-circuit when the whole hook is disabled (e.g. long debug sessions, interactive work).
+# Gate 1: refuse to stop while unresolved lint/type errors are logged. This runs BEFORE the
+# test-skip escape (SUGARA_SKIP_POST_STOP_TEST) because that escape is about skipping tests, not
+# about ignoring known lint/type failures. Escape hatch for this gate: SUGARA_IGNORE_FAILURE_LOG=1.
+if [ "${SUGARA_IGNORE_FAILURE_LOG:-0}" != "1" ] && [ -s "$LOG_FILE" ]; then
+  count=$(wc -l < "$LOG_FILE" | tr -d ' ')
+  cat >&2 <<EOF
+[Harness] 未解決の failure が ${count} 件残っています (.claude/failure-log.jsonl)
+セッション終了前に以下を実施してください:
+  1. 'bun run check && bun run check-types' が zero error で通ることを確認
+  2. zero error を確認できたら 'rm .claude/failure-log.jsonl' でクリア
+  3. 本当に無視する場合のみ SUGARA_IGNORE_FAILURE_LOG=1 を設定
+EOF
+  exit 2
+fi
+
+# Short-circuit test execution when requested (e.g. long debug sessions, interactive work).
 if [ "${SUGARA_SKIP_POST_STOP_TEST:-0}" = "1" ]; then
   exit 0
 fi
 
-# Collect the set of changed package filters. Looking at both staged and unstaged changes covers
-# both mid-session edits and staged-but-not-committed state. Untracked files are picked up too.
+# Gate 2: scope tests to packages with staged/unstaged/untracked changes.
 changed=$(git status --porcelain 2>/dev/null | awk '{print $2}' || true)
 if [ -z "$changed" ]; then
   exit 0

--- a/.claude/hooks/post-stop.sh
+++ b/.claude/hooks/post-stop.sh
@@ -17,7 +17,9 @@ LOG_FILE="${CLAUDE_PROJECT_DIR:-.}/.claude/failure-log.jsonl"
 # test-skip escape (SUGARA_SKIP_POST_STOP_TEST) because that escape is about skipping tests, not
 # about ignoring known lint/type failures. Escape hatch for this gate: SUGARA_IGNORE_FAILURE_LOG=1.
 if [ "${SUGARA_IGNORE_FAILURE_LOG:-0}" != "1" ] && [ -s "$LOG_FILE" ]; then
-  count=$(wc -l < "$LOG_FILE" | tr -d ' ')
+  # awk counts records correctly even when the final line lacks a trailing newline;
+  # `wc -l` would underreport by 1 in that case and confuse the user.
+  count=$(awk 'END{print NR}' "$LOG_FILE")
   cat >&2 <<EOF
 [Harness] 未解決の failure が ${count} 件残っています (.claude/failure-log.jsonl)
 セッション終了前に以下を実施してください:

--- a/apps/web/lib/hooks/use-trip-drag-and-drop.test.ts
+++ b/apps/web/lib/hooks/use-trip-drag-and-drop.test.ts
@@ -372,6 +372,9 @@ describe("useTripDragAndDrop — null-based snapshot isolation", () => {
     // prop has not been updated yet. If finally runs before onDone resolves,
     // localSchedules falls back to the stale prop (= old order [s1, s2]),
     // causing a brief snap-back before the refetch completes.
+    // The onDone-was-called assertion guards against a degenerate fix where
+    // the test passes only because onDone never ran.
+    expect(onDone).toHaveBeenCalledTimes(1);
     expect(result.current.localSchedules.map((s) => s.id)).toEqual(["s2", "s1"]);
 
     await act(async () => {

--- a/apps/web/lib/hooks/use-trip-drag-and-drop.test.ts
+++ b/apps/web/lib/hooks/use-trip-drag-and-drop.test.ts
@@ -335,6 +335,51 @@ describe("useTripDragAndDrop — null-based snapshot isolation", () => {
     expect(result.current.overScheduleId).toBe("s2");
   });
 
+  it("does not snap back to old order while onDone (refetch) is pending after reorderSchedule", async () => {
+    // onDone returns a pending promise — simulates an in-flight refetch.
+    let resolveOnDone: (() => void) | undefined;
+    const onDone = vi.fn(
+      () =>
+        new Promise<void>((res) => {
+          resolveOnDone = res;
+        }),
+    );
+
+    const { result } = renderHook(() =>
+      useTripDragAndDrop({
+        tripId: "trip1",
+        currentDayId: "day1",
+        currentPatternId: "pattern1",
+        schedules: [s1, s2],
+        candidates: [],
+        onDone,
+      }),
+    );
+
+    let pending!: Promise<void>;
+    act(() => {
+      pending = result.current.reorderSchedule("s2", "up");
+    });
+
+    // Flush microtasks so the optimistic setLocalSchedules and the awaited
+    // api() both settle. `onDone` is still pending.
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Bug repro: while the refetch driven by onDone is pending, the schedules
+    // prop has not been updated yet. If finally runs before onDone resolves,
+    // localSchedules falls back to the stale prop (= old order [s1, s2]),
+    // causing a brief snap-back before the refetch completes.
+    expect(result.current.localSchedules.map((s) => s.id)).toEqual(["s2", "s1"]);
+
+    await act(async () => {
+      resolveOnDone?.();
+      await pending;
+    });
+  });
+
   it("falls back to server data after the API call resolves", async () => {
     // Default mock resolves immediately (mockResolvedValue(undefined))
     const { result } = renderHook(() =>

--- a/apps/web/lib/hooks/use-trip-drag-and-drop.ts
+++ b/apps/web/lib/hooks/use-trip-drag-and-drop.ts
@@ -45,7 +45,12 @@ type UseTripDragAndDropArgs = {
   schedules: ScheduleResponse[];
   candidates: CandidateResponse[];
   crossDayEntries?: CrossDayEntry[];
-  onDone: () => void;
+  // Awaited before clearing optimistic local state. Pass an async function
+  // (typically `invalidateQueries`) so the schedules prop already reflects
+  // the new server order by the time the local snapshot is released —
+  // otherwise the list briefly snaps back to the pre-mutation order while
+  // the refetch is still in flight.
+  onDone: () => void | Promise<void>;
 };
 
 // MouseSensor (not PointerSensor) so that touch input is handled exclusively
@@ -271,14 +276,14 @@ export function useTripDragAndDrop({
               }),
             },
           );
-          onDone();
+          await onDone();
         } catch (err) {
           if (err instanceof ApiError && (err.status === 400 || err.status === 404)) {
             toast.error(tm("conflictStale"));
           } else {
             toast.error(tm("scheduleReorderFailed"));
           }
-          onDone();
+          await onDone();
         }
       } else if (sourceType === "schedule" && isOverCandidates) {
         const schedule = currentSchedules.find((s) => s.id === active.id);
@@ -318,7 +323,7 @@ export function useTripDragAndDrop({
           } else {
             toast.error(tm("scheduleMoveFailed"));
           }
-          onDone();
+          await onDone();
           return;
         }
 
@@ -341,10 +346,10 @@ export function useTripDragAndDrop({
           if (process.env.NODE_ENV !== "production") {
             console.error("[schedule→candidates reorder failed]", err);
           }
-          onDone();
+          await onDone();
           return;
         }
-        onDone();
+        await onDone();
       } else if (sourceType === "candidate" && isOverTimeline) {
         const candidate = currentCandidates.find((c) => c.id === active.id);
         if (!candidate) return;
@@ -397,7 +402,7 @@ export function useTripDragAndDrop({
           } else {
             toast.error(tm("candidateAssignFailed"));
           }
-          onDone();
+          await onDone();
           return;
         }
 
@@ -438,10 +443,10 @@ export function useTripDragAndDrop({
           if (process.env.NODE_ENV !== "production") {
             console.error("[candidate→timeline reorder failed]", err);
           }
-          onDone();
+          await onDone();
           return;
         }
-        onDone();
+        await onDone();
       } else if (sourceType === "candidate" && isOverCandidates) {
         if (over && active.id === over.id) return;
         const oldIndex = currentCandidates.findIndex((c) => c.id === active.id);
@@ -461,14 +466,14 @@ export function useTripDragAndDrop({
             method: "PATCH",
             body: JSON.stringify({ scheduleIds }),
           });
-          onDone();
+          await onDone();
         } catch (err) {
           if (err instanceof ApiError && (err.status === 400 || err.status === 404)) {
             toast.error(tm("conflictStale"));
           } else {
             toast.error(tm("scheduleReorderFailed"));
           }
-          onDone();
+          await onDone();
         }
       }
     } finally {
@@ -530,14 +535,14 @@ export function useTripDragAndDrop({
           }),
         },
       );
-      onDone();
+      await onDone();
     } catch (err) {
       if (err instanceof ApiError && (err.status === 400 || err.status === 404)) {
         toast.error(tm("conflictStale"));
       } else {
         toast.error(tm("scheduleReorderFailed"));
       }
-      onDone();
+      await onDone();
     } finally {
       setLocalSchedules(null);
     }
@@ -558,14 +563,14 @@ export function useTripDragAndDrop({
         method: "PATCH",
         body: JSON.stringify({ scheduleIds: reordered.map((c) => c.id) }),
       });
-      onDone();
+      await onDone();
     } catch (err) {
       if (err instanceof ApiError && (err.status === 400 || err.status === 404)) {
         toast.error(tm("conflictStale"));
       } else {
         toast.error(tm("scheduleReorderFailed"));
       }
-      onDone();
+      await onDone();
     } finally {
       setLocalCandidates(null);
     }


### PR DESCRIPTION
## Summary

- SP "並び替え" モードで A/B を入れ替えると、B が **上→下→上** と動いて見えるバグを修正
- `useTripDragAndDrop` の `reorderSchedule` / `reorderCandidate` / `handleDragEnd` で `onDone()` (refetch トリガー) を await せずに `finally` で `localSchedules` を null にしていたため、refetch 完了前に schedules prop の古い順序へ一瞬フォールバックしていた
- onDone を await することで、refetch 完了後に local snapshot を解放するようにし、フォールバック時点で schedules prop が既に新順序を反映している状態にする

## バグの再現フロー (修正前)

1. `setLocalSchedules([B, A])` → optimistic で **B が上に表示** ✓
2. `await api(...)` → サーバー保存
3. `onDone()` を fire-and-forget (await なし) → 裏で refetch 開始
4. `finally: setLocalSchedules(null)` → schedules prop (refetch 未完了で古い `[A, B]`) にフォールバック → **B が下に戻る** ✗
5. 裏の refetch 完了 → schedules prop が `[B, A]` に更新 → **B が再度上へ** ✓

PC のドラッグでも同じ race は発生していたが dnd-kit の drop アニメーションで覆い隠されていた。SP の上下ボタンは即時更新なので露出していた。

## 影響範囲調査

cache 直接更新パターン (`queryClient.setQueryData`) を使う他のリオーダー/ミューテーション (candidate-panel, day-timeline の delete/unassign, use-schedule-selection の batch 操作, friends/groups, trip-actions, poll-tab 等) は cache 自体が optimistic 値を持つため snap-back race は無し。bookmarks の reorder は invalidate を呼ばないため race は無し。今回の shadow local state パターンは `use-trip-drag-and-drop.ts` のみ。

## 同梱変更

- `chore(hooks)`: CLAUDE.md の「プロジェクトフック運用方針」に揃えて post-edit / post-stop の failure-log 取り扱いを更新

## Test plan

- [x] `bun run --filter @sugara/web test` — 573/573 pass (新規 1 件含む)
- [x] `bun run --filter @sugara/web check-types` — pass
- [x] `bun run --filter @sugara/web lint` — pass
- [ ] SP 実機: 1 日目で予定 A/B を上下ボタンで入れ替え、B が下に戻らずスムーズに上へ動くことを確認
- [ ] SP 実機: 候補の上下並び替えも同様に確認
- [ ] PC 実機: 予定 / 候補 / 跨ぎドラッグでも回帰がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)