### PR TITLE
feat(mcp): 外部API v1 を LLM 向けにラップする MCP サーバを追加

### DIFF
--- a/apps/mcp/README.md
+++ b/apps/mcp/README.md
@@ -64,7 +64,7 @@ sugara の設定画面からAPIキーを発行してください。
 | 変数名 | 必須 | 説明 |
 |---|---|---|
 | `SUGARA_API_KEY` | ✓ | sugara の設定画面で発行した API キー (`sk_...`) |
-| `SUGARA_API_URL` | ✓ | API の URL (例: `https://sugara.app`、ローカルは `http://localhost:3000`) |
+| `SUGARA_API_URL` | ✓ | API の URL。`https://` 推奨。`http://` は `localhost` / `127.0.0.1` のみ許可 (例: `https://sugara.app`、ローカルは `http://localhost:3000`) |
 
 ## 注意事項
 

--- a/apps/mcp/README.md
+++ b/apps/mcp/README.md
@@ -1,0 +1,73 @@
+# sugara MCP サーバ
+
+sugara の外部 API v1 を MCP (Model Context Protocol) でラップする stdio サーバです。
+Claude Desktop や Claude Code から自分の旅行データを読み取ることができます。
+
+## ツール一覧
+
+| ツール名 | 説明 |
+|---|---|
+| `list_trips` | 自分が参加している旅行の一覧を取得。`scope` (owned/shared)・limit・offset で絞り込み可 |
+| `get_trip` | 旅行の詳細を UUID で取得。メンバー (memberNo 付き) と日程・スポット一覧を含む |
+| `list_trip_expenses` | 旅行の費用一覧を取得。支払い者・分担は memberNo で参照 |
+| `list_bookmark_lists` | ブックマークリストの一覧を取得 |
+| `list_bookmarks` | 指定したブックマークリストの内容を取得 |
+| `list_articles` | 自分の記事一覧を取得 (本文なし)。本文は `get_article` で取得 |
+| `get_article` | 記事の全内容を UUID で取得 |
+
+**memberNo について**: `get_trip` や `list_trip_expenses` に登場する `memberNo` は旅行内の連番です。データベースの内部 ID ではありません。
+
+## セットアップ
+
+### 1. API キーの発行
+
+sugara の設定画面からAPIキーを発行してください。
+
+### 2. Claude Desktop への登録
+
+`~/Library/Application Support/Claude/claude_desktop_config.json` に以下を追加します:
+
+```json
+{
+  "mcpServers": {
+    "sugara": {
+      "command": "bun",
+      "args": ["run", "/絶対パス/sugara/apps/mcp/src/index.ts"],
+      "env": {
+        "SUGARA_API_KEY": "sk_...",
+        "SUGARA_API_URL": "https://sugara.app"
+      }
+    }
+  }
+}
+```
+
+### 3. Claude Code への登録
+
+```json
+{
+  "mcpServers": {
+    "sugara": {
+      "command": "bun",
+      "args": ["run", "/絶対パス/sugara/apps/mcp/src/index.ts"],
+      "env": {
+        "SUGARA_API_KEY": "sk_...",
+        "SUGARA_API_URL": "https://sugara.app"
+      }
+    }
+  }
+}
+```
+
+### 環境変数
+
+| 変数名 | 必須 | 説明 |
+|---|---|---|
+| `SUGARA_API_KEY` | ✓ | sugara の設定画面で発行した API キー (`sk_...`) |
+| `SUGARA_API_URL` | ✓ | API の URL (例: `https://sugara.app`、ローカルは `http://localhost:3000`) |
+
+## 注意事項
+
+- 読み取り専用です。データの作成・更新・削除はできません
+- 通信方式は stdio です。ネットワークで公開されることはありません
+- 取得できるデータは API キーの所有者自身のデータのみです

--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@sugara/mcp",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "bun run src/index.ts",
+    "test": "vitest run --passWithNoTests",
+    "lint": "biome lint src/",
+    "format": "biome format --write src/",
+    "check": "biome check --write src/",
+    "check-types": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "1.29.0",
+    "zod": "4.4.1"
+  },
+  "devDependencies": {
+    "@types/bun": "1.3.10",
+    "typescript": "6.0.2",
+    "vitest": "4.1.7"
+  }
+}

--- a/apps/mcp/src/__tests__/client.test.ts
+++ b/apps/mcp/src/__tests__/client.test.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiClient, type FetchLike } from "../client.js";
+
+function makeResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("ApiClient", () => {
+  let mockFetch: ReturnType<typeof vi.fn<FetchLike>>;
+  let client: ApiClient;
+
+  beforeEach(() => {
+    mockFetch = vi.fn<FetchLike>();
+    client = new ApiClient("http://localhost:3000", "sk_test_key", mockFetch);
+  });
+
+  describe("Authorization header", () => {
+    it("sends Bearer token in Authorization header", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(makeResponse({ data: [], pagination: {} }, 200));
+
+      // Act
+      await client.listTrips();
+
+      // Assert
+      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      const headers = init.headers as Record<string, string>;
+      expect(headers["Authorization"]).toBe("Bearer sk_test_key");
+    });
+
+    it("does not include the API key in error messages on 401", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(
+        makeResponse({ error: { code: "unauthorized", message: "bad key" } }, 401),
+      );
+
+      // Act
+      let errorMessage = "";
+      try {
+        await client.listTrips();
+      } catch (err) {
+        errorMessage = err instanceof Error ? err.message : "";
+      }
+
+      // Assert
+      expect(errorMessage).not.toContain("sk_test_key");
+    });
+  });
+
+  describe("error code mapping", () => {
+    it("maps 401 unauthorized to Japanese message", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(
+        makeResponse({ error: { code: "unauthorized", message: "bad key" } }, 401),
+      );
+
+      // Act
+      let errorMessage = "";
+      try {
+        await client.listTrips();
+      } catch (err) {
+        errorMessage = err instanceof Error ? err.message : "";
+      }
+
+      // Assert
+      expect(errorMessage).toContain("API キー");
+    });
+
+    it("maps 403 insufficient_scope to Japanese message", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(
+        makeResponse({ error: { code: "insufficient_scope", message: "no scope" } }, 403),
+      );
+
+      // Act
+      let errorMessage = "";
+      try {
+        await client.listTrips();
+      } catch (err) {
+        errorMessage = err instanceof Error ? err.message : "";
+      }
+
+      // Assert
+      expect(errorMessage).toContain("スコープ");
+    });
+
+    it("maps 404 not_found to Japanese message", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(
+        makeResponse({ error: { code: "not_found", message: "not found" } }, 404),
+      );
+
+      // Act
+      let errorMessage = "";
+      try {
+        await client.getTrip("00000000-0000-0000-0000-000000000001");
+      } catch (err) {
+        errorMessage = err instanceof Error ? err.message : "";
+      }
+
+      // Assert
+      expect(errorMessage).toContain("見つからない");
+    });
+
+    it("maps 429 rate_limited to Japanese message", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(
+        makeResponse({ error: { code: "rate_limited", message: "too many" } }, 429),
+      );
+
+      // Act
+      let errorMessage = "";
+      try {
+        await client.listTrips();
+      } catch (err) {
+        errorMessage = err instanceof Error ? err.message : "";
+      }
+
+      // Assert
+      expect(errorMessage).toContain("レート制限");
+    });
+
+    it("maps network failure to Japanese message", async () => {
+      // Arrange
+      mockFetch.mockRejectedValue(new TypeError("fetch failed"));
+
+      // Act
+      let errorMessage = "";
+      try {
+        await client.listTrips();
+      } catch (err) {
+        errorMessage = err instanceof Error ? err.message : "";
+      }
+
+      // Assert
+      expect(errorMessage).toContain("接続できません");
+    });
+  });
+
+  describe("query parameters", () => {
+    it("appends limit to list_trips request", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(makeResponse({ data: [], pagination: {} }, 200));
+
+      // Act
+      await client.listTrips({ limit: 10 });
+
+      // Assert
+      const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(url).toContain("limit=10");
+    });
+
+    it("appends offset to list_trips request", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(makeResponse({ data: [], pagination: {} }, 200));
+
+      // Act
+      await client.listTrips({ offset: 20 });
+
+      // Assert
+      const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(url).toContain("offset=20");
+    });
+
+    it("appends scope to list_trips request", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(makeResponse({ data: [], pagination: {} }, 200));
+
+      // Act
+      await client.listTrips({ scope: "owned" });
+
+      // Assert
+      const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(url).toContain("scope=owned");
+    });
+  });
+});

