### PR TITLE
fix(web): 並び替え連打時の optimistic state race を解消

### DIFF
--- a/apps/web/lib/hooks/use-trip-drag-and-drop.test.ts
+++ b/apps/web/lib/hooks/use-trip-drag-and-drop.test.ts
@@ -75,6 +75,10 @@ const s1 = makeSchedule("s1");
 const s2 = makeSchedule("s2");
 const s3 = makeSchedule("s3");
 
+function makeCandidate(id: string) {
+  return { ...makeSchedule(id), likeCount: 0, hmmCount: 0, myReaction: null };
+}
+
 describe("useTripDragAndDrop — null-based snapshot isolation", () => {
   afterEach(() => vi.clearAllMocks());
 
@@ -420,6 +424,46 @@ describe("useTripDragAndDrop — null-based snapshot isolation", () => {
     });
 
     expect(result.current.localSchedules.map((s) => s.id)).toEqual(["s2", "s3", "s1"]);
+  });
+
+  it("rapid reorderCandidate taps don't clobber the latest optimistic snapshot", async () => {
+    // Same opId guard applied to the candidate reorder path. Symmetric with
+    // the reorderSchedule case; covered separately so a future regression on
+    // either path is caught independently.
+    const apiMock = vi.mocked(api);
+    apiMock.mockResolvedValueOnce(undefined).mockImplementationOnce(() => new Promise(() => {}));
+
+    const c1 = makeCandidate("c1");
+    const c2 = makeCandidate("c2");
+    const c3 = makeCandidate("c3");
+
+    const { result } = renderHook(() =>
+      useTripDragAndDrop({
+        tripId: "trip1",
+        currentDayId: "day1",
+        currentPatternId: "pattern1",
+        schedules: [],
+        candidates: [c1, c2, c3],
+        onDone: vi.fn(),
+      }),
+    );
+
+    let op1Promise!: Promise<void>;
+    act(() => {
+      op1Promise = result.current.reorderCandidate("c2", "up");
+    });
+    expect(result.current.localCandidates.map((c) => c.id)).toEqual(["c2", "c1", "c3"]);
+
+    act(() => {
+      result.current.reorderCandidate("c3", "up");
+    });
+    expect(result.current.localCandidates.map((c) => c.id)).toEqual(["c2", "c3", "c1"]);
+
+    await act(async () => {
+      await op1Promise;
+    });
+
+    expect(result.current.localCandidates.map((c) => c.id)).toEqual(["c2", "c3", "c1"]);
   });
 
   it("falls back to server data after the API call resolves", async () => {

--- a/apps/web/lib/hooks/use-trip-drag-and-drop.test.ts
+++ b/apps/web/lib/hooks/use-trip-drag-and-drop.test.ts
@@ -383,6 +383,45 @@ describe("useTripDragAndDrop — null-based snapshot isolation", () => {
     });
   });
 
