### PR TITLE
fix: SP版で滞在中エントリより上に予定を並び替えできないバグを修正

### DIFF
--- a/apps/web/components/day-timeline.test.tsx
+++ b/apps/web/components/day-timeline.test.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import type { CrossDayEntry, ScheduleResponse } from "@sugara/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { SelectionProvider } from "@/lib/hooks/selection-context";
+import { MobileContext } from "@/lib/hooks/use-is-mobile";
+import { renderWithIntl } from "@/lib/test-utils";
+import { DayTimeline } from "./day-timeline";
+
+// useSortable/useDroppable need no real DndContext here; dnd-kit returns no-op refs.
+
+const noop = () => {};
+const asyncNoop = async () => {};
+
+const selectionStub = {
+  selectionTarget: null,
+  selectedIds: new Set<string>(),
+  batchLoading: false,
+  batchDeleteOpen: false,
+  setBatchDeleteOpen: noop,
+  enter: noop,
+  exit: noop,
+  toggle: noop,
+  selectAll: noop,
+  deselectAll: noop,
+  batchAssign: asyncNoop,
+  batchUnassign: asyncNoop,
+  batchDelete: asyncNoop,
+  batchDuplicateCandidates: asyncNoop,
+  batchDuplicateSchedules: asyncNoop,
+  canEnter: false,
+};
+
+function makeSchedule(overrides: Partial<ScheduleResponse> = {}): ScheduleResponse {
+  return {
+    id: "s1",
+    name: "Spot",
+    category: "sightseeing",
+    address: null,
+    startTime: null,
+    endTime: null,
+    sortOrder: 0,
+    memo: null,
+    urls: [],
+    color: "blue",
+    endDayOffset: null,
+    updatedAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeIntermediateEntry(): CrossDayEntry {
+  return {
+    schedule: makeSchedule({ id: "hotel1", name: "Hotel", category: "hotel" }),
+    sourceDayId: "d0",
+    sourcePatternId: "p0",
+    sourceDayNumber: 1,
+    crossDayPosition: "intermediate",
+  };
+}
+
+function renderTimeline({
+  schedules,
+  crossDayEntries,
+}: {
+  schedules: ScheduleResponse[];
+  crossDayEntries?: CrossDayEntry[];
+}) {
+  const queryClient = new QueryClient();
+  return renderWithIntl(
+    <QueryClientProvider client={queryClient}>
+      <MobileContext.Provider value={true}>
+        <SelectionProvider value={selectionStub}>
+          <DayTimeline
+            tripId="t1"
+            dayId="d1"
+            patternId="p1"
+            date="2026-06-11"
+            schedules={schedules}
+            crossDayEntries={crossDayEntries}
+            onRefresh={noop}
+            onReorderSchedule={noop}
+            scheduleLimitReached
+          />
+        </SelectionProvider>
+      </MobileContext.Provider>
+    </QueryClientProvider>,
+  );
+}
+
+function enterReorderMode() {
+  fireEvent.click(screen.getByRole("button", { name: "並び替え" }));
+}
+
+afterEach(cleanup);
+
+describe("DayTimeline mobile reorder with cross-day entries", () => {
+  it("enables the up button on the first schedule when a staying entry is pinned above it", () => {
+    renderTimeline({
+      schedules: [makeSchedule({ id: "s1" }), makeSchedule({ id: "s2", sortOrder: 1 })],
+      crossDayEntries: [makeIntermediateEntry()],
+    });
+    enterReorderMode();
+
+    // Merged timeline: [staying entry, s1, s2] — s1 can still move above the entry via anchor.
+    const upButtons = screen.getAllByLabelText("上に移動");
+    expect(upButtons[0].hasAttribute("disabled")).toBe(false);
+  });
+
+  it("keeps the up button disabled on the first schedule when nothing is above it", () => {
+    renderTimeline({
+      schedules: [makeSchedule({ id: "s1" }), makeSchedule({ id: "s2", sortOrder: 1 })],
+    });
+    enterReorderMode();
+
+    const upButtons = screen.getAllByLabelText("上に移動");
+    expect(upButtons[0].hasAttribute("disabled")).toBe(true);
+  });
+
+  it("enables the reorder-mode button for a single schedule when a staying entry shares the day", () => {
+    renderTimeline({
+      schedules: [makeSchedule({ id: "s1" })],
+      crossDayEntries: [makeIntermediateEntry()],
+    });
+
+    const sortButton = screen.getByRole("button", { name: "並び替え" });
+    expect(sortButton.hasAttribute("disabled")).toBe(false);
+  });
+});

--- a/apps/web/components/day-timeline.test.tsx
+++ b/apps/web/components/day-timeline.test.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import type { CrossDayEntry, ScheduleResponse } from "@sugara/shared";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, fireEvent, screen } from "@testing-library/react";
@@ -33,9 +31,10 @@ const selectionStub = {
   canEnter: false,
 };
 
-function makeSchedule(overrides: Partial<ScheduleResponse> = {}): ScheduleResponse {
+function makeSchedule(
+  overrides: Partial<ScheduleResponse> & Pick<ScheduleResponse, "id">,
+): ScheduleResponse {
   return {
-    id: "s1",
     name: "Spot",
     category: "sightseeing",
     address: null,
@@ -58,6 +57,16 @@ function makeIntermediateEntry(): CrossDayEntry {
     sourcePatternId: "p0",
     sourceDayNumber: 1,
     crossDayPosition: "intermediate",
+  };
+}
+
+function makeFinalEntry(): CrossDayEntry {
+  return {
+    schedule: makeSchedule({ id: "hotel2", name: "Hotel", category: "hotel", endTime: "10:00" }),
+    sourceDayId: "d0",
+    sourcePatternId: "p0",
+    sourceDayNumber: 1,
+    crossDayPosition: "final",
   };
 }
 
@@ -117,6 +126,18 @@ describe("DayTimeline mobile reorder with cross-day entries", () => {
 
     const upButtons = screen.getAllByLabelText("上に移動");
     expect(upButtons[0].hasAttribute("disabled")).toBe(true);
+  });
+
+  it("enables the down button on the last schedule when a final cross-day entry sits below it", () => {
+    renderTimeline({
+      schedules: [makeSchedule({ id: "s1" }), makeSchedule({ id: "s2", sortOrder: 1 })],
+      crossDayEntries: [makeFinalEntry()],
+    });
+    enterReorderMode();
+
+    // Merged timeline: [s1, s2, checkout entry] — s2 can still move below the entry via anchor.
+    const downButtons = screen.getAllByLabelText("下に移動");
+    expect(downButtons[1].hasAttribute("disabled")).toBe(false);
   });
 
   it("enables the reorder-mode button for a single schedule when a staying entry shares the day", () => {

--- a/apps/web/components/day-timeline.tsx
+++ b/apps/web/components/day-timeline.tsx
@@ -262,8 +262,6 @@ export function DayTimeline({
     // slice is O(n-k) instead of filter O(n); valid because schedules is in sortOrder order
     const schedulesAfter = scheduleIdx >= 0 ? schedules.slice(scheduleIdx + 1) : [];
     const isReorderable = isMobile && reorderMode && !disabled;
-    const reorderFirst = scheduleIdx === 0;
-    const reorderLast = scheduleIdx === schedules.length - 1;
 
     return (
       <div key={schedule.id} className="relative">
@@ -274,8 +272,8 @@ export function DayTimeline({
           dayId={dayId}
           patternId={patternId}
           date={date}
-          isFirst={isReorderable ? reorderFirst : isFirst}
-          isLast={isReorderable ? reorderLast : isLast}
+          isFirst={isFirst}
+          isLast={isLast}
           onDelete={() => handleDelete(schedule.id)}
           onUpdate={onRefresh}
           onUnassign={
@@ -443,7 +441,7 @@ export function DayTimeline({
                 variant="outline"
                 size="sm"
                 className="h-9"
-                disabled={schedules.length <= 1}
+                disabled={merged.length <= 1}
                 onClick={() => {
                   sel.exit();
                   setReorderMode(true);


### PR DESCRIPTION
## Summary
- SP版の並び替えモードで、中日の「滞在中」エントリの直下にある予定の「上へ」ボタンが誤って無効化され、滞在中エントリより上に移動できなかったバグを修正
- 予定1件+滞在中エントリの日で並び替えモードに入れなかった問題も同根として解消
- PC版のドラッグ&ドロップで可能な操作(PR #133)と SP版の挙動が揃う

## Why
- 上下ボタンの disabled 判定が raw `schedules` 配列の index(`reorderFirst`/`reorderLast`)を使っていたため、merged timeline の先頭に固定される intermediate crossDayEntry(PR #132)の存在を考慮できていなかった
- 移動処理 `reorderSchedule` は merged timeline の index + anchor(before/after)で crossDay を跨ぐ移動に対応済み。判定だけが anchor 対応前の名残で raw index のままだったので、merged 基準(`isFirst`/`isLast`)に揃えた
- 副次効果として、reorderMode 中のタイムライン縦線も merged 基準になり、滞在中エントリ直下の予定で縦線が途切れる表示も直る

## Changes
- `DayTimeline.renderItem`: reorderMode 時の `isFirst`/`isLast` を raw index 判定から merged timeline 基準に変更(raw 判定の `reorderFirst`/`reorderLast` を削除)
- 並び替えモード突入ボタンの disabled を `schedules.length <= 1` から `merged.length <= 1` に変更
- `day-timeline.test.tsx` を新規追加(モバイル + reorderMode + intermediate crossDayEntry の再現テスト3件)

## Test plan
- [x] 再現テスト: 滞在中エントリ+予定2件で先頭予定の「上へ」が有効(修正前 RED → 修正後 GREEN)
- [x] リグレッション: crossDay なしの先頭予定の「上へ」は disabled のまま
- [x] 予定1件+滞在中エントリで並び替えボタンが有効
- [x] `bun run check` / `bun run check-types` / `bun run --filter @sugara/web test`(740 件)すべて green

## Notes for reviewer
- `reorderSchedule`(`use-trip-drag-and-drop.ts`)側は変更なし。境界ガード `newMergedIdx < 0 || >= merged.length` が merged 基準の disabled 判定とそのまま一致するため
- `scheduleIdx` / `scheduleIndexById` は `schedulesAfter` の計算で引き続き使用するため残している

🤖 Generated with [Claude Code](https://claude.com/claude-code)