### PR TITLE
refactor(api): エラー応答を {code,message,details} に標準化

### DIFF
--- a/apps/api/src/__tests__/account.test.ts
+++ b/apps/api/src/__tests__/account.test.ts
@@ -1,3 +1,4 @@
+import { ERROR_CODE } from "@sugara/shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createTestApp } from "./test-helpers";
 
@@ -64,6 +65,7 @@ describe("Account routes", () => {
       body: JSON.stringify({ password: "" }),
     });
     expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe(ERROR_CODE.VALIDATION);
   });
 
   it("returns 404 when credential account not found", async () => {

--- a/apps/api/src/__tests__/error-handler.test.ts
+++ b/apps/api/src/__tests__/error-handler.test.ts
@@ -1,0 +1,59 @@
+import { ERROR_CODE, ERROR_MSG, NotFoundError, ValidationError } from "@sugara/shared";
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import { handleError } from "../lib/error-handler";
+
+function appThatThrows(err: unknown) {
+  const app = new Hono();
+  app.get("/boom", () => {
+    throw err;
+  });
+  app.onError(handleError);
+  return app;
+}
+
+describe("handleError", () => {
+  it("serializes an AppError to { code, message } with its httpStatus", async () => {
+    const res = await appThatThrows(new NotFoundError(ERROR_MSG.TRIP_NOT_FOUND)).request("/boom");
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.code).toBe(ERROR_CODE.NOT_FOUND);
+    expect(body.message).toBe(ERROR_MSG.TRIP_NOT_FOUND);
+  });
+
+  it("includes details for a ValidationError", async () => {
+    const details = { fieldErrors: { title: ["Required"] } };
+    const res = await appThatThrows(new ValidationError(ERROR_MSG.INVALID_INPUT, details)).request(
+      "/boom",
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe(ERROR_CODE.VALIDATION);
+    expect(body.details).toEqual(details);
+  });
+
+  it("keeps a legacy `error` alias equal to message for transition back-compat", async () => {
+    const res = await appThatThrows(new NotFoundError(ERROR_MSG.TRIP_NOT_FOUND)).request("/boom");
+    expect((await res.json()).error).toBe(ERROR_MSG.TRIP_NOT_FOUND);
+  });
+
+  it("maps SyntaxError to 400 INVALID_JSON", async () => {
+    const res = await appThatThrows(new SyntaxError("bad json")).request("/boom");
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe(ERROR_CODE.INVALID_JSON);
+  });
+
+  it("maps a Postgres uuid syntax error to 400 INVALID_ID_FORMAT", async () => {
+    const res = await appThatThrows(new Error('invalid input syntax for type uuid: "x"')).request(
+      "/boom",
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe(ERROR_CODE.INVALID_ID_FORMAT);
+  });
+
+  it("maps an unknown error to 500 INTERNAL", async () => {
+    const res = await appThatThrows(new Error("boom")).request("/boom");
+    expect(res.status).toBe(500);
+    expect((await res.json()).code).toBe(ERROR_CODE.INTERNAL);
+  });
+});

--- a/apps/api/src/__tests__/test-helpers.ts
+++ b/apps/api/src/__tests__/test-helpers.ts
@@ -1,10 +1,14 @@
 import type { Env } from "hono";
 import { Hono } from "hono";
+import { handleError } from "../lib/error-handler";
 
 export const TEST_USER = { id: "user-1", name: "Test User", email: "test@example.com" };
 
 export function createTestApp<E extends Env>(routes: Hono<E>, prefix: string) {
   const app = new Hono();
   app.route(prefix, routes);
+  // Mirror the production global error handler so routes that throw AppError are
+  // serialized the same way in tests as in the real app (apps/api/src/app.ts).
+  app.onError(handleError);
   return app;
 }

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,8 +1,7 @@
 import { Hono } from "hono";
 import { cors } from "hono/cors";
-import { ERROR_MSG } from "./lib/constants";
 import { env } from "./lib/env";
-import { logger } from "./lib/logger";
+import { handleError } from "./lib/error-handler";
 import { requestLogger } from "./middleware/request-logger";
 import { accountRoutes } from "./routes/account";
 import { activityLogRoutes } from "./routes/activity-logs";
@@ -52,16 +51,7 @@ app.use(
 
 app.use("*", requestLogger());
 
-app.onError((err, c) => {
-  if (err instanceof SyntaxError) {
-    return c.json({ error: ERROR_MSG.INVALID_JSON }, 400);
-  }
-  if (err.message?.includes("invalid input syntax for type uuid")) {
-    return c.json({ error: ERROR_MSG.INVALID_ID_FORMAT }, 400);
-  }
-  logger.error({ err, requestId: c.get("requestId") }, "Unhandled error");
-  return c.json({ error: ERROR_MSG.INTERNAL_ERROR }, 500);
-});
+app.onError(handleError);
 
 // Hono is mounted at /api/[[...route]] and sees the full path including /api, so this needs
 // the /api prefix to be reachable externally (e.g. post-deploy smoke checks).

--- a/apps/api/src/lib/error-handler.ts
+++ b/apps/api/src/lib/error-handler.ts
@@ -1,0 +1,41 @@
+import {
+  AppError,
+  ERROR_CODE,
+  ERROR_MSG,
+  type ErrorCode,
+  type HttpErrorStatus,
+} from "@sugara/shared";
+import type { Context } from "hono";
+import { logger } from "./logger";
+
+// Standardized error body { code, message, details? }. The legacy `error` string
+// alias is kept during the transition so frontends that still read body.error keep
+// working until they consume { code, message }. Remove once the frontend migrates.
+function errorBody(code: ErrorCode, message: string, details?: unknown) {
+  return details === undefined
+    ? { code, message, error: message }
+    : { code, message, error: message, details };
+}
+
+/**
+ * Global Hono error handler. Serializes AppError into the standardized response
+ * shape with its HTTP status; maps known low-level errors (malformed JSON,
+ * Postgres uuid syntax) to 400; falls back to 500 for everything else.
+ */
+export function handleError(err: Error, c: Context) {
+  if (err instanceof AppError) {
+    if (err.httpStatus >= 500) {
+      logger.error({ err, requestId: c.get("requestId") }, "AppError (server)");
+    }
+    return c.json(errorBody(err.code, err.message, err.details), err.httpStatus);
+  }
+  if (err instanceof SyntaxError) {
+    return c.json(errorBody(ERROR_CODE.INVALID_JSON, ERROR_MSG.INVALID_JSON), 400);
+  }
+  if (err.message?.includes("invalid input syntax for type uuid")) {
+    return c.json(errorBody(ERROR_CODE.INVALID_ID_FORMAT, ERROR_MSG.INVALID_ID_FORMAT), 400);
+  }
+  logger.error({ err, requestId: c.get("requestId") }, "Unhandled error");
+  const status: HttpErrorStatus = 500;
+  return c.json(errorBody(ERROR_CODE.INTERNAL, ERROR_MSG.INTERNAL_ERROR), status);
+}

--- a/apps/api/src/routes/account.ts
+++ b/apps/api/src/routes/account.ts
@@ -1,4 +1,4 @@
-import { deleteAccountSchema } from "@sugara/shared";
+import { deleteAccountSchema, ValidationError } from "@sugara/shared";
 import { verifyPassword } from "better-auth/crypto";
 import { and, eq } from "drizzle-orm";
 import { Hono } from "hono";
@@ -17,7 +17,7 @@ accountRoutes.delete("/account", deleteRateLimit, requireAuth, async (c) => {
   const json = await c.req.json();
   const parsed = deleteAccountSchema.safeParse(json);
   if (!parsed.success) {
-    return c.json({ error: parsed.error.issues[0].message }, 400);
+    throw new ValidationError(parsed.error.issues[0].message);
   }
 
   const user = c.get("user");

--- a/packages/shared/src/errors.ts
+++ b/packages/shared/src/errors.ts
@@ -19,6 +19,10 @@ export const ERROR_CODE = {
 
 export type ErrorCode = (typeof ERROR_CODE)[keyof typeof ERROR_CODE];
 
+// Fixed set of HTTP statuses an AppError can carry. Kept as a literal union so it
+// can be passed directly to Hono's c.json(body, status) without a cast.
+export type HttpErrorStatus = 400 | 401 | 403 | 404 | 409 | 429 | 500;
+
 // ─── Standardized error response body ─────────────────────────────────────────
 
 export const ErrorResponseSchema = z.object({
@@ -35,10 +39,10 @@ export type ErrorResponse = z.infer<typeof ErrorResponseSchema>;
 
 export class AppError extends Error {
   readonly code: ErrorCode;
-  readonly httpStatus: number;
+  readonly httpStatus: HttpErrorStatus;
   readonly details?: unknown;
 
-  constructor(message: string, code: ErrorCode, httpStatus: number, details?: unknown) {
+  constructor(message: string, code: ErrorCode, httpStatus: HttpErrorStatus, details?: unknown) {
     super(message);
     this.name = "AppError";
     this.code = code;


### PR DESCRIPTION
信頼性・観測性の底上げ(全4PR)の **PR2/4**。PR1(#107、AppError 基盤)の上に構築。

## 背景
API のグローバルエラーハンドラ(`app.onError`)が `{ error: string }` のみを返し、code/details がないためフロントが status でしか分岐できなかった。エラー応答を標準形 `{ code, message, details? }` に統一する仕組みを入れる。

## 変更
- `apps/api/src/lib/error-handler.ts`(新規): `app.onError` のハンドラを `handleError` として切り出し、テスト可能化
  - `AppError` を `{ code, message, details? }` + HTTP status にシリアライズ
  - 既存の SyntaxError→400 / pg uuid→400 / fallback 500 を `code` 付きに
  - **移行期間の後方互換**: legacy `error`(=message)エイリアスを併記。旧フロント(`body.error` を読む)が PR3 マージ前でも壊れない
- `apps/api/src/app.ts`: inline onError を `app.onError(handleError)` に置換、未使用 import 削除
- `packages/shared/src/errors.ts`: `httpStatus` を literal union(`HttpErrorStatus`)に絞り、`as` なしで Hono の `c.json(body, status)` に渡せるように
- `test-helpers.ts` の `createTestApp`: production と同じく `handleError` を登録(テストが本番の挙動に忠実になる)
- 代表移行: `routes/account.ts` の validation 応答を `throw new ValidationError(...)` に(end-to-end 検証)

## 移行戦略(38 ルートを一括書き換えしない)
旧 `c.json({error}, 4xx)` 直 return は onError を通らず**無改修で動作継続**。新規/触る箇所から `throw AppError` に寄せる opportunistic migration。残る `{ error: flatten() }` は PR3 のフロント後方互換パーサが `details` として吸収。

## 検証
- `bun run --filter @sugara/api test`: 646 passed(error-handler 6 件新規)
- `bun run --filter @sugara/shared test`: 204 passed
- `bun run check-types` 4/4、`bun run check`(biome)green

## 後続
PR3(フロント後方互換パーサ + 握りつぶし排除 + global-error)→ PR4(Sentry)。