### PR TITLE
chore: デスクトップアプリ v0.4.1 にバージョンアップ [skip deploy]

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -3898,7 +3898,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "sugara-desktop"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "chrono",
  "serde_json",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sugara-desktop"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 
 [lib]

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "sugara",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "identifier": "app.sugara.desktop",
   "build": {
     "devUrl": "https://sugara.vercel.app",
@@ -19,7 +19,7 @@
         "decorations": true,
         "visible": false,
         "backgroundColor": "#09090b",
-        "userAgent": "sugara-desktop/0.3.0"
+        "userAgent": "sugara-desktop/0.4.1"
       }
     ],
     "security": {


### PR DESCRIPTION
## 概要

tar の PAX header desync 脆弱性修正 (GHSA-3pv8-6f4r-ffg2, #102) を含むデスクトップアプリのリリース。version を `0.4.0` → `0.4.1` に patch bump する。

**このPRを main にマージすると `desktop-tag.yml` が `desktop-v0.4.1` タグを作成し、`desktop-build.yml` がビルドして `u-stem/sugara-releases` に配布する。**

## 変更内容

| ファイル | 変更 |
|---------|------|
| `tauri.conf.json` `version` | 0.4.0 → 0.4.1 |
| `tauri.conf.json` `userAgent` | **0.3.0 → 0.4.1**(0.3.0 のまま取り残されていた同期漏れも修正) |
| `Cargo.toml` `version` | 0.4.0 → 0.4.1 |
| `Cargo.lock` `sugara-desktop` | 0.4.0 → 0.4.1 |

## 検証

- [x] `cargo metadata --locked` exit 0(lockfile 整合)
- [x] `tauri.conf.json` JSON 妥当性 OK
- [x] version 4箇所すべて 0.4.1 で一致
- [x] pre-commit (biome check) / commit-msg green

🤖 Generated with [Claude Code](https://claude.com/claude-code)