### PR TITLE
fix: ドラッグ中のカードシフトを廃止し挿入線とのズレを解消

### DIFF
--- a/apps/web/app/(authenticated)/trips/[id]/page.tsx
+++ b/apps/web/app/(authenticated)/trips/[id]/page.tsx
@@ -899,6 +899,7 @@ export default function TripDetailPage() {
                 collisionDetection={dnd.collisionDetection}
                 onDragStart={dnd.handleDragStart}
                 onDragOver={dnd.handleDragOver}
+                onDragMove={dnd.handleDragMove}
                 onDragEnd={dnd.handleDragEnd}
                 accessibility={{ announcements: dndAnnouncements }}
               >

--- a/apps/web/app/(sp)/sp/trips/[id]/page.tsx
+++ b/apps/web/app/(sp)/sp/trips/[id]/page.tsx
@@ -587,6 +587,7 @@ export default function SpTripDetailPage() {
                   collisionDetection={dnd.collisionDetection}
                   onDragStart={dnd.handleDragStart}
                   onDragOver={dnd.handleDragOver}
+                  onDragMove={dnd.handleDragMove}
                   onDragEnd={dnd.handleDragEnd}
                   accessibility={{ announcements: undefined }}
                 >

--- a/apps/web/components/candidate-list.tsx
+++ b/apps/web/components/candidate-list.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import { SortableContext } from "@dnd-kit/sortable";
 import type { CandidateResponse } from "@sugara/shared";
 import { useTranslations } from "next-intl";
 import { memo } from "react";
 import { EmptyState } from "@/components/ui/empty-state";
 import { DROP_ZONE_ACTIVE } from "@/lib/colors";
+import { noShiftSortingStrategy } from "@/lib/dnd-sorting";
 import { cn } from "@/lib/utils";
 import { CandidateItem } from "./candidate-item";
 import { DndInsertIndicator } from "./dnd-insert-indicator";
@@ -105,7 +106,7 @@ export const CandidateList = memo(function CandidateList({
   if (draggable) {
     return (
       <div ref={droppableRef}>
-        <SortableContext items={candidates.map((c) => c.id)} strategy={verticalListSortingStrategy}>
+        <SortableContext items={candidates.map((c) => c.id)} strategy={noShiftSortingStrategy}>
           {candidates.length === 0 ? (
             <div
               className={cn(

--- a/apps/web/components/day-timeline.tsx
+++ b/apps/web/components/day-timeline.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useDroppable } from "@dnd-kit/core";
-import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import { SortableContext } from "@dnd-kit/sortable";
 import type { CrossDayEntry, ScheduleResponse, TripResponse } from "@sugara/shared";
 import { useQueryClient } from "@tanstack/react-query";
 import {
@@ -30,11 +30,10 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { api } from "@/lib/api";
 import { DROP_ZONE_ACTIVE } from "@/lib/colors";
+import { noShiftSortingStrategy } from "@/lib/dnd-sorting";
 import { compareByStartTime, formatDate } from "@/lib/format";
-
 import { useSelection } from "@/lib/hooks/selection-context";
 import { useMobile } from "@/lib/hooks/use-is-mobile";
-
 import type { TimelineItem } from "@/lib/merge-timeline";
 import { buildMergedTimeline, timelineSortableIds } from "@/lib/merge-timeline";
 import { queryKeys } from "@/lib/query-keys";
@@ -479,7 +478,7 @@ export function DayTimeline({
         </div>
       ) : (
         <div ref={setDroppableRef}>
-          <SortableContext items={sortableIds} strategy={verticalListSortingStrategy}>
+          <SortableContext items={sortableIds} strategy={noShiftSortingStrategy}>
             <div className="space-y-1.5">
               {merged.map((item, i) => {
                 const next = merged[i + 1];

--- a/apps/web/components/day-timeline.tsx
+++ b/apps/web/components/day-timeline.tsx
@@ -31,6 +31,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { api } from "@/lib/api";
 import { DROP_ZONE_ACTIVE } from "@/lib/colors";
 import { noShiftSortingStrategy } from "@/lib/dnd-sorting";
+import { indicatorGapIndex } from "@/lib/drop-position";
 import { compareByStartTime, formatDate } from "@/lib/format";
 import { useSelection } from "@/lib/hooks/selection-context";
 import { useMobile } from "@/lib/hooks/use-is-mobile";
@@ -199,19 +200,26 @@ export function DayTimeline({
   const scheduleIndexById = useMemo(() => new Map(schedules.map((s, i) => [s.id, i])), [schedules]);
 
   const inlineIndicator = <DndInsertIndicator />;
-  // Indicator side mirrors `upperHalf` from the drag-over event so the blue
-  // line renders on the same edge the drop will actually land on.
-  const overlayIndicator = (
-    <DndInsertIndicator overlay position={overUpperHalf ? "top" : "bottom"} />
+  // The hovered card + upperHalf pair is normalized to a gap index so that
+  // "lower half of item i" and "upper half of item i+1" — which drop into the
+  // same position — render the line at one canonical spot instead of two.
+  const insertGapIndex = useMemo(
+    () => indicatorGapIndex(sortableIds, overScheduleId ?? null, overUpperHalf),
+    [sortableIds, overScheduleId, overUpperHalf],
   );
 
   function renderItem(item: TimelineItem, i: number, opts?: { selectable?: boolean }) {
     const isFirst = i === 0;
     const isLast = i === merged.length - 1;
 
-    const sortableId =
-      item.type === "crossDay" ? `cross-${item.entry.schedule.id}` : item.schedule.id;
-    const showInsertIndicator = overScheduleId != null && sortableId === overScheduleId;
+    // Gap k renders above item k; the "after the last item" gap (k === length)
+    // renders on the bottom edge of the last item.
+    const overlayIndicator =
+      insertGapIndex === i ? (
+        <DndInsertIndicator overlay position="top" />
+      ) : isLast && insertGapIndex === merged.length ? (
+        <DndInsertIndicator overlay position="bottom" />
+      ) : null;
 
     if (item.type === "crossDay") {
       const {
@@ -225,7 +233,7 @@ export function DayTimeline({
         totalDays != null ? totalDays - sourceDayNumber : maxEndDayOffset;
       return (
         <div key={`cross-${s.id}`} className="relative">
-          {showInsertIndicator && overlayIndicator}
+          {overlayIndicator}
           <ScheduleItem
             {...s}
             tripId={tripId}
@@ -259,7 +267,7 @@ export function DayTimeline({
 
     return (
       <div key={schedule.id} className="relative">
-        {showInsertIndicator && overlayIndicator}
+        {overlayIndicator}
         <ScheduleItem
           {...schedule}
           tripId={tripId}

--- a/apps/web/lib/__tests__/dnd-sorting.test.ts
+++ b/apps/web/lib/__tests__/dnd-sorting.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { noShiftSortingStrategy } from "../dnd-sorting";
+
+function makeRect(top: number) {
+  return { width: 800, height: 100, top, left: 0, right: 800, bottom: top + 100 };
+}
+
+describe("noShiftSortingStrategy", () => {
+  it("never translates neighbor items while dragging", () => {
+    // The DndInsertIndicator line is the single insertion cue; items must
+    // stay put so the line, the cards, and dnd-kit hit-testing agree.
+    const transform = noShiftSortingStrategy({
+      activeIndex: 0,
+      activeNodeRect: makeRect(0),
+      index: 1,
+      rects: [makeRect(0), makeRect(110), makeRect(220)],
+      overIndex: 2,
+    });
+    expect(transform).toBeNull();
+  });
+});

--- a/apps/web/lib/__tests__/drop-position.test.ts
+++ b/apps/web/lib/__tests__/drop-position.test.ts
@@ -8,6 +8,7 @@ import {
   type DropTarget,
   indicatorGapIndex,
   isOverUpperHalf,
+  timelineEdge,
 } from "../drop-position";
 
 function makeSchedule(overrides: Partial<ScheduleResponse> = {}): ScheduleResponse {
@@ -558,6 +559,37 @@ describe("computeScheduleReorderResult returns anchor info for crossDay drops", 
     const result = computeScheduleReorderResult([s0, sOther], [hotelEarly], "sOther", target);
     expect(result).not.toBeNull();
     expect(result?.anchor).toEqual({ anchor: null, anchorSourceId: null });
+  });
+});
+
+describe("timelineEdge", () => {
+  const rect = { top: 100, bottom: 500 };
+
+  it("returns head when the pointer is above the zone top", () => {
+    expect(timelineEdge(new PointerEvent("pointermove", { clientY: 50 }), 0, rect)).toBe("head");
+  });
+
+  it("returns tail when the pointer is below the zone bottom", () => {
+    expect(timelineEdge(new PointerEvent("pointermove", { clientY: 600 }), 0, rect)).toBe("tail");
+  });
+
+  it("returns inside when the pointer is within the zone", () => {
+    expect(timelineEdge(new PointerEvent("pointermove", { clientY: 300 }), 0, rect)).toBe("inside");
+  });
+
+  it("offsets the activation position by the drag delta", () => {
+    // Grabbed at y=300 (inside), dragged up by 250 → now above the top.
+    expect(timelineEdge(new PointerEvent("pointermove", { clientY: 300 }), -250, rect)).toBe(
+      "head",
+    );
+  });
+
+  it("returns null when the rect is missing", () => {
+    expect(timelineEdge(new PointerEvent("pointermove", { clientY: 50 }), 0, null)).toBeNull();
+  });
+
+  it("returns null when the activator event has no pointer position", () => {
+    expect(timelineEdge(null, 0, rect)).toBeNull();
   });
 });
 

--- a/apps/web/lib/__tests__/drop-position.test.ts
+++ b/apps/web/lib/__tests__/drop-position.test.ts
@@ -6,6 +6,7 @@ import {
   computeScheduleReorderIndex,
   computeScheduleReorderResult,
   type DropTarget,
+  indicatorGapIndex,
   isOverUpperHalf,
 } from "../drop-position";
 
@@ -557,5 +558,35 @@ describe("computeScheduleReorderResult returns anchor info for crossDay drops", 
     const result = computeScheduleReorderResult([s0, sOther], [hotelEarly], "sOther", target);
     expect(result).not.toBeNull();
     expect(result?.anchor).toEqual({ anchor: null, anchorSourceId: null });
+  });
+});
+
+describe("indicatorGapIndex", () => {
+  const ids = ["s1", "s2", "s3"];
+
+  it("maps upper half of an item to the gap above it", () => {
+    expect(indicatorGapIndex(ids, "s2", true)).toBe(1);
+  });
+
+  it("maps lower half of an item to the gap below it", () => {
+    expect(indicatorGapIndex(ids, "s1", false)).toBe(1);
+  });
+
+  it("collapses lower half of item i and upper half of item i+1 into the same gap", () => {
+    // The user-visible bug: these two hover states drop into the same
+    // position but used to render the line at two different spots.
+    expect(indicatorGapIndex(ids, "s1", false)).toBe(indicatorGapIndex(ids, "s2", true));
+  });
+
+  it("maps lower half of the last item to the after-end gap", () => {
+    expect(indicatorGapIndex(ids, "s3", false)).toBe(3);
+  });
+
+  it("returns null when overId is null", () => {
+    expect(indicatorGapIndex(ids, null, true)).toBeNull();
+  });
+
+  it("returns null when overId is not in the list", () => {
+    expect(indicatorGapIndex(ids, "missing", true)).toBeNull();
   });
 });

--- a/apps/web/lib/dnd-sorting.ts
+++ b/apps/web/lib/dnd-sorting.ts
@@ -1,0 +1,13 @@
+import type { SortingStrategy } from "@dnd-kit/sortable";
+
+/**
+ * Sorting strategy that never translates items while dragging.
+ *
+ * The timelines render their own DndInsertIndicator line as the single
+ * insertion-point cue. verticalListSortingStrategy would additionally shift
+ * neighbor cards to "make room", but dnd-kit's hit-testing and the indicator
+ * overlay both use the unshifted layout rects, so the shifted cards drift
+ * away from both the blue line and the actual drop targets. Keeping items
+ * static makes the visuals, the indicator, and the hit-testing agree.
+ */
+export const noShiftSortingStrategy: SortingStrategy = () => null;

--- a/apps/web/lib/drop-position.ts
+++ b/apps/web/lib/drop-position.ts
@@ -24,6 +24,27 @@ export function isOverUpperHalf(
   return currentY < midY;
 }
 
+/**
+ * Canonical gap index for the insert indicator line.
+ *
+ * Hovering the lower half of item i and the upper half of item i+1 both drop
+ * into the same gap, but rendering the line on "bottom of i" vs "top of i+1"
+ * produces two visually distinct positions for one insertion point (the list
+ * has inter-item spacing). Normalizing to a gap index lets the caller render
+ * a single line per gap: index k means "the gap above item k", and
+ * k === items.length means "after the last item".
+ */
+export function indicatorGapIndex(
+  sortableIds: string[],
+  overId: string | null,
+  upperHalf: boolean,
+): number | null {
+  if (overId == null) return null;
+  const idx = sortableIds.indexOf(overId);
+  if (idx === -1) return null;
+  return upperHalf ? idx : idx + 1;
+}
+
 export type DropTarget =
   | { kind: "schedule"; overId: string; upperHalf: boolean }
   | { kind: "timeline" }

--- a/apps/web/lib/drop-position.ts
+++ b/apps/web/lib/drop-position.ts
@@ -1,16 +1,9 @@
 import type { CrossDayEntry, ScheduleResponse } from "@sugara/shared";
 import { buildMergedTimeline, type TimelineItem, timelineSortableIds } from "./merge-timeline";
 
-/**
- * Determine whether the pointer currently sits in the upper half of the
- * drop target's bounding rect. Works with pointer, mouse, and touch events.
- */
-export function isOverUpperHalf(
-  activatorEvent: Event | null,
-  deltaY: number,
-  overRect: { top: number; height: number } | null | undefined,
-): boolean {
-  if (!overRect || !activatorEvent) return false;
+/** Current pointer Y = activation position + drag delta. Works with pointer, mouse, and touch events. */
+function resolvePointerY(activatorEvent: Event | null, deltaY: number): number | null {
+  if (!activatorEvent) return null;
   let startY: number | null = null;
   const ev = activatorEvent as PointerEvent | MouseEvent | TouchEvent;
   if ("clientY" in ev && typeof ev.clientY === "number") {
@@ -18,10 +11,44 @@ export function isOverUpperHalf(
   } else if ("touches" in ev && ev.touches?.[0]) {
     startY = ev.touches[0].clientY;
   }
-  if (startY == null) return false;
-  const currentY = startY + deltaY;
+  if (startY == null) return null;
+  return startY + deltaY;
+}
+
+/**
+ * Determine whether the pointer currently sits in the upper half of the
+ * drop target's bounding rect.
+ */
+export function isOverUpperHalf(
+  activatorEvent: Event | null,
+  deltaY: number,
+  overRect: { top: number; height: number } | null | undefined,
+): boolean {
+  if (!overRect) return false;
+  const currentY = resolvePointerY(activatorEvent, deltaY);
+  if (currentY == null) return false;
   const midY = overRect.top + overRect.height / 2;
   return currentY < midY;
+}
+
+/**
+ * Locate the pointer relative to the timeline zone rect. The wrapper
+ * droppable wins the collision only when the pointer is outside every card —
+ * above the list ("head", insert at the top), below it ("tail", append at the
+ * end), or in a gap the wrapper happened to steal ("inside", where callers
+ * should keep their previous, more specific target).
+ */
+export function timelineEdge(
+  activatorEvent: Event | null,
+  deltaY: number,
+  rect: { top: number; bottom: number } | null | undefined,
+): "head" | "tail" | "inside" | null {
+  if (!rect) return null;
+  const currentY = resolvePointerY(activatorEvent, deltaY);
+  if (currentY == null) return null;
+  if (currentY < rect.top) return "head";
+  if (currentY > rect.bottom) return "tail";
+  return "inside";
 }
 
 /**

--- a/apps/web/lib/hooks/use-trip-drag-and-drop.test.ts
+++ b/apps/web/lib/hooks/use-trip-drag-and-drop.test.ts
@@ -275,6 +275,120 @@ describe("useTripDragAndDrop — null-based snapshot isolation", () => {
     expect(result.current.overScheduleId).toBe("s2");
   });
 
+  it("targets the first item's upper half when pointer is above the timeline zone", () => {
+    const { result } = renderHook(() =>
+      useTripDragAndDrop({
+        tripId: "trip1",
+        currentDayId: "day1",
+        currentPatternId: "pattern1",
+        schedules: [s1, s2],
+        candidates: [],
+        onDone: vi.fn(),
+      }),
+    );
+
+    act(() => {
+      result.current.handleDragStart({
+        active: {
+          id: "s2",
+          data: { current: { type: "schedule" } },
+          rect: { current: { initial: null, translated: null } },
+        },
+        activatorEvent: new PointerEvent("pointerdown"),
+      } as Parameters<typeof result.current.handleDragStart>[0]);
+    });
+
+    // Pointer above the timeline zone top (clientY 50 < rect.top 100)
+    act(() => {
+      result.current.handleDragOver({
+        active: {
+          id: "s2",
+          data: { current: { type: "schedule" } },
+          rect: { current: { initial: null, translated: null } },
+        },
+        over: {
+          id: "timeline",
+          data: { current: { type: "timeline" } },
+          rect: { width: 800, height: 400, top: 100, left: 0, bottom: 500, right: 800 },
+          disabled: false,
+        },
+        collisions: null,
+        delta: { x: 0, y: 0 },
+        activatorEvent: new PointerEvent("pointermove", { clientY: 50 }),
+      } as Parameters<typeof result.current.handleDragOver>[0]);
+    });
+
+    expect(result.current.overScheduleId).toBe("s1");
+    expect(result.current.overUpperHalf).toBe(true);
+  });
+
+  it("clears overScheduleId when pointer is below the timeline zone", () => {
+    const { result } = renderHook(() =>
+      useTripDragAndDrop({
+        tripId: "trip1",
+        currentDayId: "day1",
+        currentPatternId: "pattern1",
+        schedules: [s1, s2],
+        candidates: [],
+        onDone: vi.fn(),
+      }),
+    );
+
+    act(() => {
+      result.current.handleDragStart({
+        active: {
+          id: "s1",
+          data: { current: { type: "schedule" } },
+          rect: { current: { initial: null, translated: null } },
+        },
+        activatorEvent: new PointerEvent("pointerdown"),
+      } as Parameters<typeof result.current.handleDragStart>[0]);
+    });
+
+    // Hover a card first so overScheduleId is non-null
+    act(() => {
+      result.current.handleDragOver({
+        active: {
+          id: "s1",
+          data: { current: { type: "schedule" } },
+          rect: { current: { initial: null, translated: null } },
+        },
+        over: {
+          id: "s2",
+          data: { current: { type: "schedule" } },
+          rect: { width: 800, height: 100, top: 300, left: 0, bottom: 400, right: 800 },
+          disabled: false,
+        },
+        collisions: null,
+        delta: { x: 0, y: 0 },
+        activatorEvent: new PointerEvent("pointermove", { clientY: 350 }),
+      } as Parameters<typeof result.current.handleDragOver>[0]);
+    });
+    expect(result.current.overScheduleId).toBe("s2");
+
+    // Pointer below the timeline zone bottom (clientY 600 > rect.bottom 500)
+    act(() => {
+      result.current.handleDragOver({
+        active: {
+          id: "s1",
+          data: { current: { type: "schedule" } },
+          rect: { current: { initial: null, translated: null } },
+        },
+        over: {
+          id: "timeline",
+          data: { current: { type: "timeline" } },
+          rect: { width: 800, height: 400, top: 100, left: 0, bottom: 500, right: 800 },
+          disabled: false,
+        },
+        collisions: null,
+        delta: { x: 0, y: 0 },
+        activatorEvent: new PointerEvent("pointermove", { clientY: 600 }),
+      } as Parameters<typeof result.current.handleDragOver>[0]);
+    });
+
+    expect(result.current.overScheduleId).toBeNull();
+  });
+
   it("keeps overScheduleId when over becomes null during drag", () => {
     const { result } = renderHook(() =>
       useTripDragAndDrop({

--- a/apps/web/lib/hooks/use-trip-drag-and-drop.test.ts
+++ b/apps/web/lib/hooks/use-trip-drag-and-drop.test.ts
@@ -322,6 +322,74 @@ describe("useTripDragAndDrop — null-based snapshot isolation", () => {
     expect(result.current.overUpperHalf).toBe(true);
   });
 
+  it("resolves head via onDragMove when pointer rises above the zone without an over change", () => {
+    // dnd-kit fires onDragOver only when the over target changes. Moving the
+    // pointer above the list while the timeline wrapper stays the over target
+    // emits onDragMove only — the head state must be reachable from there.
+    const { result } = renderHook(() =>
+      useTripDragAndDrop({
+        tripId: "trip1",
+        currentDayId: "day1",
+        currentPatternId: "pattern1",
+        schedules: [s1, s2],
+        candidates: [],
+        onDone: vi.fn(),
+      }),
+    );
+
+    act(() => {
+      result.current.handleDragStart({
+        active: {
+          id: "s2",
+          data: { current: { type: "schedule" } },
+          rect: { current: { initial: null, translated: null } },
+        },
+        activatorEvent: new PointerEvent("pointerdown"),
+      } as Parameters<typeof result.current.handleDragStart>[0]);
+    });
+
+    const timelineOver = {
+      id: "timeline",
+      data: { current: { type: "timeline" } },
+      rect: { width: 800, height: 400, top: 100, left: 0, bottom: 500, right: 800 },
+      disabled: false,
+    };
+
+    // over flips to the wrapper while the pointer is still inside it → keep
+    act(() => {
+      result.current.handleDragOver({
+        active: {
+          id: "s2",
+          data: { current: { type: "schedule" } },
+          rect: { current: { initial: null, translated: null } },
+        },
+        over: timelineOver,
+        collisions: null,
+        delta: { x: 0, y: 0 },
+        activatorEvent: new PointerEvent("pointermove", { clientY: 150 }),
+      } as Parameters<typeof result.current.handleDragOver>[0]);
+    });
+    expect(result.current.overScheduleId).toBeNull();
+
+    // pointer rises above the zone top; over unchanged → only onDragMove fires
+    act(() => {
+      result.current.handleDragMove({
+        active: {
+          id: "s2",
+          data: { current: { type: "schedule" } },
+          rect: { current: { initial: null, translated: null } },
+        },
+        over: timelineOver,
+        collisions: null,
+        delta: { x: 0, y: -100 },
+        activatorEvent: new PointerEvent("pointermove", { clientY: 150 }),
+      } as Parameters<typeof result.current.handleDragMove>[0]);
+    });
+
+    expect(result.current.overScheduleId).toBe("s1");
+    expect(result.current.overUpperHalf).toBe(true);
+  });
+
   it("clears overScheduleId when pointer is below the timeline zone", () => {
     const { result } = renderHook(() =>
       useTripDragAndDrop({

--- a/apps/web/lib/hooks/use-trip-drag-and-drop.ts
+++ b/apps/web/lib/hooks/use-trip-drag-and-drop.ts
@@ -2,6 +2,7 @@ import {
   type CollisionDetection,
   closestCorners,
   type DragEndEvent,
+  type DragMoveEvent,
   type DragOverEvent,
   type DragStartEvent,
   MouseSensor,
@@ -198,7 +199,13 @@ export function useTripDragAndDrop({
     return ids.length > 0 ? ids[0] : null;
   }
 
-  function handleDragOver(event: DragOverEvent) {
+  // Shared by onDragOver and onDragMove. dnd-kit fires onDragOver only when
+  // the over target CHANGES — moving the pointer within the same droppable
+  // (e.g. lifting it above the list while the timeline wrapper stays the
+  // over target, or crossing a card's midline) emits no onDragOver. The
+  // position-dependent state (upperHalf, head/tail edge) therefore must also
+  // be re-evaluated from onDragMove, which fires on every movement.
+  function updateOverState(event: DragOverEvent | DragMoveEvent) {
     const { over, activatorEvent, delta } = event;
     if (!over) {
       // Keep overScheduleId so the insert indicator doesn't jump to the
@@ -241,6 +248,14 @@ export function useTripDragAndDrop({
       setOverCandidateId(null);
       setLastOverZone(null);
     }
+  }
+
+  function handleDragOver(event: DragOverEvent) {
+    updateOverState(event);
+  }
+
+  function handleDragMove(event: DragMoveEvent) {
+    updateOverState(event);
   }
 
   async function handleDragEnd(event: DragEndEvent) {
@@ -642,6 +657,7 @@ export function useTripDragAndDrop({
     localCandidates: localCandidates ?? candidates,
     handleDragStart,
     handleDragOver,
+    handleDragMove,
     handleDragEnd,
     reorderSchedule,
     reorderCandidate,

--- a/apps/web/lib/hooks/use-trip-drag-and-drop.ts
+++ b/apps/web/lib/hooks/use-trip-drag-and-drop.ts
@@ -27,8 +27,9 @@ import {
   computeScheduleReorderResult,
   type DropTarget,
   isOverUpperHalf,
+  timelineEdge,
 } from "@/lib/drop-position";
-import { buildMergedTimeline } from "@/lib/merge-timeline";
+import { buildMergedTimeline, timelineSortableIds } from "@/lib/merge-timeline";
 
 type ActiveDragItem = {
   id: string;
@@ -64,6 +65,7 @@ const TOUCH_SENSOR_OPTIONS = {
 function buildDropTarget(
   event: DragEndEvent,
   savedLastOverZone: "timeline" | "candidates" | null,
+  headSortableId: string | null,
 ): DropTarget {
   const { over, activatorEvent, delta } = event;
   if (!over) {
@@ -87,6 +89,17 @@ function buildDropTarget(
   }
   const overType = over.data.current?.type as string | undefined;
   if (overType === "timeline" || overType === "candidates") {
+    // The wrapper wins the collision when the pointer is outside every card.
+    // Above the list that means "insert at the head" — resolve to the first
+    // sortable's upper half so the drop shares the schedule-target semantics
+    // (insert index and crossDay anchor inference) with the indicator.
+    if (
+      overType === "timeline" &&
+      headSortableId != null &&
+      timelineEdge(activatorEvent, delta.y, over.rect) === "head"
+    ) {
+      return { kind: "schedule", overId: headSortableId, upperHalf: true };
+    }
     return { kind: "timeline" };
   }
   if (overType === "schedule" || overType === "candidate") {
@@ -177,6 +190,14 @@ export function useTripDragAndDrop({
     setLocalCandidates([...candidates]);
   }
 
+  // First sortable id of the merged timeline (crossDay entries included) —
+  // the target the "drag above the list" head case resolves to.
+  function firstTimelineSortableId(): string | null {
+    const merged = buildMergedTimeline(localSchedules ?? schedules, crossDayEntries);
+    const ids = timelineSortableIds(merged);
+    return ids.length > 0 ? ids[0] : null;
+  }
+
   function handleDragOver(event: DragOverEvent) {
     const { over, activatorEvent, delta } = event;
     if (!over) {
@@ -187,13 +208,25 @@ export function useTripDragAndDrop({
     }
     const overType = over.data.current?.type as string | undefined;
     if (overType === "schedule" || overType === "timeline") {
-      // Only update overScheduleId when hovering a specific schedule.
-      // When hovering the timeline droppable (gap between items), keep the
-      // previous value so the insert indicator doesn't briefly jump to the
-      // bottom of the list.
       if (overType === "schedule") {
         setOverScheduleId(String(over.id));
         setOverUpperHalf(isOverUpperHalf(activatorEvent, delta.y, over.rect));
+      } else {
+        // The timeline wrapper wins the collision only when the pointer is
+        // outside every card. Above the list = the head gap; below = the
+        // append-at-end inline indicator (overScheduleId null). "inside"
+        // (a gap the wrapper stole) keeps the previous, more specific value
+        // so the indicator doesn't briefly jump while crossing gaps.
+        const edge = timelineEdge(activatorEvent, delta.y, over.rect);
+        if (edge === "head") {
+          const headId = firstTimelineSortableId();
+          if (headId != null) {
+            setOverScheduleId(headId);
+            setOverUpperHalf(true);
+          }
+        } else if (edge === "tail") {
+          setOverScheduleId(null);
+        }
       }
       setOverCandidateId(null);
       setLastOverZone("timeline");
@@ -248,7 +281,7 @@ export function useTripDragAndDrop({
         const activeIdx = currentSchedules.findIndex((s) => s.id === activeId);
         if (activeIdx === -1) return;
 
-        const target = buildDropTarget(event, savedLastOverZone);
+        const target = buildDropTarget(event, savedLastOverZone, firstTimelineSortableId());
         const reorderResult = computeScheduleReorderResult(
           currentSchedules,
           crossDayEntries,
@@ -368,7 +401,7 @@ export function useTripDragAndDrop({
 
         setLocalCandidates(currentCandidates.filter((c) => c.id !== active.id));
 
-        const target = buildDropTarget(event, savedLastOverZone);
+        const target = buildDropTarget(event, savedLastOverZone, firstTimelineSortableId());
         const { insertIndex: insertIdx, anchor } = computeCandidateDropResult(
           currentSchedules,
           crossDayEntries,


### PR DESCRIPTION
## Summary

DnD の挿入インジケーター(青い線)とドロップ位置の整合性を3点修正。

### 1. ドラッグ中のカードシフトとのズレ

カード本体は `verticalListSortingStrategy` の「場所空け」translate でシフトする一方、挿入線は静的ラッパーに固定、当たり判定はシフト前の rect を使うため、線がカードの中腹を横切っていた。カードを動かさない `noShiftSortingStrategy` (`apps/web/lib/dnd-sorting.ts`) に置き換え、青い線を唯一の挿入位置表示とした(タイムライン・候補リスト両方)。

### 2. 同じ隙間に線の位置が2状態あった問題

「前カードの下半分」と「次カードの上半分」はドロップ結果が同じなのに線が別座標に描かれていた。hover 対象 + upperHalf を gap index に正規化する `indicatorGapIndex` (`apps/web/lib/drop-position.ts`) を導入し、挿入位置1つにつき線の描画位置を1つにした。

### 3. リスト先頭より上にドラッグすると線が出ず、ドロップが末尾に行く問題

先頭カードより上では over が timeline ラッパーになり、線は直前の隙間に残ったまま、ドロップは末尾追加として処理されていた。ポインタ位置をラッパー rect と比較する `timelineEdge` を追加し、上端より上は「先頭アイテムの上半分」ターゲットに解決(線は先頭に表示、ドロップは先頭挿入、crossDay anchor 推論も共通)。下端より下は末尾のインライン線を表示。rect 内側(隙間)は従来どおり直前のターゲットを維持。

## Test plan

- [x] `noShiftSortingStrategy` / `indicatorGapIndex` / `timelineEdge` の単体テスト、hook の head/tail hover テストを追加
- [x] `bun run --filter @sugara/web test` 736 件 green
- [x] lint / check-types green
- [ ] 手動確認: Preview でドラッグ中に (1) 他カードが動かない (2) 線がカード境界に1位置で出る (3) 先頭より上に持っていくと線が先頭に出て、ドロップで先頭に入る (4) 最後尾より下では末尾に線が出る こと

🤖 Generated with [Claude Code](https://claude.com/claude-code)