+  it("rapid reorderSchedule taps don't clobber the latest optimistic snapshot", async () => {
+    // Op #1's API resolves immediately; op #2's hangs. Without the opId
+    // guard, op #1's finally would null-reset localSchedules while op #2 is
+    // still in flight, causing the list to snap back to the schedules prop
+    // (= old order [s1, s2, s3]) before op #2 completes. With the guard,
+    // op #1's finally sees that opIdRef has moved past myOpId and skips the
+    // reset, leaving op #2's [s2, s3, s1] visible.
+    const apiMock = vi.mocked(api);
+    apiMock.mockResolvedValueOnce(undefined).mockImplementationOnce(() => new Promise(() => {}));
+
+    const { result } = renderHook(() =>
+      useTripDragAndDrop({
+        tripId: "trip1",
+        currentDayId: "day1",
+        currentPatternId: "pattern1",
+        schedules: [s1, s2, s3],
+        candidates: [],
+        onDone: vi.fn(),
+      }),
+    );
+
+    let op1Promise!: Promise<void>;
+    act(() => {
+      op1Promise = result.current.reorderSchedule("s2", "up");
+    });
+    expect(result.current.localSchedules.map((s) => s.id)).toEqual(["s2", "s1", "s3"]);
+
+    act(() => {
+      result.current.reorderSchedule("s3", "up");
+    });
+    expect(result.current.localSchedules.map((s) => s.id)).toEqual(["s2", "s3", "s1"]);
+
+    await act(async () => {
+      await op1Promise;
+    });
+
+    expect(result.current.localSchedules.map((s) => s.id)).toEqual(["s2", "s3", "s1"]);
+  });
+
   it("falls back to server data after the API call resolves", async () => {
     // Default mock resolves immediately (mockResolvedValue(undefined))
     const { result } = renderHook(() =>

--- a/apps/web/lib/hooks/use-trip-drag-and-drop.ts
+++ b/apps/web/lib/hooks/use-trip-drag-and-drop.ts
@@ -211,6 +211,9 @@ export function useTripDragAndDrop({
   }
 
   async function handleDragEnd(event: DragEndEvent) {
+    // Bump first; cleanup state below always runs and any "id holes" left by
+    // early returns inside the try block don't affect race correctness — only
+    // equality between myOpId and opIdRef.current at finally time matters.
     const myOpId = ++opIdRef.current;
     setActiveDragItem(null);
     setOverScheduleId(null);

--- a/apps/web/lib/hooks/use-trip-drag-and-drop.ts
+++ b/apps/web/lib/hooks/use-trip-drag-and-drop.ts
@@ -19,7 +19,7 @@ import type {
   ScheduleResponse,
 } from "@sugara/shared";
 import { useTranslations } from "next-intl";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { toast } from "sonner";
 import { ApiError, api } from "@/lib/api";
 import {
@@ -118,6 +118,14 @@ export function useTripDragAndDrop({
   const [localCandidates, setLocalCandidates] = useState<CandidateResponse[] | null>(null);
   // Track last known drop zone so we can handle drops in empty space below the last item
   const [lastOverZone, setLastOverZone] = useState<"timeline" | "candidates" | null>(null);
+  // Monotonic id assigned at the start of every reorder / drag-end. The
+  // `finally` block in each operation only resets local state when its own
+  // id still matches the latest — if a second tap fires while the first is
+  // awaiting onDone, the first's reset is skipped so it doesn't clobber the
+  // second's optimistic snapshot. Without this guard, rapid taps would
+  // briefly snap the list back to the pre-second-op order until the second
+  // op's refetch completes.
+  const opIdRef = useRef(0);
 
   const sensors = useSensors(
     useSensor(MouseSensor, MOUSE_SENSOR_OPTIONS),
@@ -203,6 +211,7 @@ export function useTripDragAndDrop({
   }
 
   async function handleDragEnd(event: DragEndEvent) {
+    const myOpId = ++opIdRef.current;
     setActiveDragItem(null);
     setOverScheduleId(null);
     setOverCandidateId(null);
@@ -479,13 +488,18 @@ export function useTripDragAndDrop({
     } finally {
       // Reset to null so the hook falls back to server props after the drop.
       // This prevents snap-back caused by stale server data overwriting
-      // the optimistic state (dnd-kit Discussion #1522).
-      setLocalSchedules(null);
-      setLocalCandidates(null);
+      // the optimistic state (dnd-kit Discussion #1522). Skip the reset when
+      // a newer op has started — letting it stand would clobber the next
+      // op's optimistic snapshot.
+      if (opIdRef.current === myOpId) {
+        setLocalSchedules(null);
+        setLocalCandidates(null);
+      }
     }
   }
 
   async function reorderSchedule(id: string, direction: "up" | "down") {
+    const myOpId = ++opIdRef.current;
     if (!currentDayId || !currentPatternId) return;
     const current = localSchedules ?? schedules;
     // Reorder by merged timeline position (what the user sees), not raw
@@ -544,11 +558,14 @@ export function useTripDragAndDrop({
       }
       await onDone();
     } finally {
-      setLocalSchedules(null);
+      if (opIdRef.current === myOpId) {
+        setLocalSchedules(null);
+      }
     }
   }
 
   async function reorderCandidate(id: string, direction: "up" | "down") {
+    const myOpId = ++opIdRef.current;
     const current = localCandidates ?? candidates;
     const idx = current.findIndex((c) => c.id === id);
     if (idx === -1) return;
@@ -572,7 +589,9 @@ export function useTripDragAndDrop({
       }
       await onDone();
     } finally {
-      setLocalCandidates(null);
+      if (opIdRef.current === myOpId) {
+        setLocalCandidates(null);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

`useTripDragAndDrop` で並び替えボタンを連打した時、操作 #1 の `finally` が操作 #2 の optimistic state を null reset してしまう race を解消。

## バグ再現

1. `reorderSchedule(B, "up")` → `setLocalSchedules([B, A, C])`、API 中
2. `reorderSchedule(C, "up")` → `setLocalSchedules([B, C, A])`、API 中
3. 操作 #1 の API + `onDone` 完了 → `finally: setLocalSchedules(null)` が走り、操作 #2 の `[B, C, A]` を消す
4. schedules prop は操作 #1 の結果 `[B, A, C]` しか反映していないので、操作 #2 の refetch 完了まで一瞬古い順序にスナップバック

## Fix

`useRef` で monotonic な `opIdRef` を持ち、各エントリポイント (`reorderSchedule` / `reorderCandidate` / `handleDragEnd`) の冒頭で `++opIdRef.current` して `myOpId` を取得。`finally` で `opIdRef.current === myOpId` のときのみ null reset する形に変える。

「最後にトリガーされた操作のみが local state を解放する」セマンティクスになり、操作 #1 の遅延した `finally` が #2 のスナップショットを上書きしない。

## テスト戦略 (TDD verify 済み)

新規テスト 1 件で race を再現:
- 操作 #1 の API は即解決、操作 #2 の API は hang
- 両方トリガー後に操作 #1 を完了まで await
- 操作 #2 の optimistic state `[s2, s3, s1]` が保持されていることを assert

guard を一時的に外してテストを走らせ、期待通り `[s1, s2, s3]` (schedules prop) にスナップバックして fail することを verify。guard を戻すと pass。**テストが偽陽性で通っているわけではない**ことを確認済み。

## Test plan

- [x] `bun run --filter @sugara/web test -- use-trip-drag-and-drop` — 8/8 pass (新規 1 件含む、元 7 + 新規 1)
- [x] `bun run --filter @sugara/web test` — 586/586 pass (回帰なし)
- [x] `bun run --filter @sugara/web check-types` — pass
- [x] guard 外し時に新規テストが失敗することを verify
- [ ] SP 実機: 並び替えボタンを連打した時にスナップバックが起きないこと

## Closes

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)