### PR TITLE
fix(web): Sentry の非推奨オプションを webpack 配下に移行

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -88,6 +88,10 @@ export default withSentryConfig(config, {
   authToken: process.env.SENTRY_AUTH_TOKEN,
   silent: !process.env.CI,
   widenClientFileUpload: true,
-  disableLogger: true,
-  automaticVercelMonitors: false,
+  webpack: {
+    // We have no Vercel Cron Jobs; keep auto-monitor instrumentation off.
+    automaticVercelMonitors: false,
+    // Strip Sentry SDK debug logging from the client bundle.
+    treeshake: { removeDebugLogging: true },
+  },
 });


### PR DESCRIPTION
## 背景
デプロイログに @sentry/nextjs の非推奨警告が出ていた:
- `disableLogger is deprecated. Use webpack.treeshake.removeDebugLogging instead.`
- `automaticVercelMonitors is deprecated. Use webpack.automaticVercelMonitors instead.`

PR #110 で `withSentryConfig` に渡していた 2 オプションが、@sentry/nextjs 10.x で `webpack` 配下に移動していた(型定義 types.d.ts:534/544 で確認)。

## 変更
- `next.config.ts` の `disableLogger: true` / `automaticVercelMonitors: false` を `webpack: { automaticVercelMonitors: false, treeshake: { removeDebugLogging: true } }` に移行(挙動は同一)
- `silent` / `widenClientFileUpload` は現役オプションのため据え置き

## 検証
- `bun run --filter @sugara/web check-types` exit 0(新構造が型に適合)
- `bun run --filter @sugara/web check`(biome)green

ビルドは元々成功していた(警告のみ)。本 PR で警告が解消する。