### PR TITLE
fix(web): api<T>() の 204 型ウソを apiVoid() で根本解消

### DIFF
--- a/apps/web/app/(authenticated)/polls/[id]/page.tsx
+++ b/apps/web/app/(authenticated)/polls/[id]/page.tsx
@@ -12,7 +12,7 @@ import { CopyButton } from "@/components/copy-button";
 import { Button } from "@/components/ui/button";
 import { LoadingBoundary } from "@/components/ui/loading-boundary";
 import { Skeleton } from "@/components/ui/skeleton";
-import { api } from "@/lib/api";
+import { api, apiVoid } from "@/lib/api";
 import { pageTitle } from "@/lib/constants";
 import { queryKeys } from "@/lib/query-keys";
 
@@ -80,7 +80,7 @@ export default function QuickPollDetailPage() {
   });
 
   const deleteMutation = useMutation({
-    mutationFn: () => api(`/api/quick-polls/${pollId}`, { method: "DELETE" }),
+    mutationFn: () => apiVoid(`/api/quick-polls/${pollId}`, { method: "DELETE" }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.quickPolls.list() });
       toast.success(tm("quickPollDeleted"));

--- a/apps/web/app/(authenticated)/polls/page.tsx
+++ b/apps/web/app/(authenticated)/polls/page.tsx
@@ -14,7 +14,7 @@ import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
 import { LoadingBoundary } from "@/components/ui/loading-boundary";
 import { Skeleton } from "@/components/ui/skeleton";
-import { api } from "@/lib/api";
+import { api, apiVoid } from "@/lib/api";
 import { pageTitle } from "@/lib/constants";
 import { isDialogOpen } from "@/lib/hotkeys";
 import { queryKeys } from "@/lib/query-keys";
@@ -112,7 +112,7 @@ export default function PollsPage() {
   });
 
   const deleteMutation = useMutation({
-    mutationFn: (id: string) => api(`/api/quick-polls/${id}`, { method: "DELETE" }),
+    mutationFn: (id: string) => apiVoid(`/api/quick-polls/${id}`, { method: "DELETE" }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.quickPolls.list() });
       toast.success(tm("quickPollDeleted"));

--- a/apps/web/app/(authenticated)/settings/page.tsx
+++ b/apps/web/app/(authenticated)/settings/page.tsx
@@ -47,7 +47,7 @@ import {
 } from "@/components/ui/select";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { UserAvatar } from "@/components/user-avatar";
-import { ApiError, api } from "@/lib/api";
+import { ApiError, apiVoid } from "@/lib/api";
 import { authClient, useSession } from "@/lib/auth-client";
 import {
   getPasswordRequirementsText,
@@ -722,7 +722,7 @@ function DeleteAccountSection({ username }: { username: string }) {
     setLoading(true);
 
     try {
-      await api("/api/account", {
+      await apiVoid("/api/account", {
         method: "DELETE",
         body: JSON.stringify({ password }),
       });

--- a/apps/web/app/(sp)/sp/polls/[id]/page.tsx
+++ b/apps/web/app/(sp)/sp/polls/[id]/page.tsx
@@ -12,7 +12,7 @@ import { CopyButton } from "@/components/copy-button";
 import { Button } from "@/components/ui/button";
 import { LoadingBoundary } from "@/components/ui/loading-boundary";
 import { Skeleton } from "@/components/ui/skeleton";
-import { api } from "@/lib/api";
+import { api, apiVoid } from "@/lib/api";
 import { pageTitle } from "@/lib/constants";
 import { queryKeys } from "@/lib/query-keys";
 
@@ -80,7 +80,7 @@ export default function SpQuickPollDetailPage() {
   });
 
   const deleteMutation = useMutation({
-    mutationFn: () => api(`/api/quick-polls/${pollId}`, { method: "DELETE" }),
+    mutationFn: () => apiVoid(`/api/quick-polls/${pollId}`, { method: "DELETE" }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.quickPolls.list() });
       toast.success(tm("quickPollDeleted"));

--- a/apps/web/app/(sp)/sp/polls/page.tsx
+++ b/apps/web/app/(sp)/sp/polls/page.tsx
@@ -13,7 +13,7 @@ import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
 import { LoadingBoundary } from "@/components/ui/loading-boundary";
 import { Skeleton } from "@/components/ui/skeleton";
-import { api } from "@/lib/api";
+import { api, apiVoid } from "@/lib/api";
 import { pageTitle } from "@/lib/constants";
 import { queryKeys } from "@/lib/query-keys";
 
@@ -83,7 +83,7 @@ export default function SpPollsPage() {
   });
 
   const deleteMutation = useMutation({
-    mutationFn: (id: string) => api(`/api/quick-polls/${id}`, { method: "DELETE" }),
+    mutationFn: (id: string) => apiVoid(`/api/quick-polls/${id}`, { method: "DELETE" }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.quickPolls.list() });
       toast.success(tm("quickPollDeleted"));

--- a/apps/web/components/expense-panel.tsx
+++ b/apps/web/components/expense-panel.tsx
@@ -31,7 +31,7 @@ import {
   ResponsiveAlertDialogTitle,
 } from "@/components/ui/responsive-alert-dialog";
 import { Skeleton } from "@/components/ui/skeleton";
-import { api, getApiErrorMessage } from "@/lib/api";
+import { api, apiVoid, getApiErrorMessage } from "@/lib/api";
 import { useSession } from "@/lib/auth-client";
 import { useMobile } from "@/lib/hooks/use-is-mobile";
 import { queryKeys } from "@/lib/query-keys";
@@ -64,7 +64,7 @@ export function ExpensePanel({ tripId, canEdit, addOpen, onAddOpenChange }: Expe
 
   const deleteMutation = useMutation({
     mutationFn: (expenseId: string) =>
-      api(`/api/trips/${tripId}/expenses/${expenseId}`, { method: "DELETE" }),
+      apiVoid(`/api/trips/${tripId}/expenses/${expenseId}`, { method: "DELETE" }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.expenses.list(tripId) });
       queryClient.invalidateQueries({ queryKey: queryKeys.trips.activityLogs(tripId) });

--- a/apps/web/components/settlement-section.tsx
+++ b/apps/web/components/settlement-section.tsx
@@ -7,7 +7,7 @@ import { ArrowRight } from "lucide-react";
 import { useLocale, useTranslations } from "next-intl";
 import { toast } from "sonner";
 import { Checkbox } from "@/components/ui/checkbox";
-import { api, getApiErrorMessage } from "@/lib/api";
+import { api, apiVoid, getApiErrorMessage } from "@/lib/api";
 import { queryKeys } from "@/lib/query-keys";
 
 type SettlementSectionProps = {
@@ -121,7 +121,7 @@ export function SettlementSection({
       toUserId: string;
       amount: number;
     }) =>
-      api(`/api/trips/${tripId}/settlement-payments/${vars.paymentId}`, {
+      apiVoid(`/api/trips/${tripId}/settlement-payments/${vars.paymentId}`, {
         method: "DELETE",
       }),
     onMutate: async (vars) => {

--- a/apps/web/lib/__tests__/api.test.ts
+++ b/apps/web/lib/__tests__/api.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { ApiError, api } from "../api";
+import { ApiError, api, apiVoid } from "../api";
 
 const mockFetch = vi.fn();
 
@@ -70,14 +70,16 @@ describe("api", () => {
     });
   });
 
-  it("returns undefined for 204 responses", async () => {
+  it("throws ApiError for 204 responses to surface the type lie", async () => {
     mockFetch.mockResolvedValue({
       ok: true,
       status: 204,
     });
 
-    const result = await api("/api/trips/123");
-    expect(result).toBeUndefined();
+    await expect(api("/api/trips/123")).rejects.toMatchObject({
+      status: 204,
+      message: expect.stringContaining("apiVoid"),
+    });
   });
 
   it("sends POST request with body", async () => {
@@ -100,6 +102,29 @@ describe("api", () => {
         }),
       }),
     );
+  });
+});
+
+describe("apiVoid", () => {
+  it("resolves on 204 responses without parsing a body", async () => {
+    const json = vi.fn();
+    mockFetch.mockResolvedValue({ ok: true, status: 204, json });
+
+    await expect(apiVoid("/api/account", { method: "DELETE" })).resolves.toBeUndefined();
+    expect(json).not.toHaveBeenCalled();
+  });
+
+  it("throws ApiError on non-ok response", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: () => Promise.resolve({ error: "Forbidden" }),
+    });
+
+    await expect(apiVoid("/api/account", { method: "DELETE" })).rejects.toMatchObject({
+      message: "Forbidden",
+      status: 403,
+    });
   });
 });
 

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -14,7 +14,7 @@ type FetchOptions = RequestInit & {
   params?: Record<string, string>;
 };
 
-export async function api<T>(path: string, options: FetchOptions = {}): Promise<T> {
+async function fetchApi(path: string, options: FetchOptions): Promise<Response> {
   const { params, ...fetchOptions } = options;
 
   let url = `${API_BASE}${path}`;
@@ -41,11 +41,32 @@ export async function api<T>(path: string, options: FetchOptions = {}): Promise<
     throw new ApiError(message, res.status);
   }
 
+  return res;
+}
+
+/**
+ * Call a JSON API endpoint that returns a body of type T.
+ * Use {@link apiVoid} for endpoints that return 204 No Content.
+ */
+export async function api<T>(path: string, options: FetchOptions = {}): Promise<T> {
+  const res = await fetchApi(path, options);
+
   if (res.status === 204) {
-    return undefined as T;
+    throw new ApiError(
+      `Expected JSON body from ${path} but got 204 No Content. Use apiVoid() for endpoints that return no body.`,
+      204,
+    );
   }
 
   return res.json();
+}
+
+/**
+ * Call an API endpoint that returns no body (typically 204 No Content).
+ * Throws if the endpoint returns a non-2xx status; ignores the body otherwise.
+ */
+export async function apiVoid(path: string, options: FetchOptions = {}): Promise<void> {
+  await fetchApi(path, options);
 }
 
 /**


### PR DESCRIPTION
## Summary

- `api<T>()` の `undefined as T` 型ウソを廃止: 204 が来たら `ApiError` を投げて表面化
- `apiVoid()` ヘルパーを新設し、204 No Content を返す endpoint を明示的に扱う
- 既知の 204 endpoint (`account` / `quick-polls` / `settlement-payments` / `expenses`) の caller (7 箇所) を `apiVoid()` に移行

Closes #53

## Why

- `api<T>(...)` は `T` を期待する caller に対して 204 のとき `undefined` を返すため、`trip.id` のようなアクセスで runtime crash の温床
- 現状 `api<X>(...)` で 204 endpoint を呼んでいる caller は 0 件で実害は出ていないが、将来の追加で気付きにくいバグが入り込みやすい
- caller 側で「結果を使う/使わない」の意図が型から読めるよう、関数自体を分離

## Test plan

- [x] `bun run --filter @sugara/web check` (biome)
- [x] `bun run --filter @sugara/web check-types`
- [x] `bun run --filter @sugara/web test` — 589 tests passed
- [x] `apiVoid()` の 204 / 4xx パスを test で網羅 (`apps/web/lib/__tests__/api.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)