### PR TITLE
perf(web): Sentry のパフォーマンストレーシングを除去しバンドル削減

### DIFF
--- a/apps/web/instrumentation-client.ts
+++ b/apps/web/instrumentation-client.ts
@@ -15,5 +15,6 @@ if (dsn) {
   });
 }
 
-// Instruments client-side navigations for tracing (Next.js 16 hook).
+// Required by @sentry/nextjs to suppress a build-time warning. With
+// removeTracing enabled this is a no-op (no BrowserTracing integration).
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/apps/web/instrumentation-client.ts
+++ b/apps/web/instrumentation-client.ts
@@ -1,10 +1,5 @@
 import * as Sentry from "@sentry/nextjs";
-import {
-  IGNORE_ERRORS,
-  beforeBreadcrumb,
-  beforeSend,
-  getTracesSampleRate,
-} from "./lib/sentry-options";
+import { IGNORE_ERRORS, beforeBreadcrumb, beforeSend } from "./lib/sentry-options";
 
 // Browser Sentry init (Next.js 16 client instrumentation). Skipped when no DSN is
 // set so local dev / tests do not send events.
@@ -13,7 +8,6 @@ if (dsn) {
   Sentry.init({
     dsn,
     environment: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT ?? process.env.NODE_ENV,
-    tracesSampleRate: getTracesSampleRate(),
     sendDefaultPii: false,
     ignoreErrors: IGNORE_ERRORS,
     beforeSend,

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -1,11 +1,6 @@
 import { setErrorReporter } from "@sugara/api/lib/error-reporter";
 import * as Sentry from "@sentry/nextjs";
-import {
-  IGNORE_ERRORS,
-  beforeBreadcrumb,
-  beforeSend,
-  getTracesSampleRate,
-} from "./lib/sentry-options";
+import { IGNORE_ERRORS, beforeBreadcrumb, beforeSend } from "./lib/sentry-options";
 
 // Server/edge Sentry init. The Hono API runs as a Next.js route handler in the
 // same Node runtime, so this init also covers API errors. The API stays free of
@@ -20,7 +15,6 @@ export async function register() {
   Sentry.init({
     dsn,
     environment: process.env.SENTRY_ENVIRONMENT ?? process.env.VERCEL_ENV ?? process.env.NODE_ENV,
-    tracesSampleRate: getTracesSampleRate(),
     sendDefaultPii: false,
     ignoreErrors: IGNORE_ERRORS,
     beforeSend,

--- a/apps/web/lib/sentry-options.ts
+++ b/apps/web/lib/sentry-options.ts
@@ -125,8 +125,3 @@ export function beforeSend<T extends ScrubbableEvent>(
   scrubEvent(event);
   return event;
 }
-
-// Production keeps tracing low to stay within the free Sentry quota; off in dev.
-export function getTracesSampleRate(): number {
-  return process.env.NODE_ENV === "production" ? 0.1 : 0;
-}

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -91,7 +91,8 @@ export default withSentryConfig(config, {
   webpack: {
     // We have no Vercel Cron Jobs; keep auto-monitor instrumentation off.
     automaticVercelMonitors: false,
-    // Strip Sentry SDK debug logging from the client bundle.
-    treeshake: { removeDebugLogging: true },
+    // Strip Sentry SDK debug logging and performance tracing from the client
+    // bundle; we only use Sentry for error monitoring, not tracing.
+    treeshake: { removeDebugLogging: true, removeTracing: true },
   },
 });


### PR DESCRIPTION
## 背景
初回ロードの体感遅延を調査したところ、Sentry のクライアント SDK チャンクが gzip 140KB あり、その中に `browserTracingIntegration`(パフォーマンストレーシング)が同梱されていた。本来の目的はエラー監視で tracing は不要のため除去し、初回ロードのバンドルを削減する。

## 変更
- `instrumentation.ts` / `instrumentation-client.ts`: `Sentry.init` から `tracesSampleRate` を除去
- `next.config.ts`: `withSentryConfig` の `webpack.treeshake` に `removeTracing: true` を追加(tracing コードをツリーシェイク)
- `lib/sentry-options.ts`: 未使用になった `getTracesSampleRate` を削除
- **エラー監視は完全維持**(`beforeSend` の PII スクラブ、`ignoreErrors`、想定内 4xx drop、`beforeBreadcrumb`、DI reporter による API 5xx 捕捉はすべて据え置き)

## 実測効果(再ビルドで確認、gzip)
| チャンク | before(tracing 有) | after(tracing 除去) |
|---|---|---|
| Sentry SDK チャンク | 140KB | **94KB** |
| main | 88KB | **69KB** |

`browserTracingIntegration` はバンドルから消失。初回ロードの Sentry 増分を **合計 ~65KB gzip 削減**。

## 検証
- `bun run --filter @sugara/web check-types` / `check`(biome)/ `test` 緑(lefthook pre-commit でも check 通過)

## 補足
将来 Web Vitals/トレーシングが必要になったら `tracesSampleRate` を低い値(例 0.02)で戻し、`removeTracing` を外せば復活可能。