### PR TITLE
test(web): isSorted ロジックを純粋関数として抽出 + unit test

### DIFF
--- a/apps/web/components/day-timeline.tsx
+++ b/apps/web/components/day-timeline.tsx
@@ -38,6 +38,7 @@ import { useMobile } from "@/lib/hooks/use-is-mobile";
 import type { TimelineItem } from "@/lib/merge-timeline";
 import { buildMergedTimeline, timelineSortableIds } from "@/lib/merge-timeline";
 import { queryKeys } from "@/lib/query-keys";
+import { isScheduleListSorted } from "@/lib/timeline-sort";
 import { moveScheduleToCandidate, removeScheduleFromPattern } from "@/lib/trip-cache";
 import { cn } from "@/lib/utils";
 import { DndInsertIndicator } from "./dnd-insert-indicator";
@@ -165,22 +166,10 @@ export function DayTimeline({
   }
 
   // Memoized so unrelated re-renders (selection-mode toggle, drag-over state)
-  // don't pay the O(n) every() cost on schedules that haven't changed.
-  // Schedules with a manual cross-day anchor are "dirty" relative to time
-  // order — even if their startTimes happen to be ascending, the anchor
-  // forces a position that the time-sort button should be able to reset.
-  const isSorted = useMemo(() => {
-    const hasAnyAnchor = schedules.some(
-      (s) => s.crossDayAnchor != null && s.crossDayAnchorSourceId != null,
-    );
-    return (
-      !hasAnyAnchor &&
-      (schedules.length <= 1 ||
-        schedules.every(
-          (schedule, i) => i === 0 || compareByStartTime(schedules[i - 1], schedule) <= 0,
-        ))
-    );
-  }, [schedules]);
+  // don't pay the O(n) cost on schedules that haven't changed. The actual
+  // sorted-vs-anchored logic lives in lib/timeline-sort.ts where it's
+  // independently unit-tested.
+  const isSorted = useMemo(() => isScheduleListSorted(schedules), [schedules]);
 
   async function handleSortByTime() {
     if (isSortingByTime) return;

--- a/apps/web/lib/__tests__/timeline-sort.test.ts
+++ b/apps/web/lib/__tests__/timeline-sort.test.ts
@@ -1,0 +1,131 @@
+import type { ScheduleResponse } from "@sugara/shared";
+import { describe, expect, it } from "vitest";
+import { isScheduleListSorted } from "../timeline-sort";
+
+function makeSchedule(overrides: Partial<ScheduleResponse> = {}): ScheduleResponse {
+  return {
+    id: "s-default",
+    name: "Default",
+    category: "sightseeing",
+    color: "blue",
+    urls: [],
+    sortOrder: 0,
+    updatedAt: "",
+    ...overrides,
+  };
+}
+
+describe("isScheduleListSorted", () => {
+  describe("trivial cases", () => {
+    it("returns true for empty list", () => {
+      expect(isScheduleListSorted([])).toBe(true);
+    });
+
+    it("returns true for single-element list regardless of anchor or time", () => {
+      expect(isScheduleListSorted([makeSchedule({ startTime: "09:00" })])).toBe(true);
+    });
+  });
+
+  describe("time order without anchors", () => {
+    it("returns true when start times are strictly ascending", () => {
+      const schedules = [
+        makeSchedule({ id: "a", startTime: "09:00" }),
+        makeSchedule({ id: "b", startTime: "10:00" }),
+        makeSchedule({ id: "c", startTime: "13:00" }),
+      ];
+      expect(isScheduleListSorted(schedules)).toBe(true);
+    });
+
+    it("returns true when consecutive start times are equal", () => {
+      const schedules = [
+        makeSchedule({ id: "a", startTime: "09:00" }),
+        makeSchedule({ id: "b", startTime: "09:00" }),
+      ];
+      expect(isScheduleListSorted(schedules)).toBe(true);
+    });
+
+    it("returns false when start times are descending", () => {
+      const schedules = [
+        makeSchedule({ id: "a", startTime: "12:00" }),
+        makeSchedule({ id: "b", startTime: "09:00" }),
+      ];
+      expect(isScheduleListSorted(schedules)).toBe(false);
+    });
+
+    it("returns false when a single pair is out of order in an otherwise sorted list", () => {
+      const schedules = [
+        makeSchedule({ id: "a", startTime: "09:00" }),
+        makeSchedule({ id: "b", startTime: "12:00" }),
+        makeSchedule({ id: "c", startTime: "10:00" }),
+      ];
+      expect(isScheduleListSorted(schedules)).toBe(false);
+    });
+  });
+
+  describe("null startTime handling", () => {
+    it("returns true when a trailing entry has null startTime (null sorts last)", () => {
+      const schedules = [
+        makeSchedule({ id: "a", startTime: "09:00" }),
+        makeSchedule({ id: "b", startTime: null }),
+      ];
+      expect(isScheduleListSorted(schedules)).toBe(true);
+    });
+
+    it("returns false when a null-startTime entry appears before a timed entry", () => {
+      const schedules = [
+        makeSchedule({ id: "a", startTime: null }),
+        makeSchedule({ id: "b", startTime: "09:00" }),
+      ];
+      expect(isScheduleListSorted(schedules)).toBe(false);
+    });
+
+    it("returns true when all entries have null startTime", () => {
+      const schedules = [
+        makeSchedule({ id: "a", startTime: null }),
+        makeSchedule({ id: "b", startTime: null }),
+      ];
+      expect(isScheduleListSorted(schedules)).toBe(true);
+    });
+  });
+
+  describe("anchor handling", () => {
+    it("returns false when any schedule carries a valid cross-day anchor, even if times are sorted", () => {
+      const schedules = [
+        makeSchedule({ id: "a", startTime: "09:00" }),
+        makeSchedule({
+          id: "b",
+          startTime: "10:00",
+          crossDayAnchor: "before",
+          crossDayAnchorSourceId: "x-source",
+        }),
+      ];
+      expect(isScheduleListSorted(schedules)).toBe(false);
+    });
+
+    it("treats anchor as absent when crossDayAnchorSourceId is missing", () => {
+      const schedules = [
+        makeSchedule({ id: "a", startTime: "09:00" }),
+        makeSchedule({
+          id: "b",
+          startTime: "10:00",
+          crossDayAnchor: "before",
+          crossDayAnchorSourceId: null,
+        }),
+      ];
+      expect(isScheduleListSorted(schedules)).toBe(true);
+    });
+
+    it("treats anchor as absent when crossDayAnchor is null even with sourceId set", () => {
+      const schedules = [
+        makeSchedule({ id: "a", startTime: "09:00" }),
+        makeSchedule({
+          id: "b",
+          startTime: "10:00",
+          crossDayAnchor: null,
+          crossDayAnchorSourceId: "x-source",
+        }),
+      ];
+      expect(isScheduleListSorted(schedules)).toBe(true);
+    });
+  });
+});

--- a/apps/web/lib/format.ts
+++ b/apps/web/lib/format.ts
@@ -71,6 +71,11 @@ export function formatTimeRange(startTime?: string | null, endTime?: string | nu
   return "";
 }
 
+// Compare two items by startTime ("HH:MM"). null sorts last.
+// Callers: handleSortByTime (DayTimeline) for the actual sort, and
+// isScheduleListSorted (lib/timeline-sort) for detecting whether the list is
+// already in this order. Changing null/equality semantics here also changes
+// when the time-sort UI is enabled — extend timeline-sort.test.ts when you do.
 export function compareByStartTime(
   a: { startTime?: string | null },
   b: { startTime?: string | null },

--- a/apps/web/lib/timeline-sort.ts
+++ b/apps/web/lib/timeline-sort.ts
@@ -1,0 +1,26 @@
+import type { ScheduleResponse } from "@sugara/shared";
+import { compareByStartTime } from "@/lib/format";
+
+/**
+ * Returns true when the schedule list is in time-sort order AND no schedule
+ * carries a manual cross-day anchor.
+ *
+ * The "any anchor" check matters because a schedule with `crossDayAnchor` set
+ * is pinned regardless of its startTime — even if startTimes happen to be
+ * ascending, the time-sort button should still be enabled so the user can
+ * reset the anchor and re-sort by time.
+ *
+ * `compareByStartTime` places null startTimes at the end, so a list ending in
+ * null-startTime entries is considered sorted; a null-startTime entry in the
+ * middle breaks the order.
+ */
+export function isScheduleListSorted(schedules: ScheduleResponse[]): boolean {
+  const hasAnyAnchor = schedules.some(
+    (s) => s.crossDayAnchor != null && s.crossDayAnchorSourceId != null,
+  );
+  if (hasAnyAnchor) return false;
+  if (schedules.length <= 1) return true;
+  return schedules.every(
+    (schedule, i) => i === 0 || compareByStartTime(schedules[i - 1], schedule) <= 0,
+  );
+}


### PR DESCRIPTION
## Summary

DayTimeline の time-sort ボタン disabled を駆動する `isSorted` 判定を、component 内インラインから `lib/timeline-sort.ts` の純粋関数 `isScheduleListSorted` へ抽出。挙動は変更なし。

## 変更内容

- `apps/web/lib/timeline-sort.ts` (新規): `isScheduleListSorted(schedules)` を export。
- `apps/web/lib/__tests__/timeline-sort.test.ts` (新規): 12 件の unit test。
- `apps/web/components/day-timeline.tsx`: `useMemo(() => isScheduleListSorted(schedules), [schedules])` で呼ぶ形に置換。`useMemo` 自体は維持 (関数呼び出しでも O(n) のため memo の利点は残る)。

## テストカバレッジ

| シナリオ | 期待 |
|----------|------|
| 空配列 | true |
| 1 要素 | true |
| 時刻昇順 | true |
| 連続同時刻 | true |
| 時刻降順 | false |
| 中間で逆転 | false |
| 末尾の null startTime | true (null は最後にソートされる仕様) |
| 中間の null startTime | false |
| 全 null startTime | true |
| 有効な anchor あり | false (時刻昇順でも) |
| `crossDayAnchorSourceId` null で anchor を持つ | true (anchor 扱いされない) |
| `crossDayAnchor` null で sourceId のみ | true (同上) |

## Test plan

- [x] `bun run --filter @sugara/web test -- timeline-sort` — 12/12 pass (新規)
- [x] `bun run --filter @sugara/web test` — 585/585 pass (回帰なし、元 573 + 新規 12)
- [x] `bun run --filter @sugara/web check-types` — pass
- [x] lint hook — clean

## Closes

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)