### PR TITLE
chore(web): Phase A — コード全体監査の trivial 修正 4 件

### DIFF
--- a/apps/web/app/admin/_components/admin-client.tsx
+++ b/apps/web/app/admin/_components/admin-client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { AdminStatsResponse } from "@sugara/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ExternalLink, KeyRound, Save, X } from "lucide-react";
 import Link from "next/link";
@@ -34,34 +35,6 @@ import { queryKeys } from "@/lib/query-keys";
 
 const SUPABASE_MAU_LIMIT = 50_000;
 const SUPABASE_DB_SIZE_LIMIT_BYTES = 500 * 1024 * 1024; // 500 MB
-
-type AdminStatsResponse = {
-  users: {
-    total: number;
-    guest: number;
-    newLast7Days: number;
-    newLast30Days: number;
-  };
-  trips: {
-    total: number;
-    byStatus: {
-      scheduling: number;
-      draft: number;
-      planned: number;
-      active: number;
-      completed: number;
-    };
-    newLast7Days: number;
-  };
-  content: {
-    schedules: number;
-    souvenirs: number;
-  };
-  supabase: {
-    mau: number;
-    dbSizeBytes: number;
-  };
-};
 
 function StatCard({ label, value }: { label: string; value: number | string }) {
   return (

--- a/apps/web/components/day-timeline.tsx
+++ b/apps/web/components/day-timeline.tsx
@@ -164,18 +164,23 @@ export function DayTimeline({
     }
   }
 
+  // Memoized so unrelated re-renders (selection-mode toggle, drag-over state)
+  // don't pay the O(n) every() cost on schedules that haven't changed.
   // Schedules with a manual cross-day anchor are "dirty" relative to time
   // order — even if their startTimes happen to be ascending, the anchor
   // forces a position that the time-sort button should be able to reset.
-  const hasAnyAnchor = schedules.some(
-    (s) => s.crossDayAnchor != null && s.crossDayAnchorSourceId != null,
-  );
-  const isSorted =
-    !hasAnyAnchor &&
-    (schedules.length <= 1 ||
-      schedules.every(
-        (schedule, i) => i === 0 || compareByStartTime(schedules[i - 1], schedule) <= 0,
-      ));
+  const isSorted = useMemo(() => {
+    const hasAnyAnchor = schedules.some(
+      (s) => s.crossDayAnchor != null && s.crossDayAnchorSourceId != null,
+    );
+    return (
+      !hasAnyAnchor &&
+      (schedules.length <= 1 ||
+        schedules.every(
+          (schedule, i) => i === 0 || compareByStartTime(schedules[i - 1], schedule) <= 0,
+        ))
+    );
+  }, [schedules]);
 
   async function handleSortByTime() {
     if (isSortingByTime) return;

--- a/apps/web/components/notification-preferences-section.tsx
+++ b/apps/web/components/notification-preferences-section.tsx
@@ -187,7 +187,7 @@ export function NotificationPreferencesSection() {
         .catch(() => {
           // Permission was granted but resolving the subscription failed —
           // surface this so the user knows the toggles won't work yet.
-          toast.error(tm("notificationPrefUpdateFailed"));
+          toast.error(tm("pushSubscribeFailed"));
         });
     }
   }

--- a/apps/web/components/notification-preferences-section.tsx
+++ b/apps/web/components/notification-preferences-section.tsx
@@ -79,7 +79,12 @@ export function NotificationPreferencesSection() {
     navigator.serviceWorker.ready
       .then((reg) => reg.pushManager.getSubscription())
       .then((sub) => sub && setDeviceEndpoint(sub.endpoint))
-      .catch((err) => console.warn("[push] failed to resolve subscription endpoint", err));
+      .catch(() => {
+        // Subscription resolution can fail on incompatible browsers or
+        // transient service-worker states. The UI degrades to "push not
+        // subscribed" automatically (deviceEndpoint stays null), so there's
+        // nothing actionable to surface to the user here.
+      });
   }, []);
 
   // User-level: inApp preferences only
@@ -179,7 +184,11 @@ export function NotificationPreferencesSection() {
       navigator.serviceWorker.ready
         .then((reg) => reg.pushManager.getSubscription())
         .then((sub) => sub && setDeviceEndpoint(sub.endpoint))
-        .catch((err) => console.warn("[push] failed to resolve subscription endpoint", err));
+        .catch(() => {
+          // Permission was granted but resolving the subscription failed —
+          // surface this so the user knows the toggles won't work yet.
+          toast.error(tm("notificationPrefUpdateFailed"));
+        });
     }
   }
 

