### PR TITLE
fix(web): Zod の eval プローブによる CSP 違反警告を抑止

### DIFF
--- a/apps/web/instrumentation-client.ts
+++ b/apps/web/instrumentation-client.ts
@@ -1,5 +1,14 @@
 import * as Sentry from "@sentry/nextjs";
+import { z } from "zod";
 import { IGNORE_ERRORS, beforeBreadcrumb, beforeSend } from "./lib/sentry-options";
+
+// Disable Zod's JIT path on the browser. Zod probes `new Function("")` to enable a
+// compiled validator, but our production CSP omits `unsafe-eval`, so the probe is
+// blocked. The throw is swallowed (Zod falls back to the interpreter), yet the
+// browser still reports it as a `securitypolicyviolation`. `jitless` skips the probe
+// entirely, silencing the console warning with no functional/perf loss (the JIT path
+// was already unavailable under the CSP).
+z.config({ jitless: true });
 
 // Browser Sentry init (Next.js 16 client instrumentation). Skipped when no DSN is
 // set so local dev / tests do not send events.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -66,7 +66,8 @@
     "sonner": "2.0.7",
     "tailwind-merge": "3.5.0",
     "tw-animate-css": "1.4.0",
-    "vaul": "1.1.2"
+    "vaul": "1.1.2",
+    "zod": "4.4.1"
   },
   "devDependencies": {
     "@playwright/test": "1.58.2",

--- a/bun.lock
+++ b/bun.lock
@@ -111,6 +111,7 @@
         "tailwind-merge": "3.5.0",
         "tw-animate-css": "1.4.0",
         "vaul": "1.1.2",
+        "zod": "4.4.1",
       },
       "devDependencies": {
         "@playwright/test": "1.58.2",


### PR DESCRIPTION
## Summary

本番のブラウザコンソールに出ていた CSP 違反警告

> Content Security Policy of your site blocks the use of 'eval' in JavaScript (`script-src` blocked)

の正体は **Zod 4 の `allowsEval` プローブ**でした。

- Zod 4 は JIT バリデーション経路が使えるか判定するため、起動時に一度だけ `new Function("")` を試す (`zod/v4/core/util.js`)
- 本番 CSP (`apps/web/proxy.ts`) は `script-src` に `'unsafe-eval'` を**意図的に含めない**(dev のみ許可)ため、このプローブがブロックされる
- `throw` は `catch` で握りつぶされ Zod は非 JIT 経路に**自動フォールバック**するので**機能は正常**。しかしブラウザは「ブロックした」事実を `securitypolicyviolation` として**必ず**報告するため、コンソールに警告が残っていた

Zod 自身のソースコメントが推奨する `jitless: true` でプローブ自体をスキップし、警告を解消する。

```js
// zod/v4/core/util.js
// Skip the probe under `jitless`: strict CSPs report the caught `new Function`
// as a `securitypolicyviolation` even though the throw is swallowed.
```

## Changes

- `apps/web/instrumentation-client.ts`: クライアント起動時に `z.config({ jitless: true })` を設定(理由コメント付き)
- `apps/web/package.json`: `zod` を direct dependency に exact pin (`4.4.1`, shared と同一バージョン) で追加
  - zod は単一物理インストール (`.bun/zod@4.4.1`) のため、web 側の global config が `@sugara/shared` のスキーマにも効く
- `bun.lock`: `bun install` による lockfile 更新

本番では元々 `'unsafe-eval'` 無しで JIT が使えていないため、**性能上の実損はない**(無駄なプローブと CSP 違反ログが消えるだけ)。CSP 設定 (`proxy.ts`) は変更しない。

## Test plan

- [x] `bun run check` → 4 パッケージすべて成功
- [x] `bun run check-types` → 4 タスクすべて zero error
- [x] `bun run --filter @sugara/web test` → 62 files / 628 tests passed
- [ ] デプロイ後、本番ブラウザのコンソールから CSP eval 違反警告が消えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)