### PR TITLE
perf(web): merge-timeline の string .slice 反復を Map で cache 化

### DIFF
--- a/apps/web/lib/merge-timeline.ts
+++ b/apps/web/lib/merge-timeline.ts
@@ -105,9 +105,11 @@ function timeBasedMerge(
   crossDayEntries: CrossDayEntry[],
 ): TimelineItem[] {
   // Pre-compute "HH:MM" strings once. Without this cache, the same slice was
-  // recomputed on every comparison — O(n + n×m + m log m) calls collapse to
-  // O(n + m). The keys are schedule/entry identity (id is unique within the
-  // function's inputs).
+  // recomputed on every comparison — the dominant cost was the O(n × m) scan
+  // over `remaining` inside the schedule loop, plus an O(m log m) sort. With
+  // the Map both collapse to one slice per input → O(n + m). Keys are schedule
+  // ids; uniqueness is guaranteed by the schedules table PK and the
+  // single-source nature of crossDayEntries (one entry per source schedule).
   const scheduleStartHHMM = new Map<string, string | null>();
   for (const s of schedules) {
     scheduleStartHHMM.set(s.id, s.startTime?.slice(0, 5) ?? null);
@@ -116,6 +118,9 @@ function timeBasedMerge(
   for (const entry of crossDayEntries) {
     entryEndHHMM.set(entry.schedule.id, entry.schedule.endTime?.slice(0, 5) ?? null);
   }
+  // Map.get's undefined branch is unreachable here (every input was set above);
+  // the `?? null` / `?? ""` fallbacks below exist purely to narrow the return
+  // type from `string | null | undefined` to the original `string | null`.
 
   const merged: TimelineItem[] = [];
   const remaining = [...crossDayEntries];

--- a/apps/web/lib/merge-timeline.ts
+++ b/apps/web/lib/merge-timeline.ts
@@ -104,17 +104,30 @@ function timeBasedMerge(
   schedules: ScheduleResponse[],
   crossDayEntries: CrossDayEntry[],
 ): TimelineItem[] {
+  // Pre-compute "HH:MM" strings once. Without this cache, the same slice was
+  // recomputed on every comparison — O(n + n×m + m log m) calls collapse to
+  // O(n + m). The keys are schedule/entry identity (id is unique within the
+  // function's inputs).
+  const scheduleStartHHMM = new Map<string, string | null>();
+  for (const s of schedules) {
+    scheduleStartHHMM.set(s.id, s.startTime?.slice(0, 5) ?? null);
+  }
+  const entryEndHHMM = new Map<string, string | null>();
+  for (const entry of crossDayEntries) {
+    entryEndHHMM.set(entry.schedule.id, entry.schedule.endTime?.slice(0, 5) ?? null);
+  }
+
   const merged: TimelineItem[] = [];
   const remaining = [...crossDayEntries];
 
   for (const schedule of schedules) {
-    const scheduleTime = schedule.startTime?.slice(0, 5) ?? null;
+    const scheduleTime = scheduleStartHHMM.get(schedule.id) ?? null;
 
     if (scheduleTime != null) {
       const toInsert: CrossDayEntry[] = [];
       // Iterate in reverse so splice() doesn't shift the indices of unvisited entries.
       for (let j = remaining.length - 1; j >= 0; j--) {
-        const entryTime = remaining[j].schedule.endTime?.slice(0, 5) ?? null;
+        const entryTime = entryEndHHMM.get(remaining[j].schedule.id) ?? null;
         if (entryTime == null) continue;
         if (entryTime <= scheduleTime) {
           toInsert.unshift(remaining[j]);
@@ -122,8 +135,8 @@ function timeBasedMerge(
         }
       }
       toInsert.sort((a, b) => {
-        const ta = a.schedule.endTime?.slice(0, 5) ?? "";
-        const tb = b.schedule.endTime?.slice(0, 5) ?? "";
+        const ta = entryEndHHMM.get(a.schedule.id) ?? "";
+        const tb = entryEndHHMM.get(b.schedule.id) ?? "";
         return ta < tb ? -1 : ta > tb ? 1 : 0;
       });
       for (const entry of toInsert) {
@@ -141,8 +154,8 @@ function timeBasedMerge(
     else withoutEnd.push(entry);
   }
   withEnd.sort((a, b) => {
-    const ta = a.schedule.endTime?.slice(0, 5) ?? "";
-    const tb = b.schedule.endTime?.slice(0, 5) ?? "";
+    const ta = entryEndHHMM.get(a.schedule.id) ?? "";
+    const tb = entryEndHHMM.get(b.schedule.id) ?? "";
     return ta < tb ? -1 : ta > tb ? 1 : 0;
   });
   for (const entry of withEnd) {


### PR DESCRIPTION
## Summary

PR #52 (Phase B) の follow-up。同じファイル内の別最適化を別 PR として塞ぐ。

`timeBasedMerge` は `schedule.startTime?.slice(0, 5)` / `entry.schedule.endTime?.slice(0, 5)` を比較や sort 比較関数で何度も再計算していた。schedules 100 件 + crossDayEntries 数件のケースで sort が走ると O(n × m + m log m) 回の slice 呼び出しになる。

関数入口で 2 つの Map (`scheduleStartHHMM` / `entryEndHHMM`) を 1 度ずつ構築し、以降の参照を `Map.get` に置き換えることで、slice 呼び出しを合計 O(n + m) に収める。

## Test plan

- [x] `bun run --filter @sugara/web test -- merge-timeline` — 31/31 pass (回帰なし)
- [x] `bun run --filter @sugara/web check-types` — pass
- [x] lint hook — clean
- [ ] schedules 多数の旅行で表示順が変わらないこと実機確認

## Closes

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)