### PR TITLE
chore: .claude/subagent-log.jsonl を gitignore に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,5 +56,8 @@ docs/superpowers/
 apps/desktop/src-tauri/gen/
 apps/desktop/src-tauri/target/
 
+# Claude Code (local-only artifacts; hooks/skills are tracked intentionally)
+.claude/subagent-log.jsonl
+
 # Misc
 *.tsbuildinfo


### PR DESCRIPTION
Claude Code のサブエージェントログ `.claude/subagent-log.jsonl` がローカルで生成され続け `git status` に常に未追跡で残るため gitignore する。`.claude/` 配下の hooks / skills は意図的に追跡しているので、当該ログファイルのみを対象にした。`settings.local.json` は既にグローバル gitignore 済み。