### PR TITLE
fix: 中日の滞在中エントリを日の先頭に固定し新規予定が先頭に入るバグを修正

### DIFF
--- a/apps/web/lib/__tests__/merge-timeline.test.ts
+++ b/apps/web/lib/__tests__/merge-timeline.test.ts
@@ -286,6 +286,99 @@ describe("buildMergedTimeline", () => {
   });
 });
 
+describe("buildMergedTimeline with intermediate cross-day entries", () => {
+  function makeIntermediateEntry(overrides: Partial<ScheduleResponse> = {}): CrossDayEntry {
+    return { ...makeCrossDayEntry(overrides), crossDayPosition: "intermediate" };
+  }
+
+  it("pins intermediate entry before a null-startTime schedule (new schedule on a stay-over day)", () => {
+    // Bug repro: adding a schedule (no startTime) on an intermediate stay-over
+    // day must land below the 滞在中 entry, not above it.
+    const schedules = [makeSchedule({ id: "s-new", startTime: undefined })];
+    const crossDayEntries = [makeIntermediateEntry({ id: "hotel", endTime: "11:00" })];
+    expect(ids(buildMergedTimeline(schedules, crossDayEntries))).toEqual(["c-hotel", "s-new"]);
+  });
+
+  it("pins intermediate entry first even when a schedule starts before its endTime", () => {
+    // The endTime is the checkout time on the FINAL day; it must not position
+    // the entry on intermediate days.
+    const schedules = [makeSchedule({ id: "s-10", startTime: "10:00" })];
+    const crossDayEntries = [makeIntermediateEntry({ id: "hotel", endTime: "11:00" })];
+    expect(ids(buildMergedTimeline(schedules, crossDayEntries))).toEqual(["c-hotel", "s-10"]);
+  });
+
+  it("pins intermediate first while final entries still merge by endTime", () => {
+    const schedules = [makeSchedule({ id: "s-11", startTime: "11:00" })];
+    const crossDayEntries = [
+      makeCrossDayEntry({ id: "hotel-b", endTime: "10:00" }),
+      makeIntermediateEntry({ id: "hotel-a", endTime: "12:00" }),
+    ];
+    expect(ids(buildMergedTimeline(schedules, crossDayEntries))).toEqual([
+      "c-hotel-a",
+      "c-hotel-b",
+      "s-11",
+    ]);
+  });
+
+  it("places a new null-startTime schedule after schedules anchored to the intermediate entry", () => {
+    // User scenario: existing schedules were dragged below 滞在中 (anchor
+    // 'after'); a newly added schedule must append at the bottom.
+    const hotelId = "hotel";
+    const schedules = [
+      makeSchedule({
+        id: "anchored",
+        crossDayAnchor: "after",
+        crossDayAnchorSourceId: hotelId,
+        sortOrder: 0,
+      }),
+      makeSchedule({ id: "s-new", startTime: undefined, sortOrder: 1 }),
+    ];
+    const crossDayEntries = [makeIntermediateEntry({ id: hotelId, endTime: "11:00" })];
+    expect(ids(buildMergedTimeline(schedules, crossDayEntries))).toEqual([
+      "c-hotel",
+      "anchored",
+      "s-new",
+    ]);
+  });
+
+  it("keeps anchor='before' schedules above the pinned intermediate entry", () => {
+    const hotelId = "hotel";
+    const schedules = [
+      makeSchedule({
+        id: "b1",
+        crossDayAnchor: "before",
+        crossDayAnchorSourceId: hotelId,
+        sortOrder: 0,
+      }),
+      makeSchedule({ id: "plain", startTime: undefined, sortOrder: 1 }),
+    ];
+    const crossDayEntries = [makeIntermediateEntry({ id: hotelId, endTime: "11:00" })];
+    expect(ids(buildMergedTimeline(schedules, crossDayEntries))).toEqual([
+      "b1",
+      "c-hotel",
+      "plain",
+    ]);
+  });
+
+  it("keeps multiple intermediate entries in source order at the top", () => {
+    const schedules = [makeSchedule({ id: "s1", startTime: undefined })];
+    const crossDayEntries = [
+      makeIntermediateEntry({ id: "hotel-day1", endTime: "11:00" }),
+      makeIntermediateEntry({ id: "hotel-day2", endTime: "10:00" }),
+    ];
+    expect(ids(buildMergedTimeline(schedules, crossDayEntries))).toEqual([
+      "c-hotel-day1",
+      "c-hotel-day2",
+      "s1",
+    ]);
+  });
+
+  it("returns only the intermediate entry when schedules is empty", () => {
+    const crossDayEntries = [makeIntermediateEntry({ id: "hotel", endTime: "11:00" })];
+    expect(ids(buildMergedTimeline([], crossDayEntries))).toEqual(["c-hotel"]);
+  });
+});
+
 describe("buildMergedTimeline with cross-day anchors", () => {
   function makeAnchoredSchedule(
     id: string,

--- a/apps/web/lib/merge-timeline.ts
+++ b/apps/web/lib/merge-timeline.ts
@@ -7,16 +7,22 @@ export type TimelineItem =
 /**
  * Build a merged timeline of schedules and cross-day entries.
  *
+ * Intermediate cross-day entries (the "staying" rows on the middle days of a
+ * multi-night stay) are pinned to the top of the day in source order. Their
+ * endTime is the checkout time on the final day, so it carries no meaning on
+ * intermediate days and must not participate in the time-based merge. Only
+ * final entries merge by endTime.
+ *
  * Schedules with a valid cross-day anchor (both `crossDayAnchor` and
  * `crossDayAnchorSourceId` set, and the source id matching one of the
  * crossDayEntries) are placed immediately before/after their target crossDay
  * and sorted by sortOrder within that slot. All other schedules (including
  * schedules with a broken/stale anchor whose source doesn't match any
  * crossDay) flow through the time-based merge: time-having schedules flush
- * pending crossDays whose endTime is <= the schedule's startTime, and
- * null-startTime schedules do not flush. Remaining crossDays fall through to
- * the end (endTime-having entries sorted by endTime, then null-endTime
- * entries).
+ * pending final crossDays whose endTime is <= the schedule's startTime, and
+ * null-startTime schedules do not flush. Remaining final crossDays fall
+ * through to the end (endTime-having entries sorted by endTime, then
+ * null-endTime entries).
  */
 export function buildMergedTimeline(
   schedules: ScheduleResponse[],
@@ -26,7 +32,12 @@ export function buildMergedTimeline(
     return schedules.map((schedule) => ({ type: "schedule", schedule }));
   }
 
+  // Anchors may target intermediate entries too, so validity checks against
+  // the full entry list, not just the time-merged (final) subset.
   const validSourceIds = new Set(crossDayEntries.map((e) => e.schedule.id));
+
+  const intermediateEntries = crossDayEntries.filter((e) => e.crossDayPosition === "intermediate");
+  const finalEntries = crossDayEntries.filter((e) => e.crossDayPosition !== "intermediate");
 
   const anchoredBefore: ScheduleResponse[] = [];
   const anchoredAfter: ScheduleResponse[] = [];
@@ -43,7 +54,10 @@ export function buildMergedTimeline(
     }
   }
 
-  const merged = timeBasedMerge(plainSchedules, crossDayEntries);
+  const merged = timeBasedMerge(plainSchedules, finalEntries);
+  merged.unshift(
+    ...intermediateEntries.map((entry): TimelineItem => ({ type: "crossDay", entry })),
+  );
 
   // Skip the bucket-and-splice pass entirely when no schedules carry a
   // cross-day anchor — the time-based merge above is already the final order.

--- a/apps/web/lib/merge-timeline.ts
+++ b/apps/web/lib/merge-timeline.ts
@@ -37,7 +37,7 @@ export function buildMergedTimeline(
   const validSourceIds = new Set(crossDayEntries.map((e) => e.schedule.id));
 
   const intermediateEntries = crossDayEntries.filter((e) => e.crossDayPosition === "intermediate");
-  const finalEntries = crossDayEntries.filter((e) => e.crossDayPosition !== "intermediate");
+  const finalEntries = crossDayEntries.filter((e) => e.crossDayPosition === "final");
 
   const anchoredBefore: ScheduleResponse[] = [];
   const anchoredAfter: ScheduleResponse[] = [];


### PR DESCRIPTION
## Summary

2泊以上の宿泊がある中日(「滞在中」表示の日)に時刻なしの新規予定を追加すると、リストの先頭(滞在中より上)に挿入されるバグを修正。

### 原因

中日の「滞在中」は `getCrossDayEntries` が生成する合成 crossDay エントリ (`crossDayPosition: "intermediate"`) だが、`buildMergedTimeline` → `timeBasedMerge` が position を見ずに endTime(=最終日のチェックアウト時刻)で時間マージしていた。時刻なしスケジュールは crossDay を flush しないため、未消化の滞在中が末尾に回り、新規予定が先頭に並んでいた。

### 修正

- intermediate エントリは時間マージから除外し、常にその日の先頭に固定(中日は終日滞在のため)
- final エントリ(チェックアウト)は従来どおり endTime ベースで配置
- anchor (`before`/`after`) の splice 処理は変更なし。滞在中の上に出したい場合は従来どおり anchor "before"(ドラッグ)で可能

### 挙動変更の留意点

中日に時刻あり予定がある場合の滞在中の表示位置も常に先頭に変わる(従来は endTime との比較位置)。終日滞在の表現として意図した変更。

## Test plan

- [x] `merge-timeline.test.ts` に intermediate エントリの回帰テスト 7 件を追加(バグ再現 → red 確認 → 実装 → green)
- [x] `bun run --filter @sugara/web test` 721 件 green
- [x] `bun run --filter @sugara/web lint` / `check-types` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)