### PR TITLE
feat(shared): AppError 基底クラスと error code 体系を追加

### DIFF
--- a/packages/shared/src/__tests__/errors.test.ts
+++ b/packages/shared/src/__tests__/errors.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import {
+  AppError,
+  ConflictError,
+  ERROR_CODE,
+  ErrorResponseSchema,
+  NotFoundError,
+  PermissionError,
+  RateLimitError,
+  UnauthorizedError,
+  ValidationError,
+} from "../index";
+
+describe("AppError", () => {
+  it("is an instance of Error", () => {
+    const err = new AppError("boom", ERROR_CODE.INTERNAL, 500);
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(AppError);
+  });
+
+  it("carries code, httpStatus and message", () => {
+    const err = new AppError("boom", ERROR_CODE.INTERNAL, 500);
+    expect(err.code).toBe(ERROR_CODE.INTERNAL);
+    expect(err.httpStatus).toBe(500);
+    expect(err.message).toBe("boom");
+  });
+
+  it("serializes to a response body without details when none given", () => {
+    const err = new AppError("boom", ERROR_CODE.INTERNAL, 500);
+    expect(err.toResponse()).toEqual({ code: ERROR_CODE.INTERNAL, message: "boom" });
+  });
+
+  it("includes details in the response body when provided", () => {
+    const details = { fieldErrors: { title: ["Required"] } };
+    const err = new ValidationError("invalid", details);
+    expect(err.toResponse()).toEqual({
+      code: ERROR_CODE.VALIDATION,
+      message: "invalid",
+      details,
+    });
+  });
+});
+
+describe("concrete error types", () => {
+  it("ValidationError maps to 400 / VALIDATION", () => {
+    const err = new ValidationError("bad");
+    expect(err.httpStatus).toBe(400);
+    expect(err.code).toBe(ERROR_CODE.VALIDATION);
+  });
+
+  it("UnauthorizedError maps to 401 / UNAUTHORIZED", () => {
+    const err = new UnauthorizedError("nope");
+    expect(err.httpStatus).toBe(401);
+    expect(err.code).toBe(ERROR_CODE.UNAUTHORIZED);
+  });
+
+  it("PermissionError maps to 403 / PERMISSION", () => {
+    const err = new PermissionError("forbidden");
+    expect(err.httpStatus).toBe(403);
+    expect(err.code).toBe(ERROR_CODE.PERMISSION);
+  });
+
+  it("NotFoundError maps to 404 / NOT_FOUND", () => {
+    const err = new NotFoundError("gone");
+    expect(err.httpStatus).toBe(404);
+    expect(err.code).toBe(ERROR_CODE.NOT_FOUND);
+  });
+
+  it("ConflictError maps to 409 / CONFLICT", () => {
+    const err = new ConflictError("conflict");
+    expect(err.httpStatus).toBe(409);
+    expect(err.code).toBe(ERROR_CODE.CONFLICT);
+  });
+
+  it("RateLimitError maps to 429 / RATE_LIMIT", () => {
+    const err = new RateLimitError("slow down");
+    expect(err.httpStatus).toBe(429);
+    expect(err.code).toBe(ERROR_CODE.RATE_LIMIT);
+  });
+
+  it("all concrete types are AppError instances", () => {
+    const errors = [
+      new ValidationError("a"),
+      new UnauthorizedError("b"),
+      new PermissionError("c"),
+      new NotFoundError("d"),
+      new ConflictError("e"),
+      new RateLimitError("f"),
+    ];
+    for (const err of errors) {
+      expect(err).toBeInstanceOf(AppError);
+    }
+  });
+});
+
+describe("ErrorResponseSchema", () => {
+  it("accepts a minimal { code, message } body", () => {
+    const result = ErrorResponseSchema.safeParse({
+      code: ERROR_CODE.NOT_FOUND,
+      message: "Trip not found",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a body with details", () => {
+    const result = ErrorResponseSchema.safeParse({
+      code: ERROR_CODE.VALIDATION,
+      message: "invalid",
+      details: { fieldErrors: { title: ["Required"] } },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a body missing code", () => {
+    const result = ErrorResponseSchema.safeParse({ message: "oops" });
+    expect(result.success).toBe(false);
+  });
+
+  it("matches what AppError.toResponse produces", () => {
+    const err = new NotFoundError("Trip not found");
+    const result = ErrorResponseSchema.safeParse(err.toResponse());
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/shared/src/errors.ts
+++ b/packages/shared/src/errors.ts
@@ -1,0 +1,96 @@
+import { z } from "zod";
+
+// ─── Error code taxonomy ──────────────────────────────────────────────────────
+// HTTP-semantic classification of API errors. The human-readable detail stays in
+// ERROR_MSG (messages.ts) and is carried in the `message` field; `code` lets the
+// frontend branch on the *kind* of error without parsing message strings.
+
+export const ERROR_CODE = {
+  VALIDATION: "VALIDATION",
+  UNAUTHORIZED: "UNAUTHORIZED",
+  PERMISSION: "PERMISSION",
+  NOT_FOUND: "NOT_FOUND",
+  CONFLICT: "CONFLICT",
+  RATE_LIMIT: "RATE_LIMIT",
+  INTERNAL: "INTERNAL",
+  INVALID_JSON: "INVALID_JSON",
+  INVALID_ID_FORMAT: "INVALID_ID_FORMAT",
+} as const;
+
+export type ErrorCode = (typeof ERROR_CODE)[keyof typeof ERROR_CODE];
+
+// ─── Standardized error response body ─────────────────────────────────────────
+
+export const ErrorResponseSchema = z.object({
+  code: z.string(),
+  message: z.string(),
+  details: z.unknown().optional(),
+});
+
+export type ErrorResponse = z.infer<typeof ErrorResponseSchema>;
+
+// ─── AppError hierarchy ───────────────────────────────────────────────────────
+// Throw an AppError from a route to have app.onError serialize it into the
+// standardized { code, message, details? } body with the right HTTP status.
+
+export class AppError extends Error {
+  readonly code: ErrorCode;
+  readonly httpStatus: number;
+  readonly details?: unknown;
+
+  constructor(message: string, code: ErrorCode, httpStatus: number, details?: unknown) {
+    super(message);
+    this.name = "AppError";
+    this.code = code;
+    this.httpStatus = httpStatus;
+    this.details = details;
+  }
+
+  toResponse(): ErrorResponse {
+    const body: ErrorResponse = { code: this.code, message: this.message };
+    if (this.details !== undefined) body.details = this.details;
+    return body;
+  }
+}
+
+export class ValidationError extends AppError {
+  constructor(message: string, details?: unknown) {
+    super(message, ERROR_CODE.VALIDATION, 400, details);
+    this.name = "ValidationError";
+  }
+}
+
+export class UnauthorizedError extends AppError {
+  constructor(message: string, details?: unknown) {
+    super(message, ERROR_CODE.UNAUTHORIZED, 401, details);
+    this.name = "UnauthorizedError";
+  }
+}
+
+export class PermissionError extends AppError {
+  constructor(message: string, details?: unknown) {
+    super(message, ERROR_CODE.PERMISSION, 403, details);
+    this.name = "PermissionError";
+  }
+}
+
+export class NotFoundError extends AppError {
+  constructor(message: string, details?: unknown) {
+    super(message, ERROR_CODE.NOT_FOUND, 404, details);
+    this.name = "NotFoundError";
+  }
+}
+
+export class ConflictError extends AppError {
+  constructor(message: string, details?: unknown) {
+    super(message, ERROR_CODE.CONFLICT, 409, details);
+    this.name = "ConflictError";
+  }
+}
+
+export class RateLimitError extends AppError {
+  constructor(message: string, details?: unknown) {
+    super(message, ERROR_CODE.RATE_LIMIT, 429, details);
+    this.name = "RateLimitError";
+  }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./constants";
 export * from "./currency";
 export * from "./discord-embed";
+export * from "./errors";
 export * from "./limits";
 export * from "./messages";
 export * from "./permissions";


### PR DESCRIPTION
信頼性・観測性の底上げ(全4PR)の **PR1/4**。純粋な追加で既存挙動を一切変えない土台。

## 背景
API のエラー応答が `{ error: string }` で不統一(code/details なし)で、フロントが status でしか分岐できない。エラー応答契約を `{ code, message, details? }` に標準化するための共通基盤を shared に用意する。

## 変更
- 新規 `packages/shared/src/errors.ts`:
  - `ERROR_CODE`(VALIDATION/UNAUTHORIZED/PERMISSION/NOT_FOUND/CONFLICT/RATE_LIMIT/INTERNAL/INVALID_JSON/INVALID_ID_FORMAT)
  - `ErrorResponseSchema`(Zod, `{ code, message, details? }`)
  - `AppError` 基底クラス + 具体型(Validation/Unauthorized/Permission/NotFound/Conflict/RateLimit)。各 `code`/`httpStatus` を固定、`toResponse()` で標準形にシリアライズ
- `packages/shared/src/index.ts` に `export * from "./errors"`
- 詳細文言は従来の `ERROR_MSG` を `message` に載せる方針(再翻訳不要)

## 検証
- `bun run --filter @sugara/shared test`: 204 passed(新規 error テスト含む)
- `bun run check-types`: 4/4 success、`bun run check`(biome)green

## 後続
PR2(API onError 標準化)→ PR3(フロント後方互換パーサ)→ PR4(Sentry 導入)。本 PR は土台のみで挙動変化なし。