--- a/apps/mcp/src/__tests__/client.test.ts
+++ b/apps/mcp/src/__tests__/client.test.ts
@@ -8,6 +8,28 @@ function makeResponse(body: unknown, status: number): Response {
   });
 }
 
+// Type guard helpers for inspecting recorded mock fetch calls without unsafe casts.
+
+function getFirstCallUrl(calls: Parameters<FetchLike>[]): string {
+  const first = calls[0];
+  if (first === undefined) throw new Error("no fetch calls recorded");
+  const [urlArg] = first;
+  return typeof urlArg === "string" ? urlArg : urlArg.toString();
+}
+
+function getFirstCallHeaders(calls: Parameters<FetchLike>[]): Record<string, string> {
+  const first = calls[0];
+  if (first === undefined) throw new Error("no fetch calls recorded");
+  const [, initArg] = first;
+  if (!initArg) throw new Error("no RequestInit in fetch call");
+  const { headers } = initArg;
+  if (typeof headers !== "object" || headers === null || Array.isArray(headers)) {
+    throw new Error("expected plain object headers, got something else");
+  }
+  // Safe: runtime checks above confirm it is a plain string-keyed object record
+  return headers as Record<string, string>;
+}
+
 describe("ApiClient", () => {
   let mockFetch: ReturnType<typeof vi.fn<FetchLike>>;
   let client: ApiClient;
@@ -26,9 +48,8 @@ describe("ApiClient", () => {
       await client.listTrips();
 
       // Assert
-      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
-      const headers = init.headers as Record<string, string>;
-      expect(headers["Authorization"]).toBe("Bearer sk_test_key");
+      const headers = getFirstCallHeaders(mockFetch.mock.calls);
+      expect(headers.Authorization).toBe("Bearer sk_test_key");
     });
 
     it("does not include the API key in error messages on 401", async () => {
@@ -37,16 +58,30 @@ describe("ApiClient", () => {
         makeResponse({ error: { code: "unauthorized", message: "bad key" } }, 401),
       );
 
-      // Act
-      let errorMessage = "";
-      try {
-        await client.listTrips();
-      } catch (err) {
-        errorMessage = err instanceof Error ? err.message : "";
-      }
+      // Act + Assert: must throw AND the message must not expose the key
+      await expect(client.listTrips()).rejects.toThrow(
+        expect.objectContaining({ message: expect.not.stringContaining("sk_test_key") }),
+      );
+    });
 
-      // Assert
-      expect(errorMessage).not.toContain("sk_test_key");
+    it("does not include the API key in error messages on network failure", async () => {
+      // Arrange
+      mockFetch.mockRejectedValue(new TypeError("fetch failed"));
+
+      // Act + Assert
+      await expect(client.listTrips()).rejects.toThrow(
+        expect.objectContaining({ message: expect.not.stringContaining("sk_test_key") }),
+      );
+    });
+
+    it("does not include the API key in error messages on non-JSON 500", async () => {
+      // Arrange — non-JSON body causes safeParse to fail, falling back to "HTTP 500 error"
+      mockFetch.mockResolvedValue(new Response("Internal Server Error", { status: 500 }));
+
+      // Act + Assert
+      await expect(client.listTrips()).rejects.toThrow(
+        expect.objectContaining({ message: expect.not.stringContaining("sk_test_key") }),
+      );
     });
   });
 
@@ -149,7 +184,7 @@ describe("ApiClient", () => {
       await client.listTrips({ limit: 10 });
 
       // Assert
-      const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
+      const url = getFirstCallUrl(mockFetch.mock.calls);
       expect(url).toContain("limit=10");
     });
 
@@ -161,7 +196,7 @@ describe("ApiClient", () => {
       await client.listTrips({ offset: 20 });
 
       // Assert
-      const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
+      const url = getFirstCallUrl(mockFetch.mock.calls);
       expect(url).toContain("offset=20");
     });
 
@@ -173,7 +208,7 @@ describe("ApiClient", () => {
       await client.listTrips({ scope: "owned" });
 
       // Assert
-      const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
+      const url = getFirstCallUrl(mockFetch.mock.calls);
       expect(url).toContain("scope=owned");
     });
   });