--- a/apps/web/components/notification-preferences-section.tsx
+++ b/apps/web/components/notification-preferences-section.tsx
@@ -79,11 +79,11 @@ export function NotificationPreferencesSection() {
     navigator.serviceWorker.ready
       .then((reg) => reg.pushManager.getSubscription())
       .then((sub) => sub && setDeviceEndpoint(sub.endpoint))
-      .catch(() => {
-        // Subscription resolution can fail on incompatible browsers or
-        // transient service-worker states. The UI degrades to "push not
-        // subscribed" automatically (deviceEndpoint stays null), so there's
-        // nothing actionable to surface to the user here.
+      .catch((_err: unknown) => {
+        // Intentionally swallowed: subscription resolution can fail on
+        // incompatible browsers or transient service-worker states. The UI
+        // degrades to "push not subscribed" automatically (deviceEndpoint
+        // stays null), so there's nothing actionable to surface here.
       });
   }, []);
 

--- a/apps/web/lib/hooks/use-schedule-selection.ts
+++ b/apps/web/lib/hooks/use-schedule-selection.ts
@@ -214,10 +214,12 @@ export function useScheduleSelection({
       });
       toast.success(tm("batchDuplicated", { count: selectedIds.size }));
       exit();
-      onDone();
     } catch {
       toast.error(tm("batchDuplicateFailed"));
     } finally {
+      // Always refetch — on success to pull the new duplicates, on failure to
+      // reconcile with whatever partial state the server may hold (timeout etc).
+      onDone();
       setBatchLoading(false);
     }
   }
@@ -235,10 +237,10 @@ export function useScheduleSelection({
       );
       toast.success(tm("batchDuplicated", { count: selectedIds.size }));
       exit();
-      onDone();
     } catch {
       toast.error(tm("batchDuplicateFailed"));
     } finally {
+      onDone();
       setBatchLoading(false);
     }
   }

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -353,6 +353,7 @@
     "notificationMarkReadFailed": "Failed to mark as read",
     "notificationMarkAllReadFailed": "Failed to mark all as read",
     "notificationPrefUpdateFailed": "Failed to update notification settings",
+    "pushSubscribeFailed": "Failed to enable push notifications",
     "emptyNotification": "No notifications",
     "accountDeleted": "Account deleted",
     "accountDeleteFailed": "Failed to delete account",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -353,6 +353,7 @@
     "notificationMarkReadFailed": "既読の更新に失敗しました",
     "notificationMarkAllReadFailed": "全て既読の更新に失敗しました",
     "notificationPrefUpdateFailed": "通知設定の更新に失敗しました",
+    "pushSubscribeFailed": "プッシュ通知の有効化に失敗しました",
     "emptyNotification": "通知はありません",
     "accountDeleted": "アカウントを削除しました",
     "accountDeleteFailed": "アカウントの削除に失敗しました",

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -375,3 +375,27 @@ export type LogsResponse = {
   items: ActivityLogResponse[];
   nextCursor: string | null;
 };
+
+// Admin /api/admin/stats response — summary counters for the admin dashboard.
+
+export type AdminStatsResponse = {
+  users: {
+    total: number;
+    guest: number;
+    newLast7Days: number;
+    newLast30Days: number;
+  };
+  trips: {
+    total: number;
+    byStatus: Record<TripStatus, number>;
+    newLast7Days: number;
+  };
+  content: {
+    schedules: number;
+    souvenirs: number;
+  };
+  supabase: {
+    mau: number;
+    dbSizeBytes: number;
+  };
+};


### PR DESCRIPTION
## Summary

`apps/web` 全体監査 (PR #43 の延長) で見つかった trivial な修正 4 件をまとめて反映。

| # | Issue | 内容 |
|---|-------|------|
| 1 | #45 | `batchDuplicate*` の catch で onDone 未呼び出しを修正 (server 部分成功時の整合崩れ防止) |
| 2 | #46 | `DayTimeline` の `isSorted` 計算を `useMemo` 化 (50+ schedules で visible) |
| 3 | #47 | `notification-preferences-section.tsx` の `console.warn` を整理 (silent or toast 化) |
| 4 | #48 | `AdminStatsResponse` をローカル定義から `packages/shared` に移動 (drift 防止) |

## Test plan

- [x] `bun run --filter @sugara/web test` — 573/573 pass
- [x] `bun run --filter @sugara/web check-types` — pass
- [x] `bun run --filter @sugara/shared check-types` — pass
- [x] lint hook — clean
- [ ] admin dashboard 表示確認 (型変更で表示崩れがないこと)
- [ ] schedule の batch duplicate を実機で 1 度走らせて regression なし確認
- [ ] push 通知の subscribe フローを実機確認 (toast.error が適切に出るか)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Closes

Closes #45, closes #46, closes #47, closes #48

