### PR TITLE
refactor(web): Phase D — roulette-presets の不要キャスト削除

### DIFF
--- a/apps/web/components/roulette-content.tsx
+++ b/apps/web/components/roulette-content.tsx
@@ -114,7 +114,7 @@ function RegionFilterPreset({
   allKeys,
   namespace,
 }: {
-  regions: RegionGroup[];
+  regions: readonly RegionGroup[];
   allKeys: string[];
   namespace: "prefectures" | "countries";
 }) {

--- a/apps/web/lib/prefectures.ts
+++ b/apps/web/lib/prefectures.ts
@@ -3,7 +3,7 @@ import type { RegionGroup } from "@/lib/roulette-presets";
 // Prefecture keys mapped to message keys in the "prefectures" namespace
 export type PrefectureKey = (typeof ALL_PREFECTURE_KEYS)[number];
 
-export const REGIONS: RegionGroup[] = [
+export const REGIONS = [
   {
     nameKey: "regionHokkaido",
     keys: ["hokkaido", "aomori", "iwate", "miyagi", "akita", "yamagata", "fukushima"],
@@ -48,6 +48,6 @@ export const REGIONS: RegionGroup[] = [
     nameKey: "regionKyushu",
     keys: ["fukuoka", "saga", "nagasaki", "kumamoto", "oita", "miyazaki", "kagoshima", "okinawa"],
   },
-];
+] as const satisfies readonly RegionGroup[];
 
 export const ALL_PREFECTURE_KEYS = REGIONS.flatMap((r) => r.keys);

--- a/apps/web/lib/roulette-presets.ts
+++ b/apps/web/lib/roulette-presets.ts
@@ -113,7 +113,11 @@ const COUNTRY_REGIONS_CONST = [
   },
 ] as const satisfies readonly RegionGroup[];
 
-export const COUNTRY_REGIONS: RegionGroup[] = COUNTRY_REGIONS_CONST as unknown as RegionGroup[];
+// Re-export under a friendlier name. The const-assertion above already gives
+// us a readonly tuple typed as RegionGroup, so no cast is needed here —
+// previously we routed through `as unknown as RegionGroup[]` which silently
+// discarded the satisfies check.
+export const COUNTRY_REGIONS = COUNTRY_REGIONS_CONST;
 
 export const ALL_COUNTRY_KEYS = COUNTRY_REGIONS_CONST.flatMap((r) => r.keys);
 


### PR DESCRIPTION
## Summary

`apps/web` 全体監査の Phase D で起票した 3 件 (#56, #57, #58) のうち、即修正可能な #56 を含めた PR。残りは別 PR / 運用ルール扱い。

| # | Issue | 対応 |
|---|-------|------|
| 1 | #56 | `roulette-presets.ts` の `as unknown as RegionGroup[]` を削除 (consumer を `readonly RegionGroup[]` に) |
| 2 | #57 | What を書いているコメントの段階的整理 — Issue 残し、運用ルールとして都度修正。今回スキャンでは顕著な違反は少なかったので局所修正は無し |
| 3 | #58 | `merge-timeline.ts` の string `.slice` を Map で cache 化 — Phase B PR (#52) と同ファイルで conflict リスクがあるため follow-up 別 PR にする |

## Test plan

- [x] `bun run --filter @sugara/web check-types` — pass
- [x] `bun run --filter @sugara/web test` — 573/573 pass
- [x] lint hook — clean
- [ ] roulette ツールの実機表示確認 (region フィルタが今まで通り動くこと)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Closes

Closes #56
