### PR TITLE
chore(web): Phase B — merge-timeline O(n) 化 + bookmark invalidate 意図コメント

### DIFF
--- a/apps/web/lib/hooks/use-bookmark-operations.ts
+++ b/apps/web/lib/hooks/use-bookmark-operations.ts
@@ -111,6 +111,9 @@ export function useBookmarkOperations({
         method: "PATCH",
         body: JSON.stringify(updatedFields),
       });
+      // Bookmark update doesn't change BookmarkListResponse fields
+      // (bookmarkCount/updatedAt are list-level, untouched by /:bookmarkId PATCH),
+      // so unlike handleAdd/handleDelete we don't invalidate the lists query here.
       invalidateBookmarks();
     } catch (err) {
       if (prev) queryClient.setQueryData(cacheKey, prev);

--- a/apps/web/lib/hooks/use-bookmark-operations.ts
+++ b/apps/web/lib/hooks/use-bookmark-operations.ts
@@ -73,6 +73,9 @@ export function useBookmarkOperations({
       resetForm();
       setAddBookmarkOpen(false);
       invalidateBookmarks();
+      // Add affects BookmarkListResponse.bookmarkCount, so the lists query
+      // also needs a refetch. handleDelete mirrors this; handleUpdate skips
+      // it intentionally (PATCH /:bookmarkId doesn't touch bookmark_lists).
       invalidateLists();
     } catch (err) {
       toast.error(getApiErrorMessage(err, tm("bookmarkAddFailed") as string));
@@ -143,6 +146,9 @@ export function useBookmarkOperations({
         method: "DELETE",
       });
       invalidateBookmarks();
+      // Delete affects BookmarkListResponse.bookmarkCount (mirrored in
+      // handleAdd; handleUpdate skips this since /:bookmarkId PATCH doesn't
+      // touch bookmark_lists).
       invalidateLists();
     } catch (err) {
       if (prev) queryClient.setQueryData(cacheKey, prev);

--- a/apps/web/lib/merge-timeline.ts
+++ b/apps/web/lib/merge-timeline.ts
@@ -47,12 +47,29 @@ export function buildMergedTimeline(
   anchoredBefore.sort(sortBySortOrder);
   anchoredAfter.sort(sortBySortOrder);
 
+  // Bucket anchored schedules by sourceId so each entry's lookup is O(1).
+  // The previous filter-per-entry implementation was O(n × m) where n is the
+  // number of anchored schedules and m is the number of crossDay entries.
+  // Insertion order into the bucket preserves the sortBySortOrder above.
+  const bucketBySourceId = (list: ScheduleResponse[]) => {
+    const map = new Map<string, ScheduleResponse[]>();
+    for (const s of list) {
+      if (!s.crossDayAnchorSourceId) continue;
+      const arr = map.get(s.crossDayAnchorSourceId);
+      if (arr) arr.push(s);
+      else map.set(s.crossDayAnchorSourceId, [s]);
+    }
+    return map;
+  };
+  const beforeBySource = bucketBySourceId(anchoredBefore);
+  const afterBySource = bucketBySourceId(anchoredAfter);
+
   const merged = timeBasedMerge(plainSchedules, crossDayEntries);
 
   for (const entry of crossDayEntries) {
     const sourceId = entry.schedule.id;
-    const before = anchoredBefore.filter((s) => s.crossDayAnchorSourceId === sourceId);
-    const after = anchoredAfter.filter((s) => s.crossDayAnchorSourceId === sourceId);
+    const before = beforeBySource.get(sourceId) ?? [];
+    const after = afterBySource.get(sourceId) ?? [];
     if (before.length === 0 && after.length === 0) continue;
 
     const pos = merged.findIndex((item) => item.type === "crossDay" && item.entry === entry);

--- a/apps/web/lib/merge-timeline.ts
+++ b/apps/web/lib/merge-timeline.ts
@@ -43,6 +43,14 @@ export function buildMergedTimeline(
     }
   }
 
+  const merged = timeBasedMerge(plainSchedules, crossDayEntries);
+
+  // Skip the bucket-and-splice pass entirely when no schedules carry a
+  // cross-day anchor — the time-based merge above is already the final order.
+  if (anchoredBefore.length === 0 && anchoredAfter.length === 0) {
+    return merged;
+  }
+
   const sortBySortOrder = (a: ScheduleResponse, b: ScheduleResponse) => a.sortOrder - b.sortOrder;
   anchoredBefore.sort(sortBySortOrder);
   anchoredAfter.sort(sortBySortOrder);
@@ -63,8 +71,6 @@ export function buildMergedTimeline(
   };
   const beforeBySource = bucketBySourceId(anchoredBefore);
   const afterBySource = bucketBySourceId(anchoredAfter);
-
-  const merged = timeBasedMerge(plainSchedules, crossDayEntries);
 
   for (const entry of crossDayEntries) {
     const sourceId = entry.schedule.id;


### PR DESCRIPTION
## Summary

`apps/web` 全体監査の Phase B 2 件。

| # | Issue | 内容 |
|---|-------|------|
| 1 | #50 | `buildMergedTimeline` の anchored filter を Map 化して O(n × m) → O(n + m) に |
| 2 | #51 | `useBookmarkOperations.handleUpdate` で `invalidateLists()` を呼ばない理由を コメント化 (verify 結果: API は list 側を touch しないため不要) |

#51 は当初「invalidate 抜け」と疑ったが、API 実装 (`apps/api/src/routes/bookmarks.ts:198-230`) を確認したところ PATCH /:bookmarkId は `bookmarks` テーブルのみ更新し `bookmark_lists` には触れない。`BookmarkListResponse` の `bookmarkCount` / `updatedAt` は bookmark update で変動しないため、`invalidateLists()` を呼ばないのは正しい挙動。今後同じ疑問が出ないよう意図コメントだけ残す。

## Test plan

- [x] `bun run --filter @sugara/web test -- merge-timeline` — 31/31 pass (回帰なし)
- [x] `bun run --filter @sugara/web test` — 573/573 pass
- [x] `bun run --filter @sugara/web check-types` — pass
- [x] lint hook — clean
- [ ] schedules 100+ の旅行で trip 詳細画面を実機表示し、merge timeline の表示順序が変わっていないこと確認
- [ ] bookmark の edit (rename/memo 編集等) を実機で行い、list 一覧の bookmarkCount/updatedAt が変化しないこと確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Closes

Closes #50, closes #51

