### PR TITLE
chore: turbo-ignore を Vercel native skipping に移行

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,7 @@ bun run --filter @sugara/shared check-types
 
 - `main` は Branch Protection で保護 → 直 push 不可、PR + CI green で squash merge
 - feature branch: `<type>/<topic>` (例: `fix/cover-upload`, `feat/expense-category`)
-- PR merge → Vercel が自動デプロイ（`turbo-ignore` で web 非依存の変更はスキップ）
+- PR merge → Vercel が自動デプロイ（Vercel native skipping で web 非依存の変更はスキップ）
 - DB migration は独立した `.github/workflows/db-migrate.yml` で実行（`[skip deploy]` でも migration は走る）
 
 コミットメッセージでのスキップ:
@@ -123,7 +123,7 @@ bun run --filter @sugara/shared check-types
   - `Cargo.toml` / `Cargo.lock` の `sugara-desktop` version は `0.0.0` 固定（cargo build ログにしか出ず、アプリ版とは無関係）。リリース時に触らない
   - `userAgent` は version を含まない固定値 `sugara-desktop`（デスクトップ判定は接頭辞一致のみ。`apps/web/lib/hooks/use-desktop-download.ts`）。version 同期は不要
 - バージョンが既にタグ済みの場合は何もしない（冪等）
-- `apps/desktop/` のみの変更は Vercel の `turbo-ignore` がスキップするため Web ビルドは不要
+- `apps/desktop/` のみの変更は Vercel native skipping がスキップするため Web ビルドは不要
 - バージョン方針: patch（0.1.x）= バグ修正・軽微な改善、minor（0.x.0）= 新機能、major（x.0.0）= 破壊的変更
 - 必要な GitHub Secrets:
   - `GH_RELEASES_TOKEN`: `u-stem/sugara-releases` repo への write 権限を持つ PAT (公開リポジトリへのリリース転送用)

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -2,5 +2,5 @@
   "buildCommand": "sh -c 'cd ../.. && bun run db:migrate' && next build --webpack",
   "framework": "nextjs",
   "fluid": true,