--- a/apps/mcp/src/__tests__/env.test.ts
+++ b/apps/mcp/src/__tests__/env.test.ts
@@ -18,6 +18,7 @@ describe("parseEnv", () => {
 
     // Assert
     expect(result.apiKey).toBe("sk_test_key");
+    expect(result.baseUrl).toBe("https://example.com");
   });
 
   it("strips trailing slash from SUGARA_API_URL", () => {
@@ -68,5 +69,45 @@ describe("parseEnv", () => {
     // Act + Assert
     expect(() => parseEnv(env)).toThrow("process.exit called");
     expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("exits with code 1 when SUGARA_API_URL uses http for an external host", () => {
+    // Arrange
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((_code) => {
+      throw new Error("process.exit called");
+    });
+    const env = { SUGARA_API_KEY: "sk_test_key", SUGARA_API_URL: "http://example.com" };
+
+    // Act + Assert
+    expect(() => parseEnv(env)).toThrow("process.exit called");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("accepts http for localhost", () => {
+    // Arrange
+    const env = {
+      SUGARA_API_KEY: "sk_test_key",
+      SUGARA_API_URL: "http://localhost:3000",
+    };
+
+    // Act
+    const result = parseEnv(env);
+
+    // Assert
+    expect(result.baseUrl).toBe("http://localhost:3000");
+  });
+
+  it("accepts http for 127.0.0.1", () => {
+    // Arrange
+    const env = {
+      SUGARA_API_KEY: "sk_test_key",
+      SUGARA_API_URL: "http://127.0.0.1:3000",
+    };
+
+    // Act
+    const result = parseEnv(env);
+
+    // Assert
+    expect(result.baseUrl).toBe("http://127.0.0.1:3000");
   });
 });

--- a/apps/mcp/src/__tests__/env.test.ts
+++ b/apps/mcp/src/__tests__/env.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { parseEnv } from "../env.js";
+
+describe("parseEnv", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns parsed env when both variables are present", () => {
+    // Arrange
+    const env = {
+      SUGARA_API_KEY: "sk_test_key",
+      SUGARA_API_URL: "https://example.com",
+    };
+
+    // Act
+    const result = parseEnv(env);
+
+    // Assert
+    expect(result.apiKey).toBe("sk_test_key");
+  });
+
+  it("strips trailing slash from SUGARA_API_URL", () => {
+    // Arrange
+    const env = {
+      SUGARA_API_KEY: "sk_test_key",
+      SUGARA_API_URL: "https://example.com/",
+    };
+
+    // Act
+    const result = parseEnv(env);
+
+    // Assert
+    expect(result.baseUrl).toBe("https://example.com");
+  });
+
+  it("exits with code 1 when SUGARA_API_KEY is missing", () => {
+    // Arrange
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((_code) => {
+      throw new Error("process.exit called");
+    });
+    const env = { SUGARA_API_URL: "https://example.com" };
+
+    // Act + Assert
+    expect(() => parseEnv(env)).toThrow("process.exit called");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("exits with code 1 when SUGARA_API_URL is missing", () => {
+    // Arrange
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((_code) => {
+      throw new Error("process.exit called");
+    });
+    const env = { SUGARA_API_KEY: "sk_test_key" };
+
+    // Act + Assert
+    expect(() => parseEnv(env)).toThrow("process.exit called");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("exits with code 1 when SUGARA_API_URL is not a valid URL", () => {
+    // Arrange
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((_code) => {
+      throw new Error("process.exit called");
+    });
+    const env = { SUGARA_API_KEY: "sk_test_key", SUGARA_API_URL: "not-a-url" };
+
+    // Act + Assert
+    expect(() => parseEnv(env)).toThrow("process.exit called");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/apps/mcp/src/__tests__/server.test.ts
+++ b/apps/mcp/src/__tests__/server.test.ts
@@ -1,0 +1,207 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ApiClient, type ListTripsOptions, type PaginationOptions } from "../client.js";
+import { registerTools } from "../tools.js";
+
+// --- Type guard helpers ---
+
+// callTool returns a union type where both branches have [x: string]: unknown, so
+// "content" in result does not narrow reliably in TypeScript. Use explicit runtime
+// guards instead.
+
+type ContentCallResult = {
+  content: unknown[];
+  isError?: boolean;
+};
+
+type TextContentItem = { type: "text"; text: string };
+
+function isContentCallResult(value: unknown): value is ContentCallResult {
+  if (typeof value !== "object" || value === null) return false;
+  // Safe: we explicitly check the runtime type before relying on the cast
+  return Array.isArray((value as Record<string, unknown>).content);
+}
+
+function isTextContentItem(item: unknown): item is TextContentItem {
+  if (typeof item !== "object" || item === null) return false;
+  const candidate = item as Record<string, unknown>;
+  return candidate.type === "text" && typeof candidate.text === "string";
+}
+
+// --- Fixtures ---
+
+// Fixed data returned by FakeApiClient.listTrips — used to assert the tool
+// correctly serialises the client response into content[0].text.
+const FAKE_TRIPS = {
+  data: [{ id: "00000000-0000-0000-0000-000000000001" }],
+  pagination: { total: 1 },
+};
+
+// The 7 tool names that registerTools must expose.
+const EXPECTED_TOOL_NAMES = [
+  "list_trips",
+  "get_trip",
+  "list_trip_expenses",
+  "list_bookmark_lists",
+  "list_bookmarks",
+  "list_articles",
+  "get_article",
+] as const;
+
+/**
+ * Fake ApiClient that returns fixed in-memory data.
+ * Overrides every public method so no network calls are made.
+ */
+class FakeApiClient extends ApiClient {
+  constructor() {
+    // baseUrl / apiKey / fetchFn are never used by the overridden methods
+    super("http://localhost", "test_key");
+  }
+
+  override async listTrips(_opts?: ListTripsOptions): Promise<unknown> {
+    return FAKE_TRIPS;
+  }
+
+  override async getTrip(_id: string): Promise<unknown> {
+    return { id: "00000000-0000-0000-0000-000000000001", title: "Test Trip", days: [] };
+  }
+
+  override async listTripExpenses(_tripId: string, _opts?: PaginationOptions): Promise<unknown> {
+    return { data: [], pagination: { total: 0 } };
+  }
+
+  override async listBookmarkLists(_opts?: PaginationOptions): Promise<unknown> {
+    return { data: [], pagination: { total: 0 } };
+  }
+
+  override async listBookmarks(_listId: string, _opts?: PaginationOptions): Promise<unknown> {
+    return { data: [], pagination: { total: 0 } };
+  }
+
+  override async listArticles(_opts?: PaginationOptions): Promise<unknown> {
+    return { data: [], pagination: { total: 0 } };
+  }
+
+  override async getArticle(_id: string): Promise<unknown> {
+    return { id: "00000000-0000-0000-0000-000000000001", title: "Test", content: "" };
+  }
+}
+
+/**
+ * Fake ApiClient where listTrips always throws — used to verify isError handling.
+ */
+class ThrowingApiClient extends ApiClient {
+  constructor() {
+    super("http://localhost", "test_key");
+  }
+
+  override async listTrips(_opts?: ListTripsOptions): Promise<unknown> {
+    throw new Error("API unavailable");
+  }
+}
+
+/**
+ * Connects an McpServer to an MCP Client through an InMemoryTransport pair.
+ * Returns both ends so tests can drive the client and tear down after.
+ */
+async function setupPair(apiClient: ApiClient): Promise<{ server: McpServer; client: Client }> {
+  const server = new McpServer({ name: "sugara-mcp", version: "0.0.0" });
+  registerTools(server, apiClient);
+
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+
+  const client = new Client({ name: "test-client", version: "0.0.0" });
+  await client.connect(clientTransport);
+
+  return { server, client };
+}
+
+// --- Tests ---
+
+describe("MCP server — tools/list", () => {
+  let mcpServer!: McpServer;
+  let mcpClient!: Client;
+
+  beforeEach(async () => {
+    const pair = await setupPair(new FakeApiClient());
+    mcpServer = pair.server;
+    mcpClient = pair.client;
+  });
+
+  afterEach(async () => {
+    await mcpClient.close();
+    await mcpServer.close();
+  });
+
+  it("returns exactly 7 tools", async () => {
+    // Arrange + Act
+    const result = await mcpClient.listTools();
+
+    // Assert
+    expect(result.tools).toHaveLength(7);
+  });
+
+  it("includes all 7 expected tool names", async () => {
+    // Arrange + Act
+    const result = await mcpClient.listTools();
+    const names = result.tools.map((t) => t.name);
+
+    // Assert
+    expect(names).toEqual(expect.arrayContaining([...EXPECTED_TOOL_NAMES]));
+  });
+});
+
+describe("MCP server — tools/call list_trips (success path)", () => {
+  let mcpServer!: McpServer;
+  let mcpClient!: Client;
+
+  beforeEach(async () => {
+    const pair = await setupPair(new FakeApiClient());
+    mcpServer = pair.server;
+    mcpClient = pair.client;
+  });
+
+  afterEach(async () => {
+    await mcpClient.close();
+    await mcpServer.close();
+  });
+
+  it("returns fake client data as JSON string in content[0].text", async () => {
+    // Arrange + Act
+    const result = await mcpClient.callTool({ name: "list_trips", arguments: {} });
+
+    // Assert — use type guards because the union's [x: string]: unknown prevents in-narrowing
+    if (!isContentCallResult(result)) throw new Error("expected content-bearing result");
+    const first = result.content[0];
+    if (!isTextContentItem(first)) throw new Error("expected text content item");
+    expect(JSON.parse(first.text)).toEqual(FAKE_TRIPS);
+  });
+});
+
+describe("MCP server — tools/call list_trips (error path)", () => {
+  let mcpServer!: McpServer;
+  let mcpClient!: Client;
+
+  beforeEach(async () => {
+    const pair = await setupPair(new ThrowingApiClient());
+    mcpServer = pair.server;
+    mcpClient = pair.client;
+  });
+
+  afterEach(async () => {
+    await mcpClient.close();
+    await mcpServer.close();
+  });
+
+  it("returns isError: true when the API client throws", async () => {
+    // Arrange + Act
+    const result = await mcpClient.callTool({ name: "list_trips", arguments: {} });
+
+    // Assert
+    if (!isContentCallResult(result)) throw new Error("expected content-bearing result");
+    expect(result.isError).toBe(true);
+  });
+});

--- a/apps/mcp/src/__tests__/tools.test.ts
+++ b/apps/mcp/src/__tests__/tools.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { INPUT_SHAPES } from "../tools.js";
+
+describe("INPUT_SHAPES", () => {
+  it("defines 7 tools", () => {
+    // Arrange + Act
+    const toolNames = Object.keys(INPUT_SHAPES);
+
+    // Assert
+    expect(toolNames).toHaveLength(7);
+  });
+});
+
+describe("list_trips input schema", () => {
+  const schema = z.object(INPUT_SHAPES.list_trips);
+
+  it("rejects limit greater than 100", () => {
+    // Arrange + Act
+    const result = schema.safeParse({ limit: 101 });
+
+    // Assert
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects limit less than 1", () => {
+    // Arrange + Act
+    const result = schema.safeParse({ limit: 0 });
+
+    // Assert
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid scope value", () => {
+    // Arrange + Act
+    const result = schema.safeParse({ scope: "all" });
+
+    // Assert
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts valid scope owned", () => {
+    // Arrange + Act
+    const result = schema.safeParse({ scope: "owned" });
+
+    // Assert
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("get_trip input schema", () => {
+  const schema = z.object(INPUT_SHAPES.get_trip);
+
+  it("rejects non-UUID id", () => {
+    // Arrange + Act
+    const result = schema.safeParse({ id: "not-a-uuid" });
+
+    // Assert
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts valid UUID", () => {
+    // Arrange + Act
+    const result = schema.safeParse({ id: "550e8400-e29b-41d4-a716-446655440000" });
+
+    // Assert
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("list_trip_expenses input schema", () => {
+  const schema = z.object(INPUT_SHAPES.list_trip_expenses);
+
+  it("rejects non-UUID tripId", () => {
+    // Arrange + Act
+    const result = schema.safeParse({ tripId: "not-a-uuid" });
+
+    // Assert
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects limit greater than 100", () => {
+    // Arrange + Act
+    const result = schema.safeParse({ tripId: "550e8400-e29b-41d4-a716-446655440000", limit: 101 });
+
+    // Assert
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("list_bookmarks input schema", () => {
+  const schema = z.object(INPUT_SHAPES.list_bookmarks);
+
+  it("rejects non-UUID listId", () => {
+    // Arrange + Act
+    const result = schema.safeParse({ listId: "not-a-uuid" });
+
+    // Assert
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("get_article input schema", () => {
+  const schema = z.object(INPUT_SHAPES.get_article);
+
+  it("rejects non-UUID id", () => {
+    // Arrange + Act
+    const result = schema.safeParse({ id: "not-a-uuid" });
+
+    // Assert
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects negative offset for list_articles", () => {
+    // Arrange
+    const listSchema = z.object(INPUT_SHAPES.list_articles);
+
+    // Act
+    const result = listSchema.safeParse({ offset: -1 });
+
+    // Assert
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/mcp/src/client.ts
+++ b/apps/mcp/src/client.ts
@@ -1,0 +1,164 @@
+import { z } from "zod";
+
+// Error response schema from the v1 API
+const v1ErrorBodySchema = z.object({
+  error: z.object({
+    code: z.string(),
+    message: z.string(),
+  }),
+});
+
+type V1ErrorCode =
+  | "unauthorized"
+  | "insufficient_scope"
+  | "not_found"
+  | "rate_limited"
+  | "invalid_request"
+  | "internal_error";
+
+function isV1ErrorCode(code: string): code is V1ErrorCode {
+  return [
+    "unauthorized",
+    "insufficient_scope",
+    "not_found",
+    "rate_limited",
+    "invalid_request",
+    "internal_error",
+  ].includes(code);
+}
+
+const ERROR_MESSAGES: Record<V1ErrorCode, string> = {
+  unauthorized: "API キーが無効か期限切れです。SUGARA_API_KEY を確認してください",
+  insufficient_scope: "このキーには必要なスコープがありません（例: trips:read）",
+  not_found: "対象が見つからないか、アクセス権がありません",
+  rate_limited: "レート制限を超えました。少し待って再試行してください",
+  invalid_request: "リクエストが無効です",
+  internal_error: "サーバーの内部エラーが発生しました",
+};
+
+async function buildApiError(response: Response): Promise<Error> {
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    return new Error(`HTTP ${response.status} error`);
+  }
+  const parsed = v1ErrorBodySchema.safeParse(body);
+  if (parsed.success) {
+    const code = parsed.data.error.code;
+    const message = isV1ErrorCode(code)
+      ? ERROR_MESSAGES[code]
+      : `Server error (${response.status})`;
+    return new Error(message);
+  }
+  return new Error(`HTTP ${response.status} error`);
+}
+
+// A minimal fetch-compatible callable used for DI and testing.
+// We do not use `typeof fetch` directly because bun's global fetch has
+// additional properties (e.g. preconnect) that vi.fn() mocks cannot satisfy.
+export type FetchLike = (input: string | URL, init?: RequestInit) => Promise<Response>;
+
+export type ListTripsOptions = {
+  scope?: "owned" | "shared";
+  limit?: number;
+  offset?: number;
+};
+
+export type PaginationOptions = {
+  limit?: number;
+  offset?: number;
+};
+
+function addPagination(params: URLSearchParams, limit?: number, offset?: number): void {
+  if (limit !== undefined) params.set("limit", String(limit));
+  if (offset !== undefined) params.set("offset", String(offset));
+}
+
+/**
+ * Thin HTTP client for the sugara external API v1.
+ * All requests include Authorization: Bearer <apiKey>.
+ * Network errors and v1 error codes are mapped to human-readable Japanese messages.
+ * The API key is never included in thrown error messages.
+ */
+export class ApiClient {
+  private readonly baseUrl: string;
+  private readonly apiKey: string;
+  private readonly _fetch: FetchLike;
+
+  constructor(
+    baseUrl: string,
+    apiKey: string,
+    fetchFn: FetchLike = (input, init) => fetch(input, init),
+  ) {
+    this.baseUrl = baseUrl;
+    this.apiKey = apiKey;
+    this._fetch = fetchFn;
+  }
+
+  private async request(path: string, params?: URLSearchParams): Promise<unknown> {
+    const url = new URL(`${this.baseUrl}/api/v1${path}`);
+    if (params) {
+      for (const [key, value] of params.entries()) {
+        url.searchParams.set(key, value);
+      }
+    }
+
+    let response: Response;
+    try {
+      response = await this._fetch(url.toString(), {
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+          Accept: "application/json",
+        },
+      });
+    } catch {
+      throw new Error("SUGARA_API_URL に接続できません");
+    }
+
+    if (!response.ok) {
+      throw await buildApiError(response);
+    }
+
+    return response.json();
+  }
+
+  async listTrips(opts?: ListTripsOptions): Promise<unknown> {
+    const params = new URLSearchParams();
+    if (opts?.scope !== undefined) params.set("scope", opts.scope);
+    addPagination(params, opts?.limit, opts?.offset);
+    return this.request("/trips", params);
+  }
+
+  async getTrip(id: string): Promise<unknown> {
+    return this.request(`/trips/${encodeURIComponent(id)}`);
+  }
+
+  async listTripExpenses(tripId: string, opts?: PaginationOptions): Promise<unknown> {
+    const params = new URLSearchParams();
+    addPagination(params, opts?.limit, opts?.offset);
+    return this.request(`/trips/${encodeURIComponent(tripId)}/expenses`, params);
+  }
+
+  async listBookmarkLists(opts?: PaginationOptions): Promise<unknown> {
+    const params = new URLSearchParams();
+    addPagination(params, opts?.limit, opts?.offset);
+    return this.request("/bookmark-lists", params);
+  }
+
+  async listBookmarks(listId: string, opts?: PaginationOptions): Promise<unknown> {
+    const params = new URLSearchParams();
+    addPagination(params, opts?.limit, opts?.offset);
+    return this.request(`/bookmark-lists/${encodeURIComponent(listId)}/bookmarks`, params);
+  }
+
+  async listArticles(opts?: PaginationOptions): Promise<unknown> {
+    const params = new URLSearchParams();
+    addPagination(params, opts?.limit, opts?.offset);
+    return this.request("/articles", params);
+  }
+
+  async getArticle(id: string): Promise<unknown> {
+    return this.request(`/articles/${encodeURIComponent(id)}`);
+  }
+}

--- a/apps/mcp/src/env.ts
+++ b/apps/mcp/src/env.ts
@@ -2,7 +2,32 @@ import { z } from "zod";
 
 const envSchema = z.object({
   SUGARA_API_KEY: z.string().min(1),
-  SUGARA_API_URL: z.string().url(),
+  SUGARA_API_URL: z
+    .string()
+    .url()
+    .refine(
+      (url) => {
+        let parsed: URL;
+        try {
+          parsed = new URL(url);
+        } catch {
+          // z.string().url() should catch this first; guard against any edge-case ordering
+          return false;
+        }
+        if (parsed.protocol === "https:") return true;
+        // http is only permitted for local development (never sends Bearer over the wire)
+        if (
+          parsed.protocol === "http:" &&
+          (parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1")
+        ) {
+          return true;
+        }
+        return false;
+      },
+      {
+        message: "SUGARA_API_URL must use https. http is only allowed for localhost and 127.0.0.1.",
+      },
+    ),
 });
 
 export type ParsedEnv = {
@@ -20,7 +45,11 @@ export type ParsedEnv = {
 export function parseEnv(env: Record<string, string | undefined> = process.env): ParsedEnv {
   const result = envSchema.safeParse(env);
   if (!result.success) {
-    const fields = result.error.issues.map((issue) => String(issue.path[0])).join(", ");
+    // Dedupe field names: one field can produce multiple issues (e.g. URL both
+    // fails .url() and .refine()), which would otherwise list it twice.
+    const fields = [...new Set(result.error.issues.map((issue) => String(issue.path[0])))].join(
+      ", ",
+    );
     process.stderr.write(
       `[sugara-mcp] Configuration error: required environment variable(s) missing or invalid: ${fields}\n`,
     );

--- a/apps/mcp/src/env.ts
+++ b/apps/mcp/src/env.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+
+const envSchema = z.object({
+  SUGARA_API_KEY: z.string().min(1),
+  SUGARA_API_URL: z.string().url(),
+});
+
+export type ParsedEnv = {
+  apiKey: string;
+  baseUrl: string;
+};
+
+/**
+ * Parses and validates required environment variables.
+ * Writes a human-readable error to stderr and exits if any required variable is
+ * missing or invalid. Never includes the API key value in error output.
+ *
+ * @param env - environment variable map (defaults to process.env)
+ */
+export function parseEnv(env: Record<string, string | undefined> = process.env): ParsedEnv {
+  const result = envSchema.safeParse(env);
+  if (!result.success) {
+    const fields = result.error.issues.map((issue) => String(issue.path[0])).join(", ");
+    process.stderr.write(
+      `[sugara-mcp] Configuration error: required environment variable(s) missing or invalid: ${fields}\n`,
+    );
+    process.stderr.write(
+      "[sugara-mcp] Please set SUGARA_API_KEY and SUGARA_API_URL before starting the server.\n",
+    );
+    process.exit(1);
+  }
+  // Normalize: strip trailing slash so callers can always append /api/v1/...
+  const baseUrl = result.data.SUGARA_API_URL.replace(/\/$/, "");
+  return { apiKey: result.data.SUGARA_API_KEY, baseUrl };
+}

--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -13,7 +13,7 @@ async function main(): Promise<void> {
 
   const server = new McpServer({
     name: "sugara-mcp",
-    version: "1.0.0",
+    version: "0.0.0",
   });
 
   registerTools(server, client);

--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -1,0 +1,33 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { ApiClient } from "./client.js";
+import { parseEnv } from "./env.js";
+import { registerTools } from "./tools.js";
+
+async function main(): Promise<void> {
+  // Validate environment before doing anything else.
+  // parseEnv writes to stderr and exits on failure — stdout is never touched.
+  const env = parseEnv();
+
+  const client = new ApiClient(env.baseUrl, env.apiKey);
+
+  const server = new McpServer({
+    name: "sugara-mcp",
+    version: "1.0.0",
+  });
+
+  registerTools(server, client);
+
+  // StdioServerTransport reads from stdin and writes to stdout.
+  // All logging must use stderr to avoid corrupting the JSON-RPC channel.
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+
+  process.stderr.write("[sugara-mcp] Server started. Listening on stdio.\n");
+}
+
+main().catch((err: unknown) => {
+  const message = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`[sugara-mcp] Fatal error: ${message}\n`);
+  process.exit(1);
+});

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -1,0 +1,196 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { ApiClient } from "./client.js";
+
+// Exported raw shapes for testing (input schema validation can be checked against these)
+export const INPUT_SHAPES = {
+  list_trips: {
+    scope: z.enum(["owned", "shared"]).optional(),
+    limit: z.number().int().min(1).max(100).optional(),
+    offset: z.number().int().min(0).optional(),
+  },
+  get_trip: {
+    id: z.string().uuid(),
+  },
+  list_trip_expenses: {
+    tripId: z.string().uuid(),
+    limit: z.number().int().min(1).max(100).optional(),
+    offset: z.number().int().min(0).optional(),
+  },
+  list_bookmark_lists: {
+    limit: z.number().int().min(1).max(100).optional(),
+    offset: z.number().int().min(0).optional(),
+  },
+  list_bookmarks: {
+    listId: z.string().uuid(),
+    limit: z.number().int().min(1).max(100).optional(),
+    offset: z.number().int().min(0).optional(),
+  },
+  list_articles: {
+    limit: z.number().int().min(1).max(100).optional(),
+    offset: z.number().int().min(0).optional(),
+  },
+  get_article: {
+    id: z.string().uuid(),
+  },
+} as const;
+
+function toolError(message: string) {
+  return {
+    content: [{ type: "text" as const, text: message }],
+    isError: true as const,
+  };
+}
+
+function toolResult(data: unknown) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }],
+  };
+}
+
+/**
+ * Registers all 7 sugara v1 read-only tools with the MCP server.
+ * Each tool maps 1:1 to a v1 endpoint and returns the raw JSON response.
+ * On client errors, returns an isError result with a human-readable message.
+ */
+export function registerTools(server: McpServer, client: ApiClient): void {
+  server.registerTool(
+    "list_trips",
+    {
+      description:
+        "List trips the API key owner is a member of. " +
+        "Scope 'owned' returns trips where the owner role is held; " +
+        "'shared' returns trips shared by others. " +
+        "Supports limit/offset pagination.",
+      inputSchema: INPUT_SHAPES.list_trips,
+    },
+    async (args) => {
+      try {
+        const result = await client.listTrips(args);
+        return toolResult(result);
+      } catch (err) {
+        return toolError(err instanceof Error ? err.message : "Unexpected error");
+      }
+    },
+  );
+
+  server.registerTool(
+    "get_trip",
+    {
+      description:
+        "Get full details of a trip by its UUID. " +
+        "Returns members with memberNo (a sequential number within the trip, not a database ID) " +
+        "and days with scheduled spots.",
+      inputSchema: INPUT_SHAPES.get_trip,
+    },
+    async (args) => {
+      try {
+        const result = await client.getTrip(args.id);
+        return toolResult(result);
+      } catch (err) {
+        return toolError(err instanceof Error ? err.message : "Unexpected error");
+      }
+    },
+  );
+
+  server.registerTool(
+    "list_trip_expenses",
+    {
+      description:
+        "List expenses for a trip. " +
+        "paidBy and splits reference members by memberNo " +
+        "(a sequential number within the trip, consistent with get_trip member list). " +
+        "Supports limit/offset pagination.",
+      inputSchema: INPUT_SHAPES.list_trip_expenses,
+    },
+    async (args) => {
+      try {
+        const result = await client.listTripExpenses(args.tripId, {
+          limit: args.limit,
+          offset: args.offset,
+        });
+        return toolResult(result);
+      } catch (err) {
+        return toolError(err instanceof Error ? err.message : "Unexpected error");
+      }
+    },
+  );
+
+  server.registerTool(
+    "list_bookmark_lists",
+    {
+      description:
+        "List the bookmark lists owned by the API key holder. " +
+        "Each list includes a bookmarkCount. " +
+        "Supports limit/offset pagination.",
+      inputSchema: INPUT_SHAPES.list_bookmark_lists,
+    },
+    async (args) => {
+      try {
+        const result = await client.listBookmarkLists(args);
+        return toolResult(result);
+      } catch (err) {
+        return toolError(err instanceof Error ? err.message : "Unexpected error");
+      }
+    },
+  );
+
+  server.registerTool(
+    "list_bookmarks",
+    {
+      description:
+        "List bookmarks inside a specific bookmark list. " +
+        "Only lists owned by the API key holder are accessible. " +
+        "Supports limit/offset pagination.",
+      inputSchema: INPUT_SHAPES.list_bookmarks,
+    },
+    async (args) => {
+      try {
+        const result = await client.listBookmarks(args.listId, {
+          limit: args.limit,
+          offset: args.offset,
+        });
+        return toolResult(result);
+      } catch (err) {
+        return toolError(err instanceof Error ? err.message : "Unexpected error");
+      }
+    },
+  );
+
+  server.registerTool(
+    "list_articles",
+    {
+      description:
+        "List articles owned by the API key holder (without content body). " +
+        "Use get_article to fetch the full content of a specific article. " +
+        "Supports limit/offset pagination.",
+      inputSchema: INPUT_SHAPES.list_articles,
+    },
+    async (args) => {
+      try {
+        const result = await client.listArticles(args);
+        return toolResult(result);
+      } catch (err) {
+        return toolError(err instanceof Error ? err.message : "Unexpected error");
+      }
+    },
+  );
+
+  server.registerTool(
+    "get_article",
+    {
+      description:
+        "Get the full content of an article by its UUID. " +
+        "Only articles owned by the API key holder are accessible.",
+      inputSchema: INPUT_SHAPES.get_article,
+    },
+    async (args) => {
+      try {
+        const result = await client.getArticle(args.id);
+        return toolResult(result);
+      } catch (err) {
+        return toolError(err instanceof Error ? err.message : "Unexpected error");
+      }
+    },
+  );
+}

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -3,6 +3,9 @@ import { z } from "zod";
 import type { ApiClient } from "./client.js";
 
 // Exported raw shapes for testing (input schema validation can be checked against these)
+// Note: z.string().uuid() validates strict UUID v4 format, which is stricter than the
+// v1 API's guid() validator (which also accepts v1-v5). All IDs are v4-generated in
+// practice, so this extra strictness causes no real-world rejections.
 export const INPUT_SHAPES = {
   list_trips: {
     scope: z.enum(["owned", "shared"]).optional(),

--- a/apps/mcp/tsconfig.json
+++ b/apps/mcp/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "types": ["@types/bun"]
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -61,6 +61,19 @@
         "@tauri-apps/cli": "2.10.1",
       },
     },
+    "apps/mcp": {
+      "name": "@sugara/mcp",
+      "version": "0.0.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "1.29.0",
+        "zod": "4.4.1",
+      },
+      "devDependencies": {
+        "@types/bun": "1.3.10",
+        "typescript": "6.0.2",
+        "vitest": "4.1.7",
+      },
+    },
     "apps/web": {
       "name": "@sugara/web",
       "version": "0.0.0",
@@ -393,6 +406,8 @@
 
     "@headlessui/vue": ["@headlessui/vue@1.7.23", "", { "dependencies": { "@tanstack/vue-virtual": "^3.0.0-beta.60" }, "peerDependencies": { "vue": "^3.2.0" } }, "sha512-JzdCNqurrtuu0YW6QaDtR2PIYCKPUWq28csDyMvN4zmGccmE7lz40Is6hc3LA4HFeCI7sekZ/PQMTNmn9I/4Wg=="],
 
+    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+
     "@hono/standard-validator": ["@hono/standard-validator@0.2.2", "", { "peerDependencies": { "@standard-schema/spec": "^1.0.0", "hono": ">=3.9.0" } }, "sha512-mJ7W84Bt/rSvoIl63Ynew+UZOHAzzRAoAXb3JaWuxAkM/Lzg+ZHTCUiz77KOtn2e623WNN8LkD57Dk0szqUrIw=="],
 
     "@img/colour": ["@img/colour@1.0.0", "", {}, "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw=="],
@@ -480,6 +495,8 @@
     "@lezer/yaml": ["@lezer/yaml@1.0.4", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.4.0" } }, "sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw=="],
 
     "@marijn/find-cluster-break": ["@marijn/find-cluster-break@1.0.2", "", {}, "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
     "@next/env": ["@next/env@16.2.6", "", {}, "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw=="],
 
@@ -847,6 +864,8 @@
 
     "@sugara/desktop": ["@sugara/desktop@workspace:apps/desktop"],
 
+    "@sugara/mcp": ["@sugara/mcp@workspace:apps/mcp"],
+
     "@sugara/shared": ["@sugara/shared@workspace:packages/shared"],
 
     "@sugara/web": ["@sugara/web@workspace:apps/web"],
@@ -1107,6 +1126,8 @@
 
     "@xtuc/long": ["@xtuc/long@4.2.2", "", {}, "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="],
 
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "acorn-import-attributes": ["acorn-import-attributes@1.9.5", "", { "peerDependencies": { "acorn": "^8" } }, "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ=="],
@@ -1119,7 +1140,7 @@
 
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
-    "ajv-formats": ["ajv-formats@2.1.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA=="],
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
     "ajv-keywords": ["ajv-keywords@5.1.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3" }, "peerDependencies": { "ajv": "^8.8.2" } }, "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw=="],
 
@@ -1171,6 +1192,8 @@
 
     "bn.js": ["bn.js@4.12.3", "", {}, "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="],
 
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
     "brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
 
     "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
@@ -1188,6 +1211,12 @@
     "buffers": ["buffers@0.1.1", "", {}, "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ=="],
 
     "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001793", "", {}, "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA=="],
 
@@ -1227,19 +1256,29 @@
 
     "compress-commons": ["compress-commons@4.1.2", "", { "dependencies": { "buffer-crc32": "^0.2.13", "crc32-stream": "^4.0.2", "normalize-path": "^3.0.0", "readable-stream": "^3.6.0" } }, "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg=="],
 
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
     "convert-hrtime": ["convert-hrtime@5.0.0", "", {}, "sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
-    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
     "core-util-is": ["core-util-is@1.0.3", "", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
 
     "crc-32": ["crc-32@1.2.2", "", { "bin": { "crc32": "bin/crc32.njs" } }, "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ=="],
 
     "crc32-stream": ["crc32-stream@4.0.3", "", { "dependencies": { "crc-32": "^1.2.0", "readable-stream": "^3.4.0" } }, "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw=="],
 
     "crelt": ["crelt@1.0.6", "", {}, "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
 
@@ -1261,6 +1300,8 @@
 
     "defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
 
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
@@ -1277,11 +1318,17 @@
 
     "drizzle-orm": ["drizzle-orm@0.45.2", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "sql.js", "sqlite3"] }, "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q=="],
 
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
     "duplexer2": ["duplexer2@0.1.4", "", { "dependencies": { "readable-stream": "^2.0.2" } }, "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA=="],
 
     "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
     "electron-to-chromium": ["electron-to-chromium@1.5.364", "", {}, "sha512-G/dYE3+AYhyHwzTwg8UbnXf7zqMERYh7l2jJ3QujhFsH8agSYwtnGAR2aZ7f0AakIKJXd5En/Hre4igIUrdlYw=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
     "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
@@ -1289,11 +1336,19 @@
 
     "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
     "es-module-lexer": ["es-module-lexer@2.0.0", "", {}, "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
 
     "esbuild": ["esbuild@0.28.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.0", "@esbuild/android-arm": "0.28.0", "@esbuild/android-arm64": "0.28.0", "@esbuild/android-x64": "0.28.0", "@esbuild/darwin-arm64": "0.28.0", "@esbuild/darwin-x64": "0.28.0", "@esbuild/freebsd-arm64": "0.28.0", "@esbuild/freebsd-x64": "0.28.0", "@esbuild/linux-arm": "0.28.0", "@esbuild/linux-arm64": "0.28.0", "@esbuild/linux-ia32": "0.28.0", "@esbuild/linux-loong64": "0.28.0", "@esbuild/linux-mips64el": "0.28.0", "@esbuild/linux-ppc64": "0.28.0", "@esbuild/linux-riscv64": "0.28.0", "@esbuild/linux-s390x": "0.28.0", "@esbuild/linux-x64": "0.28.0", "@esbuild/netbsd-arm64": "0.28.0", "@esbuild/netbsd-x64": "0.28.0", "@esbuild/openbsd-arm64": "0.28.0", "@esbuild/openbsd-x64": "0.28.0", "@esbuild/openharmony-arm64": "0.28.0", "@esbuild/sunos-x64": "0.28.0", "@esbuild/win32-arm64": "0.28.0", "@esbuild/win32-ia32": "0.28.0", "@esbuild/win32-x64": "0.28.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
     "escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
@@ -1309,13 +1364,21 @@
 
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
     "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
 
     "eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
 
     "exceljs": ["exceljs@4.4.0", "", { "dependencies": { "archiver": "^5.0.0", "dayjs": "^1.8.34", "fast-csv": "^4.3.1", "jszip": "^3.10.1", "readable-stream": "^3.6.0", "saxes": "^5.0.1", "tmp": "^0.2.0", "unzipper": "^0.10.11", "uuid": "^8.3.0" } }, "sha512-XctvKaEMaj1Ii9oDOqbW/6e1gXknSY4g/aLCDicOXqBE4M0nRWkUu0PTp++UPNzoFY12BNHMfs/VadKIS6llvg=="],
 
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.5.2", "", { "dependencies": { "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A=="],
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
@@ -1329,11 +1392,17 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
     "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
 
     "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
 
     "focus-trap": ["focus-trap@7.8.0", "", { "dependencies": { "tabbable": "^6.4.0" } }, "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
     "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
 
@@ -1343,21 +1412,29 @@
 
     "fstream": ["fstream@1.0.12", "", { "dependencies": { "graceful-fs": "^4.1.2", "inherits": "~2.0.0", "mkdirp": ">=0.5 0", "rimraf": "2" } }, "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg=="],
 
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
     "function-timeout": ["function-timeout@1.0.2", "", {}, "sha512-939eZS4gJ3htTHAldmyyuzlrD58P03fHG49v2JfFXbV6OhvZKRC9j2yAtdHw/zrp2zXHuv05zMIy40F0ge7spA=="],
 
     "fuse.js": ["fuse.js@7.4.2", "", {}, "sha512-LVbzjD4WA6UP5B1UnP8wuaXJiLnqMdM/E4fiJXTJ5haJ5b/MBNsK29h2fm6swEoQaVQjvYFWKLE2RanyZIoRVQ=="],
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
     "get-nonce": ["get-nonce@1.0.1", "", {}, "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="],
 
     "get-own-enumerable-keys": ["get-own-enumerable-keys@1.0.0", "", {}, "sha512-PKsK2FSrQCyxcGHsGrLDcK0lx+0Ke+6e8KFFozA9/fIQLhQzPaRvJFdcz7+Axg3jUH/Mq+NI4xa5u/UT2tQskA=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
     "get-tsconfig": ["get-tsconfig@4.13.6", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw=="],
 
     "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
 
     "glob-to-regexp": ["glob-to-regexp@0.4.1", "", {}, "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
@@ -1366,6 +1443,10 @@
     "guess-json-indent": ["guess-json-indent@3.0.1", "", {}, "sha512-LWZ3Vr8BG7DHE3TzPYFqkhjNRw4vYgFSsv2nfMuHklAlOfiy54/EwiDQuQfFVLxENCVv20wpbjfTayooQHrEhQ=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
 
     "hast-util-embedded": ["hast-util-embedded@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-is-element": "^3.0.0" } }, "sha512-naH8sld4Pe2ep03qqULEtvYr7EjrLK2QHY8KJR6RJkTUjPGObe1vnx585uzem2hGra+s1q08DZZpfgDVYRbaXA=="],
 
@@ -1423,11 +1504,15 @@
 
     "html5-qrcode": ["html5-qrcode@2.3.8", "", {}, "sha512-jsr4vafJhwoLVEDW3n1KvPnCCXWaQfRng0/EEYk1vNcQGcG/htAdhJX0be8YyqMoSz7+hZvOZSTAepsabiuhiQ=="],
 
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
     "http_ece": ["http_ece@1.2.0", "", {}, "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA=="],
 
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "iceberg-js": ["iceberg-js@0.8.1", "", {}, "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA=="],
+
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "icu-minify": ["icu-minify@4.13.0", "", { "dependencies": { "@formatjs/icu-messageformat-parser": "^3.4.0" } }, "sha512-SIFMeUHZJjzS5RvIGvybKvWoHjDm9cGVEs2EpJ8PmywOdJLWyblPm7TdPLLoUtkJtwQD7iGhl2WMptZ+N0on+w=="],
 
@@ -1450,6 +1535,10 @@
     "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
 
     "intl-messageformat": ["intl-messageformat@11.2.0", "", { "dependencies": { "@formatjs/ecma402-abstract": "3.2.0", "@formatjs/fast-memoize": "3.1.1", "@formatjs/icu-messageformat-parser": "3.5.3" } }, "sha512-IhghAA8n4KSlXuWKzYsWyWb82JoYTzShfyvdSF85oJPnNOjvv4kAo7S7Jtkm3/vJ53C7dQNRO+Gpnj3iWgTjBQ=="],
+
+    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
     "is-absolute-url": ["is-absolute-url@4.0.1", "", {}, "sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A=="],
 
@@ -1474,6 +1563,8 @@
     "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
     "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
     "is-reference": ["is-reference@1.2.1", "", { "dependencies": { "@types/estree": "*" } }, "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ=="],
 
@@ -1508,6 +1599,8 @@
     "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
@@ -1629,6 +1722,8 @@
 
     "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
 
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
     "mdast-util-find-and-replace": ["mdast-util-find-and-replace@3.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "escape-string-regexp": "^5.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg=="],
 
     "mdast-util-from-markdown": ["mdast-util-from-markdown@2.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "mdast-util-to-string": "^4.0.0", "micromark": "^4.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA=="],
@@ -1660,6 +1755,10 @@
     "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
 
     "mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 
     "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
 
@@ -1723,6 +1822,8 @@
 
     "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
     "minimalistic-assert": ["minimalistic-assert@1.0.1", "", {}, "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="],
 
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
@@ -1767,9 +1868,15 @@
 
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
 
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
     "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
 
     "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
@@ -1791,11 +1898,17 @@
 
     "parse5": ["parse5@8.0.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA=="],
 
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-is-absolute": ["path-is-absolute@1.0.1", "", {}, "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="],
 
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
     "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
@@ -1808,6 +1921,8 @@
     "pino-abstract-transport": ["pino-abstract-transport@3.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg=="],
 
     "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
     "playwright": ["playwright@1.58.2", "", { "dependencies": { "playwright-core": "1.58.2" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A=="],
 
@@ -1833,11 +1948,15 @@
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
     "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "qrcode.react": ["qrcode.react@4.2.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA=="],
+
+    "qs": ["qs@6.15.2", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw=="],
 
     "quansync": ["quansync@0.2.11", "", {}, "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA=="],
 
@@ -1846,6 +1965,10 @@
     "radix-ui": ["radix-ui@1.4.3", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-accessible-icon": "1.1.7", "@radix-ui/react-accordion": "1.2.12", "@radix-ui/react-alert-dialog": "1.1.15", "@radix-ui/react-arrow": "1.1.7", "@radix-ui/react-aspect-ratio": "1.1.7", "@radix-ui/react-avatar": "1.1.10", "@radix-ui/react-checkbox": "1.3.3", "@radix-ui/react-collapsible": "1.1.12", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-context-menu": "2.2.16", "@radix-ui/react-dialog": "1.1.15", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-dropdown-menu": "2.1.16", "@radix-ui/react-focus-guards": "1.1.3", "@radix-ui/react-focus-scope": "1.1.7", "@radix-ui/react-form": "0.1.8", "@radix-ui/react-hover-card": "1.1.15", "@radix-ui/react-label": "2.1.7", "@radix-ui/react-menu": "2.1.16", "@radix-ui/react-menubar": "1.1.16", "@radix-ui/react-navigation-menu": "1.2.14", "@radix-ui/react-one-time-password-field": "0.1.8", "@radix-ui/react-password-toggle-field": "0.1.3", "@radix-ui/react-popover": "1.1.15", "@radix-ui/react-popper": "1.2.8", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-progress": "1.1.7", "@radix-ui/react-radio-group": "1.3.8", "@radix-ui/react-roving-focus": "1.1.11", "@radix-ui/react-scroll-area": "1.2.10", "@radix-ui/react-select": "2.2.6", "@radix-ui/react-separator": "1.1.7", "@radix-ui/react-slider": "1.3.6", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-switch": "1.2.6", "@radix-ui/react-tabs": "1.1.13", "@radix-ui/react-toast": "1.2.15", "@radix-ui/react-toggle": "1.1.10", "@radix-ui/react-toggle-group": "1.1.11", "@radix-ui/react-toolbar": "1.1.11", "@radix-ui/react-tooltip": "1.2.8", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-effect-event": "0.0.2", "@radix-ui/react-use-escape-keydown": "1.1.1", "@radix-ui/react-use-is-hydrated": "0.1.0", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-size": "1.1.1", "@radix-ui/react-visually-hidden": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA=="],
 
     "radix-vue": ["radix-vue@1.9.17", "", { "dependencies": { "@floating-ui/dom": "^1.6.7", "@floating-ui/vue": "^1.1.0", "@internationalized/date": "^3.5.4", "@internationalized/number": "^3.5.3", "@tanstack/vue-virtual": "^3.8.1", "@vueuse/core": "^10.11.0", "@vueuse/shared": "^10.11.0", "aria-hidden": "^1.2.4", "defu": "^6.1.4", "fast-deep-equal": "^3.1.3", "nanoid": "^5.0.7" }, "peerDependencies": { "vue": ">= 3.2.0" } }, "sha512-mVCu7I2vXt1L2IUYHTt0sZMz7s1K2ZtqKeTIxG3yC5mMFfLBG4FtE1FDeRMpDd+Hhg/ybi9+iXmAP1ISREndoQ=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
     "react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
 
@@ -1907,6 +2030,8 @@
 
     "rou3": ["rou3@0.7.12", "", {}, "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg=="],
 
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
@@ -1923,13 +2048,31 @@
 
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
     "serwist": ["serwist@9.5.11", "", { "dependencies": { "@serwist/utils": "9.5.11", "idb": "8.0.3" }, "peerDependencies": { "typescript": ">=5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-Bq6uwJFd4ET60BWI77v3VbazKHv6k7lECOiiCFwKyBu/slaCn0GHJ5L5RfsuJUKrnbD9lYUCDo6sqaKRM5M2vA=="],
 
     "set-cookie-parser": ["set-cookie-parser@3.0.1", "", {}, "sha512-n7Z7dXZhJbwuAHhNzkTti6Aw9QDDjZtm3JTpTGATIdNzdQz5GuFs22w90BcvF4INfnrL5xrX3oGsuqO5Dx3A1Q=="],
 
     "setimmediate": ["setimmediate@1.0.5", "", {}, "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="],
 
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
     "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4", "side-channel-list": "^1.0.1", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
 
@@ -1952,6 +2095,8 @@
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
     "stacktrace-parser": ["stacktrace-parser@0.1.11", "", { "dependencies": { "type-fest": "^0.7.1" } }, "sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "std-env": ["std-env@4.0.0", "", {}, "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ=="],
 
@@ -2017,6 +2162,8 @@
 
     "tmp": ["tmp@0.2.7", "", {}, "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw=="],
 
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
     "tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
 
     "tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
@@ -2038,6 +2185,8 @@
     "tw-animate-css": ["tw-animate-css@1.4.0", "", {}, "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ=="],
 
     "type-fest": ["type-fest@5.6.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA=="],
+
+    "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
 
     "typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
 
@@ -2063,6 +2212,8 @@
 
     "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
 
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
     "unzipper": ["unzipper@0.10.14", "", { "dependencies": { "big-integer": "^1.6.17", "binary": "~0.3.0", "bluebird": "~3.4.1", "buffer-indexof-polyfill": "~1.0.0", "duplexer2": "~0.1.4", "fstream": "^1.0.12", "graceful-fs": "^4.2.2", "listenercount": "~1.0.1", "readable-stream": "~2.3.6", "setimmediate": "~1.0.4" } }, "sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
@@ -2078,6 +2229,8 @@
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "uuid": ["uuid@11.1.1", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "vaul": ["vaul@1.1.2", "", { "dependencies": { "@radix-ui/react-dialog": "^1.1.1" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA=="],
 
@@ -2140,6 +2293,8 @@
     "zip-stream": ["zip-stream@4.1.1", "", { "dependencies": { "archiver-utils": "^3.0.4", "compress-commons": "^4.1.2", "readable-stream": "^3.6.0" } }, "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ=="],
 
     "zod": ["zod@4.4.1", "", {}, "sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
@@ -2216,6 +2371,8 @@
     "@rollup/plugin-commonjs/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+
+    "@scalar/api-client/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
     "@scalar/api-client/nanoid": ["nanoid@5.1.11", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg=="],
 
@@ -2317,11 +2474,15 @@
 
     "rimraf/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
+    "schema-utils/ajv-formats": ["ajv-formats@2.1.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA=="],
+
     "source-map/whatwg-url": ["whatwg-url@7.1.0", "", { "dependencies": { "lodash.sortby": "^4.7.0", "tr46": "^1.0.1", "webidl-conversions": "^4.0.2" } }, "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg=="],
 
     "source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "stacktrace-parser/type-fest": ["type-fest@0.7.1", "", {}, "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg=="],
+
+    "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "unzipper/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 

--- a/docs/architecture/external-api.md
+++ b/docs/architecture/external-api.md
@@ -126,9 +126,19 @@ v1 エンドポイントの OpenAPI 3.1 仕様と Scalar UI を提供する。
 
 **実装**: `hono-openapi` の `describeRoute` を v1 の 7 ルートに追加してメタデータを付与し、`generateSpecs(v1App, ...)` で spec を生成。`@scalar/hono-api-reference` の `Scalar` ミドルウェアで UI を提供。`Scalar({ cdn: "/scalar/standalone.js", withDefaultFonts: false })` で外部 CDN とフォントサービスへの依存を排除。
 
+## MCP サーバ（apps/mcp）
+
+v1 REST を LLM（Claude Desktop / Claude Code 等）から扱うための MCP サーバ。`apps/mcp`（`private`、未公開）に置き、**stdio トランスポート**で動作する（LLM クライアントが子プロセスとして起動）。
+
+- 認証: API キーを環境変数 `SUGARA_API_KEY` で受け取り `Authorization: Bearer` で v1 を叩く。接続先は `SUGARA_API_URL`。生キーはログ・エラーに出さない
+- ツール: v1 の 7 エンドポイントに 1:1 対応する 7 つの read ツール（`list_trips` / `get_trip` / `list_trip_expenses` / `list_bookmark_lists` / `list_bookmarks` / `list_articles` / `get_article`）。入力は zod で境界検証（limit 1–100 / offset 0+ / uuid / scope enum）
+- エラー: v1 の `{ error: { code, message } }` を人間可読メッセージに写像（`isError: true`）
+- 読み取り専用・stdio のため公開ネットワーク面はなく、攻撃面は「キーを持つローカルプロセス」に限定
+- SDK: `@modelcontextprotocol/sdk`。実行はビルドせず `bun run src/index.ts`（モノレポの TS 直接実行規約に準拠）
+- セットアップ手順は `apps/mcp/README.md`
+
 ## 今後の課題
 
 - レート制限の具体値（IP 段の window/max）を実負荷に基づいて調整
 - キー ID 単位のレート制限・`X-RateLimit-*` ヘッダ（公開拡大時に後方互換追加）
 - 書き込み系スコープ（`trips:write` / `expenses:write`）の追加
-- MCP サーバによる LLM 連携（v1 REST を下層として薄くラップ）


### PR DESCRIPTION
## Summary

外部 API v1 を LLM（Claude Desktop / Claude Code 等）から扱うための MCP サーバを `apps/mcp` として追加。API キーを環境変数で受け取り、v1 の 7 エンドポイントを 7 つの read ツールとして公開する。計画当初からの段階設計「v1 REST を下層、LLM 連携は MCP ラッパで補完」の実体化。

## Why

- v1 REST は Bearer 認証のサーバ間 API で、LLM から直接は扱いにくい。主消費者は「自分専用 + ローカル LLM」のため、子プロセスとして起動する **stdio トランスポート**が最も素直（OAuth/CORS が要るリモート HTTP は過剰）
- モノレポ内 `apps/mcp`（`private`、未公開）に置き、まず自分用にローカル運用。npm 公開はしない（必要になれば publish 設定を後付け）

## Changes

- **7 ツール**（v1 と 1:1）: `list_trips` / `get_trip` / `list_trip_expenses` / `list_bookmark_lists` / `list_bookmarks` / `list_articles` / `get_article`。入力は zod で境界検証（limit 1–100 / offset 0+ / uuid / scope enum）
- **client.ts**: v1 を `Authorization: Bearer ${SUGARA_API_KEY}` で叩く薄いクライアント。v1 の `{ error: { code, message } }` を人間可読メッセージに写像。**生キーは例外・ログに出さない**
- **env.ts**: `SUGARA_API_KEY` / `SUGARA_API_URL` を Parse-don't-validate（欠落時は stderr に明示して exit、キー値は出さない）
- **index.ts**: `@modelcontextprotocol/sdk` の McpServer + StdioServerTransport。**stdout は JSON-RPC 専用、ログは全て stderr**
- 依存追加: `@modelcontextprotocol/sdk@1.29.0`（MIT・install scripts なし・週3500万DL・zod peer 互換）。transitive は SDK が内包する HTTP トランスポート用（express/cors 等）のみ
- 実行はビルドせず `bun run src/index.ts`（モノレポの TS 直接実行規約に準拠）
- `docs/architecture/external-api.md` に MCP 節を追加（計画書から昇格・削除）、README にセットアップ手順

## Test plan

- [x] 単体: 27 tests 全緑（client の Bearer 付与・401/403/404/429 のメッセージ写像・**キーが例外に出ないこと**・クエリ付与、tools の input schema が limit>100/不正uuid/不正scope を reject、env の欠落検証）
- [x] `bun run check` / `check-types`（全体）緑
- [x] **手動 stdio 疎通**: 実 dev サーバに対し JSON-RPC で initialize → tools/list（7ツール列挙）→ tools/call(list_trips) が実データ（沖縄旅行、pagination 反映、isError:false）を返すことを確認

## Notes for reviewer

- 読み取り専用・stdio のため公開ネットワーク面はなく、攻撃面は「キーを持つローカルプロセス」に限定
- MCP SDK は HTTP トランスポートも内包するため express 等を transitive で引くが、本サーバは stdio のみ使用
- README の登録例は `command: "bun", args: ["run", "<絶対パス>/apps/mcp/src/index.ts"]`。生キーは `sk_...` プレースホルダ

## Related

- PR #129（v1 本体）/ #130（OpenAPI docs）
- 設計: `docs/architecture/external-api.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)