### PR TITLE
chore: claude-system の web 共通 fragment を CLAUDE.md に取り込む

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,5 @@
+@~/ws/claude-system/adapters/claude-code/project-fragments/web-apps-common.md
+
 # sugara - 旅行計画アプリ
 
 ## プロジェクト概要


### PR DESCRIPTION
## Summary
- `~/ws/claude-system/adapters/claude-code/project-fragments/web-apps-common.md` を CLAUDE.md 冒頭で `@` import するよう追加
- Web 系プロジェクトのレンダリング戦略 / a11y / Web Vitals / SEO / セキュリティの共通指針をプロジェクト指示として参照する

## Test plan
- [x] `git diff main...HEAD` で CLAUDE.md の 2 行追加のみであることを確認
- [x] pre-push hook (check-types) が通ることを確認