### PR TITLE
chore: デスクトップ版を tauri.conf.json の version 単一ソースに統一

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,18 +113,18 @@ bun run --filter @sugara/shared check-types
 ```
 1. feature branch を切る (例: `chore/desktop-v0.2.0`)
 2. apps/desktop/src-tauri/tauri.conf.json の version を更新 (例: "0.1.0" → "0.2.0")
-3. apps/desktop/src-tauri/tauri.conf.json の userAgent も同じバージョンに更新
-4. apps/desktop/src-tauri/Cargo.toml の version も同じ値に更新
-5. コミット & push → PR 作成 → CI green → squash merge [skip deploy]
-6. desktop-tag.yml が自動で desktop-v<version> タグを作成
-7. desktop-build.yml がタグをトリガーにビルド・リリース
-8. バイナリが u-stem/sugara-releases に公開される
+3. コミット & push → PR 作成 → CI green → squash merge [skip deploy]
+4. desktop-tag.yml が自動で desktop-v<version> タグを作成
+5. desktop-build.yml がタグをトリガーにビルド・リリース
+6. バイナリが u-stem/sugara-releases に公開される
 ```
 
+- **version の単一ソースは `tauri.conf.json` の `version` の 1 箇所だけ**。Tauri はこれを優先してバイナリ/インストーラに焼き、`tauri-action` の `__VERSION__` も同じ値を使う
+  - `Cargo.toml` / `Cargo.lock` の `sugara-desktop` version は `0.0.0` 固定（cargo build ログにしか出ず、アプリ版とは無関係）。リリース時に触らない
+  - `userAgent` は version を含まない固定値 `sugara-desktop`（デスクトップ判定は接頭辞一致のみ。`apps/web/lib/hooks/use-desktop-download.ts`）。version 同期は不要
 - バージョンが既にタグ済みの場合は何もしない（冪等）
 - `apps/desktop/` のみの変更は Vercel の `turbo-ignore` がスキップするため Web ビルドは不要
 - バージョン方針: patch（0.1.x）= バグ修正・軽微な改善、minor（0.x.0）= 新機能、major（x.0.0）= 破壊的変更
-- **3 ファイルの version 同期は自動検証なし**。手動で一致させる
 - 必要な GitHub Secrets:
   - `GH_RELEASES_TOKEN`: `u-stem/sugara-releases` repo への write 権限を持つ PAT (公開リポジトリへのリリース転送用)
   - `TAURI_SIGNING_PRIVATE_KEY` / `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`: 自動更新用の署名鍵

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -3898,7 +3898,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "sugara-desktop"
-version = "0.4.1"
+version = "0.0.0"
 dependencies = [
  "chrono",
  "serde_json",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,9 @@
+# App version is managed solely in tauri.conf.json (Tauri uses it as the single
+# source of truth and overrides this value). Keep this fixed at 0.0.0 — this crate
+# is never published, and its version only appears in cargo build logs.
 [package]
 name = "sugara-desktop"
-version = "0.4.1"
+version = "0.0.0"
 edition = "2021"
 
 [lib]

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -19,7 +19,7 @@
         "decorations": true,
         "visible": false,
         "backgroundColor": "#09090b",
-        "userAgent": "sugara-desktop/0.4.1"
+        "userAgent": "sugara-desktop"
       }
     ],
     "security": {


### PR DESCRIPTION
## 背景

デスクトップリリース時に **version を 3 箇所手動同期**(`tauri.conf.json` の `version` / `userAgent`、`Cargo.toml` の `version`)していたため、先のリリースで **userAgent が 0.3.0 のまま取り残される同期漏れ**が発生していた。CLAUDE.md にも「3 ファイルの version 同期は自動検証なし。手動で一致させる」と明記されていた手作業の穴。

## 方針(調査で確定したデファクト)

Tauri 公式仕様では:
- `tauri.conf.json` の `version` が**最優先**でバイナリ/インストーラに焼かれ、`Cargo.toml` は省略時のフォールバックでしかない(メンテナ明言: Cargo.toml version は cargo build ログにしか出ない)
- `tauri-action` の `__VERSION__` も `tauri.conf.json` から解決

→ **version の真実を `tauri.conf.json` の 1 箇所に集約**し、残りを同期対象から外す。

## 変更内容

| ファイル | 変更 | 理由 |
|---------|------|------|
| `Cargo.toml` / `Cargo.lock` | `sugara-desktop` version を `0.4.1` → **`0.0.0` 固定** + コメント | アプリ版とは無関係(build ログ専用)。リリース時に触らない |
| `tauri.conf.json` `userAgent` | `sugara-desktop/0.4.1` → **`sugara-desktop`**(version 削除) | デスクトップ判定は接頭辞一致のみ(`use-desktop-download.ts`)。version は機能未使用 |
| `tauri.conf.json` `version` | **変更なし**(`0.4.1` のまま単一ソースとして維持) | — |
| `CLAUDE.md` | リリース手順を「`tauri.conf.json` の version 1 箇所のみ更新」に簡素化 | — |

リリースパイプライン(`desktop-tag.yml` / `desktop-build.yml` / tauri-action)は **一切変更不要**(`tauri.conf.json` の version を読む現行のまま動く)。

## 効果

リリース時に編集するのは **`tauri.conf.json` の `version` 1 行だけ**になり、同期漏れが**構造的に発生しなくなる**。

## 検証

- [x] `cargo metadata --locked` exit 0(Cargo.toml/lock の 0.0.0 整合)
- [x] `tauri.conf.json` JSON 妥当性 OK、version 0.4.1 維持
- [x] デスクトップ判定テスト(`use-desktop-download`)5 passed(固定 UA でも判定が壊れないこと)
- [x] pre-commit (biome check) / commit-msg green

## 補足

このPRは version を変更しない(0.4.1 据え置き)ため `desktop-tag` は冪等で**新規リリースは発生しない**。次回以降の version bump から新フローが適用される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)