### PR TITLE
feat(web): ApiError を新旧エラー形に後方互換対応し global-error を追加

### DIFF
--- a/apps/web/app/__tests__/global-error.test.tsx
+++ b/apps/web/app/__tests__/global-error.test.tsx
@@ -1,0 +1,22 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import GlobalError from "../global-error";
+
+describe("GlobalError", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders a fallback message and a retry button", () => {
+    render(<GlobalError error={new Error("boom")} reset={vi.fn()} />);
+    expect(screen.getByRole("heading", { name: /エラーが発生しました/ })).toBeDefined();
+    expect(screen.getByRole("button", { name: /Retry/ })).toBeDefined();
+  });
+
+  it("calls reset when the retry button is clicked", () => {
+    const reset = vi.fn();
+    render(<GlobalError error={new Error("boom")} reset={reset} />);
+    fireEvent.click(screen.getByRole("button", { name: /Retry/ }));
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/app/global-error.tsx
+++ b/apps/web/app/global-error.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+// global-error.tsx replaces the root layout when an error is thrown during
+// rendering of the layout itself, so next-intl's provider is unavailable here.
+// Text is therefore fixed (Japanese primary + English) and styling is inline so
+// the fallback renders even if the app stylesheet failed to load.
+// Sentry capture is wired in a later change.
+export default function GlobalError({
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <html lang="ja">
+      <body
+        style={{
+          margin: 0,
+          minHeight: "100vh",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: "1rem",
+          fontFamily: "system-ui, sans-serif",
+          color: "#18181b",
+          backgroundColor: "#fafafa",
+          padding: "1.5rem",
+          textAlign: "center",
+        }}
+      >
+        <h1 style={{ fontSize: "1.25rem", fontWeight: 700, margin: 0 }}>エラーが発生しました</h1>
+        <p style={{ color: "#71717a", margin: 0 }}>
+          予期しないエラーが発生しました。もう一度お試しください。
+          <br />
+          Something went wrong. Please try again.
+        </p>
+        <button
+          type="button"
+          onClick={reset}
+          style={{
+            cursor: "pointer",
+            border: "none",
+            borderRadius: "0.5rem",
+            backgroundColor: "#18181b",
+            color: "#fafafa",
+            padding: "0.5rem 1.25rem",
+            fontSize: "0.875rem",
+          }}
+        >
+          再読み込み / Retry
+        </button>
+      </body>
+    </html>
+  );
+}

--- a/apps/web/lib/__tests__/api.test.ts
+++ b/apps/web/lib/__tests__/api.test.ts
@@ -136,4 +136,47 @@ describe("ApiError", () => {
     expect(error.status).toBe(404);
     expect(error).toBeInstanceOf(Error);
   });
+
+  it("optionally carries a code and details", () => {
+    const error = new ApiError("invalid", 400, "VALIDATION", { f: ["x"] });
+    expect(error.code).toBe("VALIDATION");
+    expect(error.details).toEqual({ f: ["x"] });
+  });
+});
+
+describe("fetchApi error shape parsing", () => {
+  it("parses the standardized { code, message, details } shape", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: () =>
+        Promise.resolve({
+          code: "VALIDATION",
+          message: "入力内容を確認してください",
+          details: { fieldErrors: { title: ["Required"] } },
+        }),
+    });
+
+    await expect(apiVoid("/api/x", { method: "POST" })).rejects.toMatchObject({
+      status: 400,
+      code: "VALIDATION",
+      message: "入力内容を確認してください",
+      details: { fieldErrors: { title: ["Required"] } },
+    });
+  });
+
+  it("keeps a legacy object { error } (Zod flatten) as details instead of swallowing it", async () => {
+    const flatten = { formErrors: [], fieldErrors: { title: ["Required"] } };
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: () => Promise.resolve({ error: flatten }),
+    });
+
+    const err = await apiVoid("/api/x", { method: "POST" }).catch((e) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.status).toBe(400);
+    expect(err.details).toEqual(flatten);
+    expect(err.message).toContain("400");
+  });
 });

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -4,10 +4,43 @@ export class ApiError extends Error {
   constructor(
     message: string,
     public status: number,
+    // Standardized error code (e.g. "VALIDATION"); undefined for legacy responses.
+    public code?: string,
+    // Structured error detail (e.g. Zod flatten); undefined when not provided.
+    public details?: unknown,
   ) {
     super(message);
     this.name = "ApiError";
   }
+}
+
+// Parse an error body into { message, code, details }, accepting both the
+// standardized { code, message, details? } shape and legacy { error } responses.
+// A legacy object `error` (e.g. Zod flatten) is preserved as `details` rather
+// than being dropped behind a generic message.
+function parseErrorBody(
+  body: unknown,
+  status: number,
+): {
+  message: string;
+  code?: string;
+  details?: unknown;
+} {
+  const fallback = `API error: ${status}`;
+  if (body === null || typeof body !== "object") {
+    return { message: fallback };
+  }
+  const record = body as Record<string, unknown>;
+  if (typeof record.code === "string" && typeof record.message === "string") {
+    return { message: record.message, code: record.code, details: record.details };
+  }
+  if (typeof record.error === "string") {
+    return { message: record.error };
+  }
+  if (record.error !== undefined) {
+    return { message: fallback, details: record.error };
+  }
+  return { message: fallback };
 }
 
 type FetchOptions = RequestInit & {
@@ -36,9 +69,8 @@ async function fetchApi(path: string, options: FetchOptions): Promise<Response> 
 
   if (!res.ok) {
     const body = await res.json().catch(() => ({ error: "Unknown error" }));
-    const error = body.error;
-    const message = typeof error === "string" ? error : `API error: ${res.status}`;
-    throw new ApiError(message, res.status);
+    const { message, code, details } = parseErrorBody(body, res.status);
+    throw new ApiError(message, res.status, code, details);
   }
 
   return res;


### PR DESCRIPTION
信頼性・観測性の底上げ(全4PR)の **PR3/4**。

## 背景
- フロントの `ApiError` は `status` のみ保持し、API の新標準形 `{ code, message, details }`(PR2)を活かせない
- `fetchApi` は `body.error` がオブジェクト(Zod flatten)のとき `API error: <status>` に**握り潰すバグ**があり、フィールドエラーがフロントに届かない
- ルートレイアウト崩壊時の `global-error.tsx`(ErrorBoundary)がなく、白画面になりうる

## 変更
- `apps/web/lib/api.ts`:
  - `ApiError` に `code?` / `details?` を追加(`status` は維持 → `query-client` の 401 リトライ判定・`getApiErrorMessage` の status 分岐を壊さない)
  - `parseErrorBody` を追加し `fetchApi` を**新旧両対応**に: 新形式 `{code,message,details}` / legacy 文字列 `{error}` / legacy オブジェクト `{error: flatten}`(→ `details` に保持)。**握り潰しバグを修正**
- `apps/web/app/global-error.tsx`(新規): `"use client"`、CSS 非依存の inline style + 固定文言(next-intl provider を使えないため)+ Retry(reset)ボタン。Sentry 捕捉は PR4 で配線
- `getApiErrorMessage` は status ベースのまま(後方互換)

## 後方互換
- `fetchApi` は新形式・旧形式の両方をパースするため、バックエンドが新形式に移行する前後どちらでも動作。既存の "Unknown error" fallback も維持

## 検証
- `bun run --filter @sugara/web test`: 594 passed(api パーサ 3 + global-error 2 の新規)
- `check-types` / `check`(biome)green

## 後続(PR4)
Sentry 導入 + 握りつぶし 4 箇所の修正(想定外を Sentry 報告)+ error.tsx/global-error の captureException 配線。