### PR TITLE
fix(deps): tar を 0.4.46 に更新し PAX header desync 脆弱性を解消

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -4028,9 +4028,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",


### PR DESCRIPTION
## 概要

Dependabot alert #13 (GHSA-3pv8-6f4r-ffg2, **medium**) に対応。

`tar <= 0.4.45` の PAX header desynchronization を修正したパッチリリース `0.4.46` に更新する。`tar` は `apps/desktop` (tauri) 経由の transitive 依存。

## 変更内容

- `apps/desktop/src-tauri/Cargo.lock` の `tar` エントリ (version + checksum) のみを更新
- `cargo update -p tar` をそのまま使うと過去の依存更新 PR で統一した `windows-sys 0.61.2` が各クレートの最小要求にダウングレードされる副作用があったため、tar の2行のみをピンポイントで書き換え、windows-sys には未接触

## 検証

- [x] `cargo metadata --locked` exit 0 (lockfile 完全整合、tar 0.4.46 で依存構成変化なし)
- [x] `cargo check` exit 0
- [x] pre-commit (biome check) / commit-msg (conventional commit) green

## スコープ外

- alert #10 `rand` 0.7.3 (GHSA-cq8v-f236-94qc, **low**): tauri の **build-dependency** chain (`tauri-utils 2.9.2 → kuchikiki → selectors → phf 0.8 → rand ^0.7`) が固定しており、こちら側の lockfile では解消不能。実行時バイナリには含まれず、上流が新 phf へ移行するまで待ち。

🤖 Generated with [Claude Code](https://claude.com/claude-code)