-  "ignoreCommand": "git log -1 --pretty=%B | grep -qE '\\[skip (ci|deploy)\\]' && exit 0; [[ \"$VERCEL_GIT_COMMIT_REF\" == dependabot/* ]] && exit 0; npx --yes turbo-ignore"
+  "ignoreCommand": "git log -1 --pretty=%B | grep -qE '\\[skip (ci|deploy)\\]' && exit 0; [[ \"$VERCEL_GIT_COMMIT_REF\" == dependabot/* ]] && exit 0; exit 1"
 }

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -50,7 +50,7 @@ graph LR
     Actions -.->|release| Desktop["デスクトップアプリ"]
 ```
 
-- Web: main への push で Vercel が自動デプロイ。`turbo-ignore` で関連変更がなければスキップ
+- Web: main への push で Vercel が自動デプロイ。Vercel native skipping で関連変更がなければスキップ
 - デスクトップ: `tauri.conf.json` のバージョン変更 → タグ作成 → ビルド → リリース
 - DB マイグレーションは Vercel ビルド時に `MIGRATION_URL` (Direct Connection) 経由で自動実行
 

--- a/docs/development/release-flow.md
+++ b/docs/development/release-flow.md
@@ -80,7 +80,8 @@ gh pr create --title "<type>: <日本語タイトル>" --body "<本文>"
 ### Vercel 自動デプロイ
 
 - `main` への merge をトリガーに Vercel が web アプリをデプロイ
-- `turbo-ignore` で `@sugara/web` / `@sugara/api` / `@sugara/shared` に変更がない場合はスキップ
+- Vercel native skipping (Settings → Build and Deployment → Skip deployment) で `@sugara/web` / `@sugara/api` / `@sugara/shared` に変更がない場合はスキップ (workspace 依存グラフを Vercel が解析)
+- `apps/web/vercel.json` の `ignoreCommand` は `[skip ci]` / `[skip deploy]` コミットと `dependabot/*` ブランチのスキップを担う (native skipping では代替されない独自ガード)
 - `[skip ci]` `[skip deploy]` コミットメッセージでスキップ可能 (本番 deploy を意図的に止めたい場合のみ)
 
 ### DB migration

--- a/docs/development/release-flow.md
+++ b/docs/development/release-flow.md
@@ -99,7 +99,7 @@ Vercel `buildCommand` が `next build` の前に `bun run db:migrate` を実行�
 - `apps/desktop/src-tauri/tauri.conf.json` の `version` 変更を `desktop-tag.yml` が検知
 - 自動で `desktop-v<version>` タグを作成
 - タグ push を `desktop-build.yml` が検知してビルド → `sugara-releases` repo に公開
-- **バージョンは 3 箇所で手動同期**: `apps/desktop/src-tauri/tauri.conf.json` の `version` と `userAgent`、`apps/desktop/src-tauri/Cargo.toml` の `version` を同じ値にする (自動検証なし)
+- **バージョンの単一ソースは `apps/desktop/src-tauri/tauri.conf.json` の `version` 1 箇所のみ** (Tauri がバイナリ/インストーラに焼き、`tauri-action` の `__VERSION__` も同じ値を使う)。`Cargo.toml` / `Cargo.lock` の version は `0.0.0` 固定でリリース時に触らない。`userAgent` は version を含まない固定値 `sugara-desktop` で同期不要 (詳細は CLAUDE.md「デスクトップアプリのリリース」)
 - 必要な GitHub Secrets:
   - `GH_RELEASES_TOKEN` — `u-stem/sugara-releases` 公開 repo への write 権限を持つ PAT
   - `TAURI_SIGNING_PRIVATE_KEY` / `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` — Tauri 自動更新の署名鍵


### PR DESCRIPTION
## 背景
Vercel のビルドログに `"turbo-ignore" is deprecated. Use Vercel's built-in project skipping instead.` が出ていた。turbo-ignore は Turborepo 2.9 で deprecated。Vercel native skipping(workspace 依存グラフ解析で未変更プロジェクトをスキップ)へ移行する。

## 調査(research-summarizer ロールで一次情報確認)
- native skipping は **ダッシュボード設定**(Settings → Build and Deployment → Skip deployment: Enabled)で有効化。**Bun workspaces は 2026-03-06 対応**・GitHub 接続必須 → sugara は要件充足
- 現行 `ignoreCommand` は turbo-ignore 以外に **(A) `[skip ci/deploy]` コミットガード / (B) `dependabot/*` ブランチガード**も担う → これらは native skipping で代替されないため**残す**

## 変更
- `apps/web/vercel.json` の `ignoreCommand`: `npx --yes turbo-ignore` を除去し、(A)(B) ガード + 末尾 `exit 1`(該当しなければビルド続行)に。未変更プロジェクトのスキップは native skipping に委譲
- ドキュメントの turbo-ignore 記述を native skipping に更新(CLAUDE.md ×2 / release-flow.md / overview.md)

## あなたの手作業(マージとセットで)
Vercel Dashboard → sugara web → **Settings → Build and Deployment → Skip deployment: Enabled**。有効化後、数デプロイで Deployments タブを見て、apps/desktop だけの変更等で web ビルドがスキップされるか確認。

## 注意(調査で判明したリスク)
- native skipping と ignoreCommand の実行順序は Vercel 公式に明文規定なし(コミュニティ報告では native が先 → ガードは affected 判定後に評価され有効)
- native skipping には「マージコミット/複数コミット push で変更取りこぼし」既知 issue あり。数デプロイ様子見推奨
- 有効化前にマージしても**壊れない**(turbo-ignore 除去で一時的にビルド頻度が増えるだけ。[skip]/dependabot ガードは維持)

## 検証
- vercel.json JSON 妥当性 OK、turbo-ignore 参照ゼロ(grep 確認)