### PR TITLE
refactor: 外部API v1/MCPの重複集約とexpense書き込みの効率化

### DIFF
--- a/apps/api/src/__tests__/v1-write-routes.test.ts
+++ b/apps/api/src/__tests__/v1-write-routes.test.ts
@@ -34,6 +34,7 @@ const {
     trips: { findFirst: vi.fn() },
     tripMembers: { findMany: vi.fn() },
     expenses: { findFirst: vi.fn(), findMany: vi.fn() },
+    expenseSplits: { findMany: vi.fn() },
     bookmarkLists: { findFirst: vi.fn(), findMany: vi.fn() },
     bookmarks: { findFirst: vi.fn(), findMany: vi.fn() },
     articles: { findFirst: vi.fn(), findMany: vi.fn() },
@@ -409,18 +410,20 @@ describe("POST /trips/:tripId/expenses", () => {
     });
     mockDbQuery.tripMembers.findMany.mockResolvedValue(MEMBER_ROWS);
     mockDbQuery.users.findFirst.mockResolvedValue({ name: "Alice" });
-    mockCreateExpenseCore.mockResolvedValue({ ok: true, expense: { id: EXPENSE_ID } });
-    // fetchExpenseForResponse: contains paidByUserId and splits.userId internally,
-    // but resolveMemberRef converts them to { memberNo, displayName } in the DTO
-    mockDbQuery.expenses.findFirst.mockResolvedValue({
-      id: EXPENSE_ID,
-      title: "Dinner",
-      amount: 1000,
-      currency: "JPY",
-      category: "meals",
-      paidByUserId: USER_ID_1,
-      createdAt: new Date("2026-06-01T18:00:00Z"),
-      paidByUser: { name: "Alice" },
+    // createExpenseCore returns the inserted row and splits; the route builds the
+    // response in memory and serializeExpenseDto converts internal userIds to
+    // { memberNo, displayName } refs (no re-SELECT).
+    mockCreateExpenseCore.mockResolvedValue({
+      ok: true,
+      expense: {
+        id: EXPENSE_ID,
+        title: "Dinner",
+        amount: 1000,
+        currency: "JPY",
+        category: "meals",
+        paidByUserId: USER_ID_1,
+        createdAt: new Date("2026-06-01T18:00:00Z"),
+      },
       splits: [
         { userId: USER_ID_1, amount: 500 },
         { userId: USER_ID_2, amount: 500 },
@@ -580,7 +583,67 @@ describe("PATCH /trips/:id error mapping", () => {
 // PATCH /trips/:tripId/expenses/:expenseId — amount/splits consistency
 // ---------------------------------------------------------------------------
 
-describe("PATCH expense with both amount and splits", () => {
+describe("PATCH expense response construction", () => {
+  const UPDATED_EXPENSE = {
+    id: EXPENSE_ID,
+    title: "Dinner",
+    amount: 1000,
+    currency: "JPY",
+    category: "meals",
+    paidByUserId: USER_ID_1,
+    createdAt: new Date("2026-06-01T18:00:00Z"),
+  };
+
+  it("builds the response from the service result without re-selecting splits when splits were updated", async () => {
+    // Arrange — updateExpenseCore returns the rewritten splits in memory
+    mockVerifyApiKey.mockResolvedValue(WRITE_KEY);
+    mockCheckTripAccess.mockResolvedValue("editor");
+    mockDbQuery.tripMembers.findMany.mockResolvedValue(MEMBER_ROWS);
+    mockUpdateExpenseCore.mockResolvedValue({
+      ok: true,
+      expense: UPDATED_EXPENSE,
+      splits: [
+        { userId: USER_ID_1, amount: 500 },
+        { userId: USER_ID_2, amount: 500 },
+      ],
+    });
+
+    // Act
+    const res = await jsonPatch(`/trips/${TRIP_ID}/expenses/${EXPENSE_ID}`, {
+      splitType: "equal",
+      splits: [{ memberNo: 1 }, { memberNo: 2 }],
+    });
+    const body = await res.json();
+
+    // Assert — splits come from the service result, no fallback SELECT
+    expect(res.status).toBe(200);
+    expect(mockDbQuery.expenseSplits.findMany).not.toHaveBeenCalled();
+    expect(body.splits).toEqual([
+      { memberNo: 1, displayName: "Alice", amount: 500 },
+      { memberNo: 2, displayName: "Bob", amount: 500 },
+    ]);
+  });
+
+  it("falls back to selecting splits when the update did not modify them", async () => {
+    // Arrange — title-only update: result.splits is undefined
+    mockVerifyApiKey.mockResolvedValue(WRITE_KEY);
+    mockCheckTripAccess.mockResolvedValue("editor");
+    mockDbQuery.tripMembers.findMany.mockResolvedValue(MEMBER_ROWS);
+    mockUpdateExpenseCore.mockResolvedValue({ ok: true, expense: UPDATED_EXPENSE });
+    mockDbQuery.expenseSplits.findMany.mockResolvedValue([{ userId: USER_ID_1, amount: 1000 }]);
+
+    // Act
+    const res = await jsonPatch(`/trips/${TRIP_ID}/expenses/${EXPENSE_ID}`, {
+      title: "Dinner",
+    });
+    const body = await res.json();
+
+    // Assert — splits are fetched once and serialized to memberNo refs
+    expect(res.status).toBe(200);
+    expect(mockDbQuery.expenseSplits.findMany).toHaveBeenCalledTimes(1);
+    expect(body.splits).toEqual([{ memberNo: 1, displayName: "Alice", amount: 1000 }]);
+  });
+
   it("returns 400 when custom split amounts do not sum to the new amount (service validation)", async () => {
     // Arrange — validation moved to service layer (schema refine removed).
     // The service returns split_amount_mismatch which maps to 400 invalid_request.

--- a/apps/api/src/lib/expense-service.ts
+++ b/apps/api/src/lib/expense-service.ts
@@ -25,8 +25,10 @@ import { calculateEqualSplit } from "./settlement";
 
 type ExpenseRow = typeof expenses.$inferSelect;
 
+type SplitRow = { userId: string; amount: number };
+
 export type CreateExpenseResult =
-  | { ok: true; expense: ExpenseRow }
+  | { ok: true; expense: ExpenseRow; splits: SplitRow[] }
   | { ok: false; error: "exchange_rate_required" }
   | { ok: false; error: "limit_reached" }
   | { ok: false; error: "payer_not_member" }
@@ -34,7 +36,7 @@ export type CreateExpenseResult =
   | { ok: false; error: "amount_below_minor_unit" };
 
 export type UpdateExpenseResult =
-  | { ok: true; expense: ExpenseRow }
+  | { ok: true; expense: ExpenseRow; splits?: SplitRow[] }
   | { ok: false; error: "not_found" }
   | { ok: false; error: "exchange_rate_required" }
   | { ok: false; error: "payer_not_member" }
@@ -42,6 +44,14 @@ export type UpdateExpenseResult =
   | { ok: false; error: "split_amount_mismatch" }
   | { ok: false; error: "itemized_no_line_items" }
   | { ok: false; error: "amount_below_minor_unit" };
+
+// Options shared by create and update operations.
+// When memberIds is provided, the service skips its own DB member query and
+// uses the supplied set directly — callers that already fetched members for
+// other purposes (e.g. building a memberNoMap) can avoid a redundant round-trip.
+type ExpenseCoreOptions = {
+  memberIds?: ReadonlySet<string>;
+};
 
 /**
  * Core business logic for creating an expense.
@@ -55,6 +65,7 @@ export async function createExpenseCore(
   userId: string,
   actorName: string,
   input: z.infer<typeof createExpenseSchema>,
+  options?: ExpenseCoreOptions,
 ): Promise<CreateExpenseResult> {
   const {
     title,
@@ -99,11 +110,18 @@ export async function createExpenseCore(
     return { ok: false, error: "limit_reached" };
   }
 
-  // Verify all users are trip members
-  const members = await db.query.tripMembers.findMany({
-    where: eq(tripMembers.tripId, tripId),
-  });
-  const memberIds = new Set(members.map((m) => m.userId));
+  // Verify all users are trip members.
+  // When the caller already fetched members for another purpose (e.g. building
+  // a memberNoMap), they can pass the set via options to skip this round-trip.
+  const memberIds: ReadonlySet<string> =
+    options?.memberIds ??
+    new Set(
+      (
+        await db.query.tripMembers.findMany({
+          where: eq(tripMembers.tripId, tripId),
+        })
+      ).map((m) => m.userId),
+    );
 
   if (!memberIds.has(paidByUserId)) {
     return { ok: false, error: "payer_not_member" };
@@ -221,7 +239,11 @@ export async function createExpenseCore(
     }),
   });
 
-  return { ok: true, expense: result };
+  return {
+    ok: true,
+    expense: result,
+    splits: splits.map((s, i) => ({ userId: s.userId, amount: splitAmounts[i] })),
+  };
 }
 
 /**
@@ -234,6 +256,7 @@ export async function updateExpenseCore(
   expenseId: string,
   userId: string,
   input: z.infer<typeof updateExpenseSchema>,
+  options?: ExpenseCoreOptions,
 ): Promise<UpdateExpenseResult> {
   const existing = await db.query.expenses.findFirst({
     where: eq(expenses.id, expenseId),
@@ -292,10 +315,15 @@ export async function updateExpenseCore(
 
   // Verify member constraints when paidByUserId, splits, or lineItems change
   if (updateFields.paidByUserId || splits || lineItems) {
-    const members = await db.query.tripMembers.findMany({
-      where: eq(tripMembers.tripId, tripId),
-    });
-    const memberIds = new Set(members.map((m) => m.userId));
+    const memberIds: ReadonlySet<string> =
+      options?.memberIds ??
+      new Set(
+        (
+          await db.query.tripMembers.findMany({
+            where: eq(tripMembers.tripId, tripId),
+          })
+        ).map((m) => m.userId),
+      );
 
     if (updateFields.paidByUserId && !memberIds.has(updateFields.paidByUserId)) {
       return { ok: false, error: "payer_not_member" };
@@ -365,6 +393,10 @@ export async function updateExpenseCore(
     }
   }
 
+  // Captured inside the transaction and returned to callers that already hold
+  // the memberNoMap so they can skip a second DB round-trip for serialization.
+  // Undefined when splits were not modified in this update.
+  let computedSplits: SplitRow[] | undefined;
   const updated = await db.transaction(async (tx) => {
     const [result] = await tx
       .update(expenses)
@@ -382,6 +414,8 @@ export async function updateExpenseCore(
           ? calculateEqualSplit(effectiveBaseAmount, splits.length)
           : splits.map((s) => toMinorUnits(s.amount ?? 0, finalCurrency));
 
+      // Capture for the return value before the DB operations consume the arrays.
+      computedSplits = splits.map((s, i) => ({ userId: s.userId, amount: splitAmounts[i] }));
       await tx.delete(expenseSplits).where(eq(expenseSplits.expenseId, expenseId));
       await tx.insert(expenseSplits).values(
         splits.map((s, i) => ({
@@ -447,5 +481,5 @@ export async function updateExpenseCore(
     detail,
   });
 
-  return { ok: true, expense: updated };
+  return { ok: true, expense: updated, splits: computedSplits };
 }

--- a/apps/api/src/lib/external-api/member-no.test.ts
+++ b/apps/api/src/lib/external-api/member-no.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { buildMemberNoMap, invertMemberNoMap, resolveMemberRef } from "./member-no";
+
+describe("invertMemberNoMap", () => {
+  it("returns a map from memberNo to userId", () => {
+    // Arrange: provide members in non-sorted order to confirm buildMemberNoMap sorts them
+    const members = [
+      { userId: "aaaaaaaa-0000-0000-0000-000000000002" },
+      { userId: "aaaaaaaa-0000-0000-0000-000000000001" },
+    ];
+    const memberNoMap = buildMemberNoMap(members);
+
+    // Act
+    const inverted = invertMemberNoMap(memberNoMap);
+
+    // Assert: sorted order means smaller UUID gets memberNo 1
+    expect(inverted.get(1)).toBe("aaaaaaaa-0000-0000-0000-000000000001");
+    expect(inverted.get(2)).toBe("aaaaaaaa-0000-0000-0000-000000000002");
+  });
+
+  it("round-trips with buildMemberNoMap: every memberNo resolves back to the original userId", () => {
+    // Arrange
+    const members = [
+      { userId: "cccccccc-0000-0000-0000-000000000003" },
+      { userId: "aaaaaaaa-0000-0000-0000-000000000001" },
+      { userId: "bbbbbbbb-0000-0000-0000-000000000002" },
+    ];
+    const memberNoMap = buildMemberNoMap(members);
+
+    // Act
+    const inverted = invertMemberNoMap(memberNoMap);
+
+    // Assert: every entry in the forward map resolves back via the inverse
+    for (const [userId, memberNo] of memberNoMap) {
+      expect(inverted.get(memberNo)).toBe(userId);
+    }
+  });
+
+  it("returns an empty map when the input is empty", () => {
+    // Arrange
+    const memberNoMap = buildMemberNoMap([]);
+
+    // Act
+    const inverted = invertMemberNoMap(memberNoMap);
+
+    // Assert
+    expect(inverted.size).toBe(0);
+  });
+});
+
+describe("resolveMemberRef", () => {
+  it("returns memberNo and displayName for a known member", () => {
+    // Arrange
+    const userId = "aaaaaaaa-0000-0000-0000-000000000001";
+    const memberNoMap = buildMemberNoMap([{ userId }]);
+    const nameMap = new Map([[userId, "Alice"]]);
+
+    // Act
+    const ref = resolveMemberRef(memberNoMap, nameMap, userId);
+
+    // Assert
+    expect(ref).toEqual({ memberNo: 1, displayName: "Alice" });
+  });
+
+  it("falls back to displayName-only when the user is not in the member map", () => {
+    // Arrange: user removed outside the normal flow — no memberNo, no name
+    const memberNoMap = buildMemberNoMap([]);
+    const nameMap = new Map<string, string>();
+
+    // Act
+    const ref = resolveMemberRef(memberNoMap, nameMap, "aaaaaaaa-0000-0000-0000-000000000009");
+
+    // Assert
+    expect(ref).toEqual({ displayName: "Unknown" });
+  });
+});

--- a/apps/api/src/lib/external-api/member-no.ts
+++ b/apps/api/src/lib/external-api/member-no.ts
@@ -18,15 +18,36 @@ export function buildMemberNoMap(members: ReadonlyArray<{ userId: string }>): Ma
   return map;
 }
 
-// Looks up a userId by its 1-indexed memberNo.
-// Returns undefined when the memberNo is not present in the map
-// (e.g. the caller supplied an out-of-range or invalid number).
-export function resolveMemberNoToUserId(
+// MemberRef represents a reference to a trip member in v1 API responses.
+// When the member is present in the trip's membership list, both memberNo and
+// displayName are included. When that invariant is broken (e.g. a member was
+// removed outside the normal flow), only displayName is returned as a
+// defensive fallback. See design doc §4.3 defensive fallback note.
+export type MemberRef = { memberNo: number; displayName: string } | { displayName: string };
+
+// Resolves a userId to its MemberRef for v1 API response serialization.
+// Single source of truth shared by read (index.ts) and write (expenses-write.ts) routes.
+export function resolveMemberRef(
   memberNoMap: Map<string, number>,
-  memberNo: number,
-): string | undefined {
-  for (const [userId, no] of memberNoMap) {
-    if (no === memberNo) return userId;
+  nameMap: Map<string, string>,
+  userId: string,
+): MemberRef {
+  const memberNo = memberNoMap.get(userId);
+  const displayName = nameMap.get(userId) ?? "Unknown";
+  if (memberNo !== undefined) {
+    return { memberNo, displayName };
   }
-  return undefined;
+  // Defensive fallback: invariant broken — include displayName only
+  return { displayName };
+}
+
+// Builds a memberNo → userId reverse lookup map from the given memberNoMap.
+// The resulting map supports O(1) userId resolution by memberNo, replacing
+// the O(n) linear scan over the forward map.
+export function invertMemberNoMap(memberNoMap: Map<string, number>): Map<number, string> {
+  const inverted = new Map<number, string>();
+  for (const [userId, memberNo] of memberNoMap) {
+    inverted.set(memberNo, userId);
+  }
+  return inverted;
 }

--- a/apps/api/src/routes/expenses.ts
+++ b/apps/api/src/routes/expenses.ts
@@ -37,7 +37,7 @@ expenseRoutes.get("/:tripId/expenses", requireTripAccess(), async (c) => {
         paidByUser: { columns: { id: true, name: true } },
         splits: { with: { user: { columns: { id: true, name: true } } } },
         lineItems: {
-          with: { members: true },
+          with: { members: { orderBy: (members, { asc }) => [asc(members.userId)] } },
           orderBy: (lineItems, { asc }) => [asc(lineItems.sortOrder)],
         },
       },

--- a/apps/api/src/routes/v1/articles-write.ts
+++ b/apps/api/src/routes/v1/articles-write.ts
@@ -14,6 +14,7 @@ import { ApiV1Error, getApiKey, type V1Env } from "../../lib/external-api/errors
 import { getNextSortOrder } from "../../lib/sort-order";
 import { requireApiKey } from "../../middleware/require-api-key";
 import { errorResponseSchema } from "./openapi-schemas";
+import { serializeArticleDto } from "./serializers";
 import { uuidSchema } from "./shared";
 import {
   v1ArticleWriteResponseSchema,
@@ -22,25 +23,6 @@ import {
 } from "./write-schemas";
 
 export const articlesWriteApp = new Hono<V1Env>();
-
-// ---------------------------------------------------------------------------
-// Serializer
-// ---------------------------------------------------------------------------
-
-type ArticleRow = typeof articles.$inferSelect;
-
-function serializeArticleDto(article: ArticleRow, tripIds: string[]) {
-  return {
-    id: article.id,
-    title: article.title,
-    content: article.content,
-    tags: article.tags,
-    visibility: article.visibility,
-    tripIds,
-    createdAt: article.createdAt.toISOString(),
-    updatedAt: article.updatedAt.toISOString(),
-  };
-}
 
 // ---------------------------------------------------------------------------
 // POST /articles

--- a/apps/api/src/routes/v1/bookmarks-write.ts
+++ b/apps/api/src/routes/v1/bookmarks-write.ts
@@ -17,6 +17,7 @@ import { ApiV1Error, getApiKey, type V1Env } from "../../lib/external-api/errors
 import { getNextSortOrder } from "../../lib/sort-order";
 import { requireApiKey } from "../../middleware/require-api-key";
 import { errorResponseSchema } from "./openapi-schemas";
+import { serializeBookmarkDto, serializeListDto } from "./serializers";
 import { uuidSchema } from "./shared";
 import {
   v1BookmarkListWriteResponseSchema,
@@ -28,37 +29,6 @@ import {
 } from "./write-schemas";
 
 export const bookmarksWriteApp = new Hono<V1Env>();
-
-// ---------------------------------------------------------------------------
-// Serializers
-// ---------------------------------------------------------------------------
-
-type BookmarkListRow = typeof bookmarkLists.$inferSelect;
-type BookmarkRow = typeof bookmarks.$inferSelect;
-
-function serializeListDto(list: BookmarkListRow, bookmarkCount: number) {
-  return {
-    id: list.id,
-    name: list.name,
-    visibility: list.visibility,
-    sortOrder: list.sortOrder,
-    bookmarkCount,
-    createdAt: list.createdAt.toISOString(),
-    updatedAt: list.updatedAt.toISOString(),
-  };
-}
-
-function serializeBookmarkDto(b: BookmarkRow) {
-  return {
-    id: b.id,
-    name: b.name,
-    memo: b.memo ?? null,
-    urls: b.urls,
-    sortOrder: b.sortOrder,
-    createdAt: b.createdAt.toISOString(),
-    updatedAt: b.updatedAt.toISOString(),
-  };
-}
 
 // ---------------------------------------------------------------------------
 // POST /bookmark-lists

--- a/apps/api/src/routes/v1/expenses-write.ts
+++ b/apps/api/src/routes/v1/expenses-write.ts
@@ -13,13 +13,14 @@ import { count, eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { describeRoute, resolver } from "hono-openapi";
 import { db } from "../../db";
-import { expenses, tripDays, tripMembers, users } from "../../db/schema";
+import { expenseSplits, tripDays, tripMembers } from "../../db/schema";
 import { createExpenseCore, updateExpenseCore } from "../../lib/expense-service";
 import { ApiV1Error, getApiKey, type V1Env } from "../../lib/external-api/errors";
-import { buildMemberNoMap, resolveMemberNoToUserId } from "../../lib/external-api/member-no";
+import { buildMemberNoMap, invertMemberNoMap } from "../../lib/external-api/member-no";
 import { requireApiKey } from "../../middleware/require-api-key";
 import { errorResponseSchema } from "./openapi-schemas";
-import { uuidSchema, withTripAccess } from "./shared";
+import { serializeExpenseDto } from "./serializers";
+import { getActorName, uuidSchema, withTripAccess } from "./shared";
 import {
   v1CreateExpenseSchema,
   v1ExpenseWriteResponseSchema,
@@ -27,38 +28,6 @@ import {
 } from "./write-schemas";
 
 export const expensesWriteApp = new Hono<V1Env>();
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-// Mirror of the local resolveMemberRef in index.ts — kept private to this file.
-type MemberRef = { memberNo: number; displayName: string } | { displayName: string };
-
-function resolveMemberRef(
-  memberNoMap: Map<string, number>,
-  nameMap: Map<string, string>,
-  userId: string,
-): MemberRef {
-  const memberNo = memberNoMap.get(userId);
-  const displayName = nameMap.get(userId) ?? "Unknown";
-  if (memberNo !== undefined) {
-    return { memberNo, displayName };
-  }
-  // Defensive fallback: member was removed outside the normal flow
-  return { displayName };
-}
-
-// Fetch the expense with paidByUser name and splits for response serialization.
-async function fetchExpenseForResponse(expenseId: string) {
-  return db.query.expenses.findFirst({
-    where: eq(expenses.id, expenseId),
-    with: {
-      paidByUser: { columns: { name: true } },
-      splits: { columns: { userId: true, amount: true } },
-    },
-  });
-}
 
 // ---------------------------------------------------------------------------
 // POST /trips/:tripId/expenses
@@ -148,9 +117,11 @@ expensesWriteApp.post(
         with: { user: { columns: { name: true } } },
       });
       const memberNoMap = buildMemberNoMap(memberRows);
+      const userIdByMemberNo = invertMemberNoMap(memberNoMap);
+      const nameMap = new Map(memberRows.map((m) => [m.userId, m.user?.name ?? "Unknown"]));
 
       // Resolve paidByMemberNo → paidByUserId.
-      const paidByUserId = resolveMemberNoToUserId(memberNoMap, parsed.data.paidByMemberNo);
+      const paidByUserId = userIdByMemberNo.get(parsed.data.paidByMemberNo);
       if (!paidByUserId) {
         throw new ApiV1Error(400, "invalid_request", "Unknown paidByMemberNo");
       }
@@ -158,7 +129,7 @@ expensesWriteApp.post(
       // Resolve splits[].memberNo → splits[].userId.
       const resolvedSplits: { userId: string; amount?: number }[] = [];
       for (const s of parsed.data.splits) {
-        const uid = resolveMemberNoToUserId(memberNoMap, s.memberNo);
+        const uid = userIdByMemberNo.get(s.memberNo);
         if (!uid) {
           throw new ApiV1Error(400, "invalid_request", `Unknown memberNo ${s.memberNo} in splits`);
         }
@@ -172,7 +143,7 @@ expensesWriteApp.post(
         for (const item of parsed.data.lineItems) {
           const memberIds: string[] = [];
           for (const mno of item.memberNos) {
-            const uid = resolveMemberNoToUserId(memberNoMap, mno);
+            const uid = userIdByMemberNo.get(mno);
             if (!uid) {
               throw new ApiV1Error(400, "invalid_request", `Unknown memberNo ${mno} in lineItems`);
             }
@@ -183,23 +154,25 @@ expensesWriteApp.post(
       }
 
       // Fetch actor name for createExpenseCore notifications.
-      const actorRow = await db.query.users.findFirst({
-        where: eq(users.id, key.userId),
-        columns: { name: true },
-      });
-      const actorName = actorRow?.name ?? "Unknown";
+      const actorName = await getActorName(key.userId);
 
-      const result = await createExpenseCore(tripId, key.userId, actorName, {
-        title: parsed.data.title,
-        amount: parsed.data.amount,
-        paidByUserId,
-        splitType: parsed.data.splitType,
-        category: parsed.data.category,
-        currency: parsed.data.currency,
-        exchangeRate: parsed.data.exchangeRate,
-        splits: resolvedSplits,
-        lineItems: resolvedLineItems,
-      });
+      const result = await createExpenseCore(
+        tripId,
+        key.userId,
+        actorName,
+        {
+          title: parsed.data.title,
+          amount: parsed.data.amount,
+          paidByUserId,
+          splitType: parsed.data.splitType,
+          category: parsed.data.category,
+          currency: parsed.data.currency,
+          exchangeRate: parsed.data.exchangeRate,
+          splits: resolvedSplits,
+          lineItems: resolvedLineItems,
+        },
+        { memberIds: new Set(memberRows.map((m) => m.userId)) },
+      );
 
       if (!result.ok) {
         switch (result.error) {
@@ -224,28 +197,8 @@ expensesWriteApp.post(
         }
       }
 
-      // Re-fetch with relations for the response DTO.
-      const expenseWithRelations = await fetchExpenseForResponse(result.expense.id);
-      if (!expenseWithRelations) {
-        throw new ApiV1Error(500, "internal_error", "Expense not found after creation");
-      }
-
-      const nameMap = new Map(memberRows.map((m) => [m.userId, m.user?.name ?? "Unknown"]));
-
       return c.json(
-        {
-          id: expenseWithRelations.id,
-          title: expenseWithRelations.title,
-          amount: expenseWithRelations.amount,
-          currency: expenseWithRelations.currency,
-          category: expenseWithRelations.category ?? null,
-          date: expenseWithRelations.createdAt.toISOString(),
-          paidBy: resolveMemberRef(memberNoMap, nameMap, expenseWithRelations.paidByUserId),
-          splits: expenseWithRelations.splits.map((s) => ({
-            ...resolveMemberRef(memberNoMap, nameMap, s.userId),
-            amount: s.amount,
-          })),
-        },
+        serializeExpenseDto({ ...result.expense, splits: result.splits }, memberNoMap, nameMap),
         201,
       );
     },
@@ -342,11 +295,13 @@ expensesWriteApp.patch(
         with: { user: { columns: { name: true } } },
       });
       const memberNoMap = buildMemberNoMap(memberRows);
+      const userIdByMemberNo = invertMemberNoMap(memberNoMap);
+      const nameMap = new Map(memberRows.map((m) => [m.userId, m.user?.name ?? "Unknown"]));
 
       // Resolve paidByMemberNo → paidByUserId when present.
       let paidByUserId: string | undefined;
       if (parsed.data.paidByMemberNo !== undefined) {
-        const uid = resolveMemberNoToUserId(memberNoMap, parsed.data.paidByMemberNo);
+        const uid = userIdByMemberNo.get(parsed.data.paidByMemberNo);
         if (!uid) {
           throw new ApiV1Error(400, "invalid_request", "Unknown paidByMemberNo");
         }
@@ -358,7 +313,7 @@ expensesWriteApp.patch(
       if (parsed.data.splits) {
         resolvedSplits = [];
         for (const s of parsed.data.splits) {
-          const uid = resolveMemberNoToUserId(memberNoMap, s.memberNo);
+          const uid = userIdByMemberNo.get(s.memberNo);
           if (!uid) {
             throw new ApiV1Error(
               400,
@@ -378,7 +333,7 @@ expensesWriteApp.patch(
         for (const item of parsed.data.lineItems) {
           const memberIds: string[] = [];
           for (const mno of item.memberNos) {
-            const uid = resolveMemberNoToUserId(memberNoMap, mno);
+            const uid = userIdByMemberNo.get(mno);
             if (!uid) {
               throw new ApiV1Error(400, "invalid_request", `Unknown memberNo ${mno} in lineItems`);
             }
@@ -388,17 +343,23 @@ expensesWriteApp.patch(
         }
       }
 
-      const result = await updateExpenseCore(tripId, expenseId, key.userId, {
-        title: parsed.data.title,
-        amount: parsed.data.amount,
-        paidByUserId,
-        splitType: parsed.data.splitType,
-        category: parsed.data.category,
-        currency: parsed.data.currency,
-        exchangeRate: parsed.data.exchangeRate,
-        splits: resolvedSplits,
-        lineItems: resolvedLineItems,
-      });
+      const result = await updateExpenseCore(
+        tripId,
+        expenseId,
+        key.userId,
+        {
+          title: parsed.data.title,
+          amount: parsed.data.amount,
+          paidByUserId,
+          splitType: parsed.data.splitType,
+          category: parsed.data.category,
+          currency: parsed.data.currency,
+          exchangeRate: parsed.data.exchangeRate,
+          splits: resolvedSplits,
+          lineItems: resolvedLineItems,
+        },
+        { memberIds: new Set(memberRows.map((m) => m.userId)) },
+      );
 
       if (!result.ok) {
         switch (result.error) {
@@ -435,27 +396,18 @@ expensesWriteApp.patch(
         }
       }
 
-      // Re-fetch with relations for the response DTO.
-      const expenseWithRelations = await fetchExpenseForResponse(result.expense.id);
-      if (!expenseWithRelations) {
-        throw new ApiV1Error(500, "internal_error", "Expense not found after update");
-      }
+      // Use splits from service result when splits were updated; fall back to a
+      // DB query when only non-split fields changed (result.splits is undefined).
+      const splitRows =
+        result.splits ??
+        (await db.query.expenseSplits.findMany({
+          where: eq(expenseSplits.expenseId, expenseId),
+          columns: { userId: true, amount: true },
+        }));
 
-      const nameMap = new Map(memberRows.map((m) => [m.userId, m.user?.name ?? "Unknown"]));
-
-      return c.json({
-        id: expenseWithRelations.id,
-        title: expenseWithRelations.title,
-        amount: expenseWithRelations.amount,
-        currency: expenseWithRelations.currency,
-        category: expenseWithRelations.category ?? null,
-        date: expenseWithRelations.createdAt.toISOString(),
-        paidBy: resolveMemberRef(memberNoMap, nameMap, expenseWithRelations.paidByUserId),
-        splits: expenseWithRelations.splits.map((s) => ({
-          ...resolveMemberRef(memberNoMap, nameMap, s.userId),
-          amount: s.amount,
-        })),
-      });
+      return c.json(
+        serializeExpenseDto({ ...result.expense, splits: splitRows }, memberNoMap, nameMap),
+      );
     },
     { minRole: "editor" },
   ),

--- a/apps/api/src/routes/v1/index.ts
+++ b/apps/api/src/routes/v1/index.ts
@@ -23,6 +23,12 @@ import {
   tripDetailResponseSchema,
   tripListResponseSchema,
 } from "./openapi-schemas";
+import {
+  serializeArticleDto,
+  serializeBookmarkDto,
+  serializeExpenseDto,
+  serializeListDto,
+} from "./serializers";
 import { uuidSchema, withTripAccess } from "./shared";
 import { tripsWriteApp } from "./trips-write";
 
@@ -56,29 +62,6 @@ const paginationSchema = z.object({
 const tripsQuerySchema = paginationSchema.extend({
   scope: z.enum(["owned", "shared"]).optional(),
 });
-
-// ---------- Helper: resolve a userId to its memberNo + displayName ----------
-//
-// Members in a trip are expected to always be present (fees cannot reference
-// users outside the trip). When that invariant is violated (e.g. a member was
-// removed outside the normal flow), we return just the displayName rather than
-// crashing with a 500. See design doc §4.3 defensive fallback note.
-
-type MemberRef = { memberNo: number; displayName: string } | { displayName: string };
-
-function resolveMemberRef(
-  memberNoMap: Map<string, number>,
-  nameMap: Map<string, string>,
-  userId: string,
-): MemberRef {
-  const memberNo = memberNoMap.get(userId);
-  const displayName = nameMap.get(userId) ?? "Unknown";
-  if (memberNo !== undefined) {
-    return { memberNo, displayName };
-  }
-  // Defensive fallback: invariant broken — include displayName only
-  return { displayName };
-}
 
 // ---------- GET /api/v1/trips ----------
 
@@ -459,19 +442,7 @@ v1App.get(
       offset: queryOffset,
     });
 
-    const data = expenseRows.map((exp) => ({
-      id: exp.id,
-      title: exp.title,
-      amount: exp.amount,
-      currency: exp.currency,
-      category: exp.category ?? null,
-      date: exp.createdAt.toISOString(),
-      paidBy: resolveMemberRef(memberNoMap, nameMap, exp.paidByUserId),
-      splits: exp.splits.map((s) => ({
-        ...resolveMemberRef(memberNoMap, nameMap, s.userId),
-        amount: s.amount,
-      })),
-    }));
+    const data = expenseRows.map((exp) => serializeExpenseDto(exp, memberNoMap, nameMap));
 
     return c.json({
       data,
@@ -565,15 +536,7 @@ v1App.get(
       offset: queryOffset,
     });
 
-    const data = listRows.map((list) => ({
-      id: list.id,
-      name: list.name,
-      visibility: list.visibility,
-      sortOrder: list.sortOrder,
-      bookmarkCount: list.bookmarks.length,
-      createdAt: list.createdAt.toISOString(),
-      updatedAt: list.updatedAt.toISOString(),
-    }));
+    const data = listRows.map((list) => serializeListDto(list, list.bookmarks.length));
 
     return c.json({
       data,
@@ -689,15 +652,7 @@ v1App.get(
       offset: queryOffset,
     });
 
-    const data = bookmarkRows.map((bm) => ({
-      id: bm.id,
-      name: bm.name,
-      memo: bm.memo ?? null,
-      urls: bm.urls,
-      sortOrder: bm.sortOrder,
-      createdAt: bm.createdAt.toISOString(),
-      updatedAt: bm.updatedAt.toISOString(),
-    }));
+    const data = bookmarkRows.map((bm) => serializeBookmarkDto(bm));
 
     return c.json({
       data,
@@ -894,16 +849,12 @@ v1App.get(
       throw new ApiV1Error(404, "not_found", "Article not found or access denied");
     }
 
-    return c.json({
-      id: article.id,
-      title: article.title,
-      content: article.content,
-      tags: article.tags,
-      visibility: article.visibility,
-      tripIds: article.articleTrips.map((t) => t.tripId),
-      createdAt: article.createdAt.toISOString(),
-      updatedAt: article.updatedAt.toISOString(),
-    });
+    return c.json(
+      serializeArticleDto(
+        article,
+        article.articleTrips.map((t) => t.tripId),
+      ),
+    );
   },
 );
 

--- a/apps/api/src/routes/v1/serializers.ts
+++ b/apps/api/src/routes/v1/serializers.ts
@@ -1,0 +1,185 @@
+// Shared serializers for v1 external API DTOs.
+//
+// All functions here are pure transformations from internal row/data shapes to
+// the public v1 JSON format. No DB calls, no side effects.
+//
+// Structural (minimal) types are used for rows that may come from either a full
+// `$inferSelect` (write paths) or a column-selected query result (read paths).
+// Full-row types are used only where the serializer is write-side exclusive.
+
+import type { schedules, trips } from "../../db/schema";
+import { resolveMemberRef } from "../../lib/external-api/member-no";
+
+// ---------------------------------------------------------------------------
+// Trip
+// ---------------------------------------------------------------------------
+
+type TripRow = typeof trips.$inferSelect;
+
+export function serializeTripDto(trip: TripRow) {
+  return {
+    id: trip.id,
+    title: trip.title,
+    destination: trip.destination ?? null,
+    startDate: trip.startDate ?? null,
+    endDate: trip.endDate ?? null,
+    currency: trip.currency,
+    status: trip.status,
+    createdAt: trip.createdAt.toISOString(),
+    updatedAt: trip.updatedAt.toISOString(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Schedule
+// ---------------------------------------------------------------------------
+
+type ScheduleRow = typeof schedules.$inferSelect;
+
+export function serializeScheduleDto(s: ScheduleRow) {
+  return {
+    id: s.id,
+    name: s.name,
+    category: s.category,
+    startTime: s.startTime ?? null,
+    endTime: s.endTime ?? null,
+    address: s.address ?? null,
+    memo: s.memo ?? null,
+    urls: s.urls,
+    departurePlace: s.departurePlace ?? null,
+    arrivalPlace: s.arrivalPlace ?? null,
+    transportMethod: s.transportMethod ?? null,
+    cost: s.cost ?? null,
+    color: s.color,
+    endDayOffset: s.endDayOffset ?? null,
+    sortOrder: s.sortOrder,
+    createdAt: s.createdAt.toISOString(),
+    updatedAt: s.updatedAt.toISOString(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Bookmark list
+//
+// Accepts a structural type so that both full-row (write) and column-selected
+// (read) query results are assignable without extra casts.
+// ---------------------------------------------------------------------------
+
+type BookmarkListInput = {
+  id: string;
+  name: string;
+  visibility: string;
+  sortOrder: number;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export function serializeListDto(list: BookmarkListInput, bookmarkCount: number) {
+  return {
+    id: list.id,
+    name: list.name,
+    visibility: list.visibility,
+    sortOrder: list.sortOrder,
+    bookmarkCount,
+    createdAt: list.createdAt.toISOString(),
+    updatedAt: list.updatedAt.toISOString(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Bookmark
+// ---------------------------------------------------------------------------
+
+type BookmarkInput = {
+  id: string;
+  name: string;
+  memo: string | null;
+  urls: string[];
+  sortOrder: number;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export function serializeBookmarkDto(b: BookmarkInput) {
+  return {
+    id: b.id,
+    name: b.name,
+    memo: b.memo ?? null,
+    urls: b.urls,
+    sortOrder: b.sortOrder,
+    createdAt: b.createdAt.toISOString(),
+    updatedAt: b.updatedAt.toISOString(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Article
+//
+// `content` and `tags` are included even though the list endpoint omits them;
+// the read-list path never calls this function (the list endpoint intentionally
+// excludes the body). Only the write (POST/PATCH) and read-detail (GET /:id)
+// paths call serializeArticleDto.
+// ---------------------------------------------------------------------------
+
+type ArticleInput = {
+  id: string;
+  title: string;
+  content: string;
+  tags: string[];
+  visibility: string;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export function serializeArticleDto(article: ArticleInput, tripIds: string[]) {
+  return {
+    id: article.id,
+    title: article.title,
+    content: article.content,
+    tags: article.tags,
+    visibility: article.visibility,
+    tripIds,
+    createdAt: article.createdAt.toISOString(),
+    updatedAt: article.updatedAt.toISOString(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Expense
+//
+// Converts internal userId references to memberNo-based MemberRef objects
+// for the v1 external format. `splits` must already be computed (minor units).
+// ---------------------------------------------------------------------------
+
+type ExpenseSplitInput = { userId: string; amount: number };
+
+type ExpenseInput = {
+  id: string;
+  title: string;
+  amount: number;
+  currency: string;
+  category: string | null;
+  createdAt: Date;
+  paidByUserId: string;
+  splits: ReadonlyArray<ExpenseSplitInput>;
+};
+
+export function serializeExpenseDto(
+  expense: ExpenseInput,
+  memberNoMap: Map<string, number>,
+  nameMap: Map<string, string>,
+) {
+  return {
+    id: expense.id,
+    title: expense.title,
+    amount: expense.amount,
+    currency: expense.currency,
+    category: expense.category,
+    date: expense.createdAt.toISOString(),
+    paidBy: resolveMemberRef(memberNoMap, nameMap, expense.paidByUserId),
+    splits: expense.splits.map((s) => ({
+      ...resolveMemberRef(memberNoMap, nameMap, s.userId),
+      amount: s.amount,
+    })),
+  };
+}

--- a/apps/api/src/routes/v1/shared.ts
+++ b/apps/api/src/routes/v1/shared.ts
@@ -1,9 +1,22 @@
 import type { MemberRole } from "@sugara/shared";
 import { canEdit } from "@sugara/shared";
+import { eq } from "drizzle-orm";
 import type { Context } from "hono";
 import { z } from "zod";
+import { db } from "../../db";
+import { users } from "../../db/schema";
 import { ApiV1Error, getApiKey, type V1Env } from "../../lib/external-api/errors";
 import { checkTripAccess } from "../../lib/permissions";
+
+// Fetches the display name for a user, used for notification payloads.
+// Returns "Unknown" when the user row is not found (defensive fallback).
+export async function getActorName(userId: string): Promise<string> {
+  const row = await db.query.users.findFirst({
+    where: eq(users.id, userId),
+    columns: { name: true },
+  });
+  return row?.name ?? "Unknown";
+}
 
 // Shared UUID schema used across all v1 routes.
 // z.guid() validates the 8-4-4-4-12 hex GUID format without enforcing UUID

--- a/apps/api/src/routes/v1/trips-write.ts
+++ b/apps/api/src/routes/v1/trips-write.ts
@@ -11,7 +11,7 @@ import { count, eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { describeRoute, resolver } from "hono-openapi";
 import { db } from "../../db";
-import { dayPatterns, schedules, tripDays, tripMembers, trips, users } from "../../db/schema";
+import { dayPatterns, schedules, tripDays, tripMembers, trips } from "../../db/schema";
 import { logActivity } from "../../lib/activity-logger";
 import { ApiV1Error, getApiKey, type V1Env } from "../../lib/external-api/errors";
 import { notifyTripMembersExcluding } from "../../lib/notifications";
@@ -22,7 +22,8 @@ import { resolveTripLimit } from "../../lib/trip-limit";
 import { updateTripCore } from "../../lib/trip-service";
 import { requireApiKey } from "../../middleware/require-api-key";
 import { errorResponseSchema } from "./openapi-schemas";
-import { uuidSchema, withTripAccess } from "./shared";
+import { serializeScheduleDto, serializeTripDto } from "./serializers";
+import { getActorName, uuidSchema, withTripAccess } from "./shared";
 import {
   v1CreateScheduleSchema,
   v1CreateTripSchema,
@@ -33,66 +34,6 @@ import {
 } from "./write-schemas";
 
 export const tripsWriteApp = new Hono<V1Env>();
-
-// ---------------------------------------------------------------------------
-// Helper: fetch the calling user's display name for notifications
-// ---------------------------------------------------------------------------
-
-async function getActorName(userId: string): Promise<string> {
-  const row = await db.query.users.findFirst({
-    where: eq(users.id, userId),
-    columns: { name: true },
-  });
-  return row?.name ?? "Unknown";
-}
-
-// ---------------------------------------------------------------------------
-// Helper: serialize a trip row to the v1 external DTO (no ownerId / cover image)
-// ---------------------------------------------------------------------------
-
-type TripRow = typeof trips.$inferSelect;
-
-function serializeTripDto(trip: TripRow) {
-  return {
-    id: trip.id,
-    title: trip.title,
-    destination: trip.destination ?? null,
-    startDate: trip.startDate ?? null,
-    endDate: trip.endDate ?? null,
-    currency: trip.currency,
-    status: trip.status,
-    createdAt: trip.createdAt.toISOString(),
-    updatedAt: trip.updatedAt.toISOString(),
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Helper: serialize a schedule row to the v1 external DTO
-// ---------------------------------------------------------------------------
-
-type ScheduleRow = typeof schedules.$inferSelect;
-
-function serializeScheduleDto(s: ScheduleRow) {
-  return {
-    id: s.id,
-    name: s.name,
-    category: s.category,
-    startTime: s.startTime ?? null,
-    endTime: s.endTime ?? null,
-    address: s.address ?? null,
-    memo: s.memo ?? null,
-    urls: s.urls,
-    departurePlace: s.departurePlace ?? null,
-    arrivalPlace: s.arrivalPlace ?? null,
-    transportMethod: s.transportMethod ?? null,
-    cost: s.cost ?? null,
-    color: s.color,
-    endDayOffset: s.endDayOffset ?? null,
-    sortOrder: s.sortOrder,
-    createdAt: s.createdAt.toISOString(),
-    updatedAt: s.updatedAt.toISOString(),
-  };
-}
 
 // ---------------------------------------------------------------------------
 // POST /trips

--- a/apps/api/src/routes/v1/write-schemas.ts
+++ b/apps/api/src/routes/v1/write-schemas.ts
@@ -22,7 +22,7 @@ import {
   expenseCategorySchema,
   expenseSplitTypeSchema,
   MAX_LINE_ITEMS_PER_EXPENSE,
-  toMinorUnits,
+  splitsTotalMatchesAmount,
   updateArticleSchema,
   updateBookmarkListSchema,
   updateBookmarkSchema,
@@ -146,21 +146,10 @@ export const v1CreateExpenseSchema = z
     },
     { message: "Custom splits require amount for each member", path: ["splits"] },
   )
-  .refine(
-    (data) => {
-      if (data.splitType === "custom" || data.splitType === "itemized") {
-        // Compare in minor units so that e.g. 6.25 + 6.25 === 12.50 for USD
-        // (floating-point addition of major units would lose precision).
-        const splitMinor = data.splits.reduce(
-          (sum, s) => sum + toMinorUnits(s.amount ?? 0, data.currency),
-          0,
-        );
-        return splitMinor === toMinorUnits(data.amount, data.currency);
-      }
-      return true;
-    },
-    { message: "Split amounts must equal total amount", path: ["splits"] },
-  )
+  .refine((data) => splitsTotalMatchesAmount(data), {
+    message: "Split amounts must equal total amount",
+    path: ["splits"],
+  })
   .refine(
     (data) => {
       if (data.splitType === "itemized") {

--- a/apps/api/src/routes/v1/write-schemas.ts
+++ b/apps/api/src/routes/v1/write-schemas.ts
@@ -23,6 +23,7 @@ import {
   expenseSplitTypeSchema,
   MAX_LINE_ITEMS_PER_EXPENSE,
   splitsTotalMatchesAmount,
+  tripStatusSchema,
   updateArticleSchema,
   updateBookmarkListSchema,
   updateBookmarkSchema,
@@ -235,7 +236,7 @@ export const v1TripWriteResponseSchema = z.object({
   startDate: z.string().nullable(),
   endDate: z.string().nullable(),
   currency: z.string(),
-  status: z.enum(["scheduling", "draft", "planned", "active", "completed"]),
+  status: tripStatusSchema,
   createdAt: z.string(),
   updatedAt: z.string(),
 });

--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.29.0",
+    "@sugara/shared": "workspace:*",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -5,6 +5,7 @@ import {
   scheduleCategorySchema,
   scheduleColorSchema,
   transportMethodSchema,
+  tripStatusSchema,
 } from "@sugara/shared";
 import { z } from "zod";
 import type { ApiClient } from "./client.js";
@@ -79,7 +80,7 @@ export const INPUT_SHAPES = {
     id: z.string().uuid(),
     title: z.string().min(1).max(100).optional(),
     destination: z.string().max(100).nullable().optional(),
-    status: z.enum(["scheduling", "draft", "planned", "active", "completed"]).optional(),
+    status: tripStatusSchema.optional(),
     startDate: z.string().date().optional(),
     endDate: z.string().date().optional(),
     currency: currencyCodeSchema.optional(),

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -1,4 +1,11 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  currencyCodeSchema,
+  expenseCategorySchema,
+  scheduleCategorySchema,
+  scheduleColorSchema,
+  transportMethodSchema,
+} from "@sugara/shared";
 import { z } from "zod";
 import type { ApiClient } from "./client.js";
 
@@ -6,22 +13,6 @@ import type { ApiClient } from "./client.js";
 // Note: z.string().uuid() validates strict UUID v4 format, which is stricter than the
 // v1 API's guid() validator (which also accepts v1-v5). All IDs are v4-generated in
 // practice, so this extra strictness causes no real-world rejections.
-
-// Currency codes supported by the v1 API (mirrored from @sugara/shared currency.ts).
-const currencyEnum = z.enum([
-  "JPY",
-  "USD",
-  "EUR",
-  "GBP",
-  "AUD",
-  "CAD",
-  "CHF",
-  "CNY",
-  "KRW",
-  "THB",
-  "SGD",
-  "HKD",
-]);
 
 // Shared sub-schemas for expense splits/line-items (memberNo-based, not userId-based).
 const splitItemShape = z.object({
@@ -80,7 +71,7 @@ export const INPUT_SHAPES = {
     // YYYY-MM-DD; endDate must be >= startDate (validated by API)
     startDate: z.string().date(),
     endDate: z.string().date(),
-    currency: currencyEnum.optional(),
+    currency: currencyCodeSchema.optional(),
   },
 
   // PATCH /trips/:id — requires editor or owner role on the trip.
@@ -91,7 +82,7 @@ export const INPUT_SHAPES = {
     status: z.enum(["scheduling", "draft", "planned", "active", "completed"]).optional(),
     startDate: z.string().date().optional(),
     endDate: z.string().date().optional(),
-    currency: currencyEnum.optional(),
+    currency: currencyCodeSchema.optional(),
   },
 
   // POST /trips/:tripId/days/:dayNumber/schedules — appends to the default day pattern.
@@ -100,7 +91,7 @@ export const INPUT_SHAPES = {
     // 1-indexed day number within the trip; check get_trip for the total day count
     dayNumber: z.number().int().min(1),
     name: z.string().min(1).max(200),
-    category: z.enum(["sightseeing", "restaurant", "hotel", "transport", "activity", "other"]),
+    category: scheduleCategorySchema,
     address: z.string().max(500).optional(),
     // HH:MM or HH:MM:SS format
     startTime: z.string().optional(),
@@ -110,25 +101,9 @@ export const INPUT_SHAPES = {
     urls: z.array(z.string()).max(5).optional(),
     departurePlace: z.string().max(200).optional(),
     arrivalPlace: z.string().max(200).optional(),
-    transportMethod: z
-      .enum([
-        "train",
-        "shinkansen",
-        "bus",
-        "taxi",
-        "walk",
-        "car",
-        "airplane",
-        "bicycle",
-        "ropeway",
-        "cable_car",
-        "ferry",
-      ])
-      .optional(),
+    transportMethod: transportMethodSchema.optional(),
     cost: z.number().int().nonnegative().max(99999999).optional(),
-    color: z
-      .enum(["blue", "red", "green", "yellow", "purple", "pink", "orange", "gray"])
-      .optional(),
+    color: scheduleColorSchema.optional(),
     // how many extra days the schedule spans (1 = next day)
     endDayOffset: z.number().int().min(1).max(30).optional(),
   },
@@ -138,9 +113,7 @@ export const INPUT_SHAPES = {
     tripId: z.string().uuid(),
     scheduleId: z.string().uuid(),
     name: z.string().min(1).max(200).optional(),
-    category: z
-      .enum(["sightseeing", "restaurant", "hotel", "transport", "activity", "other"])
-      .optional(),
+    category: scheduleCategorySchema.optional(),
     address: z.string().max(500).optional(),
     startTime: z.string().optional(),
     endTime: z.string().optional(),
@@ -148,25 +121,9 @@ export const INPUT_SHAPES = {
     urls: z.array(z.string()).max(5).optional(),
     departurePlace: z.string().max(200).optional(),
     arrivalPlace: z.string().max(200).optional(),
-    transportMethod: z
-      .enum([
-        "train",
-        "shinkansen",
-        "bus",
-        "taxi",
-        "walk",
-        "car",
-        "airplane",
-        "bicycle",
-        "ropeway",
-        "cable_car",
-        "ferry",
-      ])
-      .optional(),
+    transportMethod: transportMethodSchema.optional(),
     cost: z.number().int().nonnegative().max(99999999).optional(),
-    color: z
-      .enum(["blue", "red", "green", "yellow", "purple", "pink", "orange", "gray"])
-      .optional(),
+    color: scheduleColorSchema.optional(),
     endDayOffset: z.number().int().min(1).max(30).optional(),
   },
 
@@ -179,19 +136,8 @@ export const INPUT_SHAPES = {
     // obtain memberNo from get_trip members list before calling this tool
     paidByMemberNo: z.number().int().positive(),
     splitType: z.enum(["equal", "custom", "itemized"]),
-    category: z
-      .enum([
-        "transportation",
-        "accommodation",
-        "meals",
-        "communication",
-        "supplies",
-        "entertainment",
-        "conference",
-        "other",
-      ])
-      .optional(),
-    currency: currencyEnum.optional(),
+    category: expenseCategorySchema.optional(),
+    currency: currencyCodeSchema.optional(),
     // required when currency differs from the trip currency
     exchangeRate: z.number().positive().max(999999).optional(),
     // at least one split entry is required; amount required for custom/itemized
@@ -208,20 +154,8 @@ export const INPUT_SHAPES = {
     amount: z.number().positive().optional(),
     paidByMemberNo: z.number().int().positive().optional(),
     splitType: z.enum(["equal", "custom", "itemized"]).optional(),
-    category: z
-      .enum([
-        "transportation",
-        "accommodation",
-        "meals",
-        "communication",
-        "supplies",
-        "entertainment",
-        "conference",
-        "other",
-      ])
-      .nullable()
-      .optional(),
-    currency: currencyEnum.optional(),
+    category: expenseCategorySchema.nullable().optional(),
+    currency: currencyCodeSchema.optional(),
     exchangeRate: z.number().positive().max(999999).optional(),
     // if provided, splitType must also be provided (API enforces both-or-neither)
     splits: z.array(splitItemShape).min(1).optional(),

--- a/apps/web/app/(authenticated)/trips/[id]/export/page.tsx
+++ b/apps/web/app/(authenticated)/trips/[id]/export/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ExpensesResponse, TripResponse } from "@sugara/shared";
-import { fromMinorUnits, toCurrencyCode } from "@sugara/shared";
+import { toCurrencyCode } from "@sugara/shared";
 import { useQuery } from "@tanstack/react-query";
 import { CheckCheck, Download, X } from "lucide-react";
 import { useParams } from "next/navigation";
@@ -33,7 +33,6 @@ import {
   type CSVLineEnding,
   DEFAULT_CSV_OPTIONS,
   EXPORT_FIELDS,
-  type ExpenseExportData,
   type ExpenseExportLabels,
   type ExportField,
   type ExportFieldLabels,
@@ -42,6 +41,7 @@ import {
   exportTrip,
   filterCandidateFields,
   type PatternMode,
+  toExpenseExportData,
   type ValueLabels,
 } from "@/lib/export";
 import { useAuthRedirect } from "@/lib/hooks/use-auth-redirect";
@@ -53,44 +53,6 @@ const FORMAT_LABELS: Record<ExportFormat, string> = {
   csv: "CSV (.csv)",
   ics: "iCal (.ics)",
 };
-
-// Convert API response amounts (minor units) to major units for spreadsheet cells.
-// Equal splits are stored in trip currency; custom/itemized use the expense currency.
-function toExpenseExportData(
-  data: ExpensesResponse,
-  translateCategory?: (key: string) => string,
-): ExpenseExportData {
-  const tripCurrency = data.tripCurrency;
-  return {
-    expenses: data.expenses.map((e) => ({
-      title: e.title,
-      amount: fromMinorUnits(e.amount, e.currency),
-      paidByName: e.paidByUser.name,
-      splitType: e.splitType,
-      category: e.category
-        ? translateCategory
-          ? translateCategory(e.category)
-          : e.category
-        : null,
-      splits: e.splits.map((s) => ({
-        name: s.user.name,
-        amount: fromMinorUnits(s.amount, e.splitType === "equal" ? tripCurrency : e.currency),
-      })),
-    })),
-    settlement: {
-      totalAmount: fromMinorUnits(data.settlement.totalAmount, tripCurrency),
-      balances: data.settlement.balances.map((b) => ({
-        name: b.name,
-        net: fromMinorUnits(b.net, tripCurrency),
-      })),
-      transfers: data.settlement.transfers.map((t) => ({
-        fromName: t.from.name,
-        toName: t.to.name,
-        amount: fromMinorUnits(t.amount, tripCurrency),
-      })),
-    },
-  };
-}
 
 function ExpensePreviewTable({
   data,

--- a/apps/web/app/(sp)/sp/trips/[id]/export/page.tsx
+++ b/apps/web/app/(sp)/sp/trips/[id]/export/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ExpensesResponse, TripResponse } from "@sugara/shared";
-import { fromMinorUnits, toCurrencyCode } from "@sugara/shared";
+import { toCurrencyCode } from "@sugara/shared";
 import { useQuery } from "@tanstack/react-query";
 import { ArrowLeft, CheckCheck, Download, X } from "lucide-react";
 import Link from "next/link";
@@ -33,7 +33,6 @@ import {
   type CSVLineEnding,
   DEFAULT_CSV_OPTIONS,
   EXPORT_FIELDS,
-  type ExpenseExportData,
   type ExpenseExportLabels,
   type ExportField,
   type ExportFieldLabels,
@@ -42,6 +41,7 @@ import {
   exportTrip,
   filterCandidateFields,
   type PatternMode,
+  toExpenseExportData,
   type ValueLabels,
 } from "@/lib/export";
 import { useAuthRedirect } from "@/lib/hooks/use-auth-redirect";
@@ -53,44 +53,6 @@ const FORMAT_LABELS: Record<ExportFormat, string> = {
   csv: "CSV (.csv)",
   ics: "iCal (.ics)",
 };
-
-// Convert API response amounts (minor units) to major units for spreadsheet cells.
-// Equal splits are stored in trip currency; custom/itemized use the expense currency.
-function toExpenseExportData(
-  data: ExpensesResponse,
-  translateCategory?: (key: string) => string,
-): ExpenseExportData {
-  const tripCurrency = data.tripCurrency;
-  return {
-    expenses: data.expenses.map((e) => ({
-      title: e.title,
-      amount: fromMinorUnits(e.amount, e.currency),
-      paidByName: e.paidByUser.name,
-      splitType: e.splitType,
-      category: e.category
-        ? translateCategory
-          ? translateCategory(e.category)
-          : e.category
-        : null,
-      splits: e.splits.map((s) => ({
-        name: s.user.name,
-        amount: fromMinorUnits(s.amount, e.splitType === "equal" ? tripCurrency : e.currency),
-      })),
-    })),
-    settlement: {
-      totalAmount: fromMinorUnits(data.settlement.totalAmount, tripCurrency),
-      balances: data.settlement.balances.map((b) => ({
-        name: b.name,
-        net: fromMinorUnits(b.net, tripCurrency),
-      })),
-      transfers: data.settlement.transfers.map((t) => ({
-        fromName: t.from.name,
-        toName: t.to.name,
-        amount: fromMinorUnits(t.amount, tripCurrency),
-      })),
-    },
-  };
-}
 
 function ExportSkeleton() {
   return (

--- a/apps/web/components/expense-dialog.tsx
+++ b/apps/web/components/expense-dialog.tsx
@@ -14,6 +14,8 @@ import {
   expenseCategorySchema,
   formatCurrency,
   fromMinorUnits,
+  getAmountInputStep,
+  getSplitDisplayCurrency,
   toMinorUnits,
 } from "@sugara/shared";
 import { useQuery } from "@tanstack/react-query";
@@ -147,7 +149,11 @@ export function ExpenseDialog({
       setSelectedMembers(new Set(expense.splits.map((s) => s.userId)));
       const amounts: Record<string, string> = {};
       // Equal splits are stored in trip currency; custom/itemized use expense currency
-      const splitCurrency = expense.splitType === "equal" ? tripCurrency : expense.currency;
+      const splitCurrency = getSplitDisplayCurrency(
+        expense.splitType,
+        tripCurrency,
+        expense.currency,
+      );
       for (const s of expense.splits) {
         amounts[s.userId] = String(fromMinorUnits(s.amount, splitCurrency));
       }
@@ -433,7 +439,7 @@ export function ExpenseDialog({
               onChange={(e) => setAmount(e.target.value)}
               placeholder="0"
               min={CURRENCIES[currency].decimals > 0 ? "0.01" : "1"}
-              step={CURRENCIES[currency].decimals > 0 ? "0.01" : "1"}
+              step={getAmountInputStep(currency)}
               required
             />
           </div>
@@ -559,7 +565,7 @@ export function ExpenseDialog({
                           }
                           placeholder="0"
                           min={0}
-                          step={CURRENCIES[currency].decimals > 0 ? "0.01" : "1"}
+                          step={getAmountInputStep(currency)}
                         />
                       </div>
                     ))}
@@ -626,7 +632,7 @@ export function ExpenseDialog({
                       placeholder={te("lineItemAmountPlaceholder")}
                       className="w-24"
                       min={0}
-                      step={CURRENCIES[currency].decimals > 0 ? "0.01" : "1"}
+                      step={getAmountInputStep(currency)}
                     />
                     <Button
                       type="button"

--- a/apps/web/components/expense-panel.tsx
+++ b/apps/web/components/expense-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { CurrencyCode, ExpenseItem, ExpensesResponse } from "@sugara/shared";
-import { formatCurrency } from "@sugara/shared";
+import { formatCurrency, getSplitDisplayCurrency } from "@sugara/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   ArrowUpDown,
@@ -611,7 +611,11 @@ function ExpenseRow({
                 .sort((a, b) => b.amount - a.amount)
                 .map((split) => {
                   // Equal splits are calculated in base currency; custom/itemized remain in expense currency
-                  const splitCurrency = expense.splitType === "equal" ? tripCurrency : currency;
+                  const splitCurrency = getSplitDisplayCurrency(
+                    expense.splitType,
+                    tripCurrency,
+                    currency,
+                  );
                   return (
                     <div
                       key={split.userId}

--- a/apps/web/lib/__tests__/export.test.ts
+++ b/apps/web/lib/__tests__/export.test.ts
@@ -2,6 +2,7 @@ import type {
   CandidateResponse,
   DayPatternResponse,
   DayResponse,
+  ExpensesResponse,
   ScheduleResponse,
   TripResponse,
 } from "@sugara/shared";
@@ -29,6 +30,7 @@ import {
   filterCandidateFields,
   rowsToCSV,
   scheduleToRow,
+  toExpenseExportData,
   type ValueLabels,
 } from "../export";
 
@@ -1275,6 +1277,89 @@ describe("exportTripToCSV - expenses", () => {
     });
 
     expect(capturedContent).not.toContain("Expenses");
+  });
+});
+
+// --- toExpenseExportData ---
+
+describe("toExpenseExportData", () => {
+  function makeExpensesResponse(overrides: Partial<ExpensesResponse> = {}): ExpensesResponse {
+    return {
+      tripCurrency: "JPY",
+      expenses: [],
+      settlement: {
+        totalAmount: 0,
+        balances: [],
+        transfers: [],
+        directTransfers: [],
+      },
+      settlementPayments: [],
+      categoryTotals: [],
+      memberTotals: [],
+      ...overrides,
+    };
+  }
+
+  it("uses trip currency for split amounts on equal split", () => {
+    // JPY has 0 decimals; USD has 2 decimals. tripCurrency=JPY, expenseCurrency=USD.
+    // Equal split resolves splits in trip currency (JPY):
+    //   fromMinorUnits(500, "JPY") = 500
+    //   fromMinorUnits(500, "USD") = 5  (would be wrong value)
+    const data = makeExpensesResponse({
+      tripCurrency: "JPY",
+      expenses: [
+        {
+          id: "e1",
+          title: "Dinner",
+          amount: 1000,
+          currency: "USD",
+          exchangeRate: null,
+          baseAmount: null,
+          splitType: "equal",
+          category: null,
+          paidByUserId: "u1",
+          paidByUser: { id: "u1", name: "Alice" },
+          splits: [{ userId: "u1", amount: 500, user: { id: "u1", name: "Alice" } }],
+          lineItems: [],
+          createdAt: "2025-01-01T00:00:00Z",
+        },
+      ],
+    });
+
+    const result = toExpenseExportData(data);
+
+    expect(result.expenses[0].splits[0].amount).toBe(500);
+  });
+
+  it("uses expense currency for split amounts on custom split", () => {
+    // JPY has 0 decimals; USD has 2 decimals. tripCurrency=JPY, expenseCurrency=USD.
+    // Custom split resolves splits in expense currency (USD):
+    //   fromMinorUnits(625, "USD") = 6.25
+    //   fromMinorUnits(625, "JPY") = 625  (would be wrong value)
+    const data = makeExpensesResponse({
+      tripCurrency: "JPY",
+      expenses: [
+        {
+          id: "e1",
+          title: "Taxi",
+          amount: 1250,
+          currency: "USD",
+          exchangeRate: null,
+          baseAmount: null,
+          splitType: "custom",
+          category: null,
+          paidByUserId: "u1",
+          paidByUser: { id: "u1", name: "Alice" },
+          splits: [{ userId: "u1", amount: 625, user: { id: "u1", name: "Alice" } }],
+          lineItems: [],
+          createdAt: "2025-01-01T00:00:00Z",
+        },
+      ],
+    });
+
+    const result = toExpenseExportData(data);
+
+    expect(result.expenses[0].splits[0].amount).toBe(6.25);
   });
 });
 

--- a/apps/web/lib/export.ts
+++ b/apps/web/lib/export.ts
@@ -3,10 +3,16 @@ import type {
   CurrencyCode,
   DayPatternResponse,
   DayResponse,
+  ExpensesResponse,
   ScheduleResponse,
   TripResponse,
 } from "@sugara/shared";
-import { formatWholeUnits, toCurrencyCode } from "@sugara/shared";
+import {
+  formatWholeUnits,
+  fromMinorUnits,
+  getSplitDisplayCurrency,
+  toCurrencyCode,
+} from "@sugara/shared";
 import { formatDate, formatTime, toDateString } from "@/lib/format";
 
 // Ordered by: When → What → Where → How → Extra → Meta
@@ -319,6 +325,47 @@ export function buildPreviewRows(
     }
   }
   return rows;
+}
+
+// Convert API response amounts (minor units) to major units for spreadsheet cells.
+// Equal splits are stored in trip currency; custom/itemized use the expense currency.
+export function toExpenseExportData(
+  data: ExpensesResponse,
+  translateCategory?: (key: string) => string,
+): ExpenseExportData {
+  const tripCurrency = data.tripCurrency;
+  return {
+    expenses: data.expenses.map((e) => ({
+      title: e.title,
+      amount: fromMinorUnits(e.amount, e.currency),
+      paidByName: e.paidByUser.name,
+      splitType: e.splitType,
+      category: e.category
+        ? translateCategory
+          ? translateCategory(e.category)
+          : e.category
+        : null,
+      splits: e.splits.map((s) => ({
+        name: s.user.name,
+        amount: fromMinorUnits(
+          s.amount,
+          getSplitDisplayCurrency(e.splitType, tripCurrency, e.currency),
+        ),
+      })),
+    })),
+    settlement: {
+      totalAmount: fromMinorUnits(data.settlement.totalAmount, tripCurrency),
+      balances: data.settlement.balances.map((b) => ({
+        name: b.name,
+        net: fromMinorUnits(b.net, tripCurrency),
+      })),
+      transfers: data.settlement.transfers.map((t) => ({
+        fromName: t.from.name,
+        toName: t.to.name,
+        amount: fromMinorUnits(t.amount, tripCurrency),
+      })),
+    },
+  };
 }
 
 export type ExpenseExportResult = {

--- a/bun.lock
+++ b/bun.lock
@@ -66,6 +66,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
+        "@sugara/shared": "workspace:*",
         "zod": "4.4.3",
       },
       "devDependencies": {

--- a/packages/shared/src/__tests__/expense-helpers.test.ts
+++ b/packages/shared/src/__tests__/expense-helpers.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { getAmountInputStep } from "../currency";
+import { getSplitDisplayCurrency, splitsTotalMatchesAmount } from "../schemas/expense";
+
+describe("splitsTotalMatchesAmount", () => {
+  it("returns true for equal split regardless of amounts", () => {
+    // Arrange
+    const data = {
+      splitType: "equal" as const,
+      splits: [{ amount: undefined }, { amount: undefined }],
+      currency: "JPY" as const,
+      amount: 1000,
+    };
+
+    // Act
+    const result = splitsTotalMatchesAmount(data);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  it("returns true for custom split when minor-unit totals match (USD 6.25+6.25=12.50)", () => {
+    // Arrange
+    const data = {
+      splitType: "custom" as const,
+      splits: [{ amount: 6.25 }, { amount: 6.25 }],
+      currency: "USD" as const,
+      amount: 12.5,
+    };
+
+    // Act
+    const result = splitsTotalMatchesAmount(data);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  it("returns false for custom split when minor-unit totals do not match", () => {
+    // Arrange — 6.25 + 6.30 = 12.55 ≠ 12.50 (1255 ≠ 1250 minor units)
+    const data = {
+      splitType: "custom" as const,
+      splits: [{ amount: 6.25 }, { amount: 6.3 }],
+      currency: "USD" as const,
+      amount: 12.5,
+    };
+
+    // Act
+    const result = splitsTotalMatchesAmount(data);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+});
+
+describe("getSplitDisplayCurrency", () => {
+  it("returns trip currency for equal split", () => {
+    // Arrange / Act / Assert
+    expect(getSplitDisplayCurrency("equal", "JPY", "USD")).toBe("JPY");
+  });
+
+  it("returns expense currency for custom split", () => {
+    // Arrange / Act / Assert
+    expect(getSplitDisplayCurrency("custom", "JPY", "USD")).toBe("USD");
+  });
+
+  it("returns expense currency for itemized split", () => {
+    // Arrange / Act / Assert
+    expect(getSplitDisplayCurrency("itemized", "JPY", "EUR")).toBe("EUR");
+  });
+});
+
+describe("getAmountInputStep", () => {
+  it("returns '1' for JPY (zero decimals)", () => {
+    // Arrange / Act / Assert
+    expect(getAmountInputStep("JPY")).toBe("1");
+  });
+
+  it("returns '0.01' for USD (two decimals)", () => {
+    // Arrange / Act / Assert
+    expect(getAmountInputStep("USD")).toBe("0.01");
+  });
+
+  it("returns '1' for KRW (zero decimals)", () => {
+    // Arrange / Act / Assert
+    expect(getAmountInputStep("KRW")).toBe("1");
+  });
+});

--- a/packages/shared/src/currency.ts
+++ b/packages/shared/src/currency.ts
@@ -64,6 +64,12 @@ export function fromMinorUnits(minorAmount: number, currency: CurrencyCode): num
   return minorAmount / 10 ** decimals;
 }
 
+// Input step for an amount field: one minor unit expressed in major units (e.g. "0.01" for USD, "1" for JPY).
+export function getAmountInputStep(currency: CurrencyCode): string {
+  const { decimals } = CURRENCIES[currency];
+  return decimals > 0 ? (1 / 10 ** decimals).toString() : "1";
+}
+
 // Converts fromMinor units of fromCurrency to minor units of baseCurrency.
 // Formula: round(fromMinor * rate * 10^baseDecimals / 10^fromDecimals)
 // Rate is the number of baseCurrency major units per 1 fromCurrency major unit.

--- a/packages/shared/src/currency.ts
+++ b/packages/shared/src/currency.ts
@@ -65,9 +65,11 @@ export function fromMinorUnits(minorAmount: number, currency: CurrencyCode): num
 }
 
 // Input step for an amount field: one minor unit expressed in major units (e.g. "0.01" for USD, "1" for JPY).
+// toFixed keeps the value in plain decimal notation; naive division would yield
+// exponent notation ("1e-7") for high-decimal currencies, which is invalid as an input step.
 export function getAmountInputStep(currency: CurrencyCode): string {
   const { decimals } = CURRENCIES[currency];
-  return decimals > 0 ? (1 / 10 ** decimals).toString() : "1";
+  return decimals > 0 ? (10 ** -decimals).toFixed(decimals) : "1";
 }
 
 // Converts fromMinor units of fromCurrency to minor units of baseCurrency.

--- a/packages/shared/src/schemas/expense.ts
+++ b/packages/shared/src/schemas/expense.ts
@@ -1,11 +1,38 @@
 import { z } from "zod";
-import { currencyCodeSchema, toMinorUnits } from "../currency";
+import { type CurrencyCode, currencyCodeSchema, toMinorUnits } from "../currency";
 import { MAX_EXPENSES_PER_TRIP, MAX_LINE_ITEMS_PER_EXPENSE } from "../limits";
 
 export const EXPENSE_TITLE_MAX_LENGTH = 200;
 
 export const expenseSplitTypeSchema = z.enum(["equal", "custom", "itemized"]);
 export type ExpenseSplitType = z.infer<typeof expenseSplitTypeSchema>;
+
+// Compare in minor units so that e.g. 6.25 + 6.25 === 12.50 for USD
+// (floating-point addition of major units would lose precision).
+export function splitsTotalMatchesAmount(data: {
+  splitType: ExpenseSplitType;
+  splits: ReadonlyArray<{ amount?: number }>;
+  currency: CurrencyCode;
+  amount: number;
+}): boolean {
+  if (data.splitType === "custom" || data.splitType === "itemized") {
+    const splitMinor = data.splits.reduce(
+      (sum, s) => sum + toMinorUnits(s.amount ?? 0, data.currency),
+      0,
+    );
+    return splitMinor === toMinorUnits(data.amount, data.currency);
+  }
+  return true;
+}
+
+// Equal splits are stored in the trip currency; custom/itemized splits in the expense currency.
+export function getSplitDisplayCurrency(
+  splitType: ExpenseSplitType,
+  tripCurrency: CurrencyCode,
+  expenseCurrency: CurrencyCode,
+): CurrencyCode {
+  return splitType === "equal" ? tripCurrency : expenseCurrency;
+}
 
 export const expenseCategorySchema = z.enum([
   "transportation",
@@ -60,21 +87,10 @@ export const createExpenseSchema = z
     },
     { message: "Custom splits require amount for each member", path: ["splits"] },
   )
-  .refine(
-    (data) => {
-      if (data.splitType === "custom" || data.splitType === "itemized") {
-        // Compare in minor units so that e.g. 6.25 + 6.25 === 12.50 for USD
-        // (floating-point addition of major units would lose precision).
-        const splitMinor = data.splits.reduce(
-          (sum, s) => sum + toMinorUnits(s.amount ?? 0, data.currency),
-          0,
-        );
-        return splitMinor === toMinorUnits(data.amount, data.currency);
-      }
-      return true;
-    },
-    { message: "Split amounts must equal total amount", path: ["splits"] },
-  )
+  .refine((data) => splitsTotalMatchesAmount(data), {
+    message: "Split amounts must equal total amount",
+    path: ["splits"],
+  })
   .refine(
     (data) => {
       if (data.splitType === "itemized") {


### PR DESCRIPTION
## Summary

- 外部 API v1 / MCP / web に点在していた重複コード(member 解決・DTO serializer・enum・通貨分岐)を単一情報源に集約し、将来の変更が 1 箇所で済む構造にした
- expense 書き込み(POST/PATCH)の DB 往復を削減(tripMembers 再取得の回避・レスポンス用再 SELECT の廃止・memberNo 解決の O(1) 化)
- 動作・レスポンス形状には影響しない品質改善のみ

## Why

PR #135 / #141 のレビューで挙がった品質指摘のまとめ対応(Issue #138)。重複コピーは「Mirror of...」「mirrored from...」とコメントで自己申告される状態で、shared の enum 追加や DTO 変更が複数箇所の手修正を要する構造だった。read/write でレスポンス形状が暗黙に同形なものは serializer を共有し、意図的に形状が異なるもの(trip read の role、schedule read の簡略形、article list の content なし)はあえて統一せず、その方針を serializers.ts のコメントに明記した。

## Changes

- **shared**: `splitsTotalMatchesAmount` / `getSplitDisplayCurrency` / `getAmountInputStep` を抽出し、shared 自身と v1 write-schemas の逐語コピー refine を置換
- **web**: `toExpenseExportData` を `lib/export.ts` に集約(export 2 ページの逐語コピー解消)、split 表示通貨の分岐 4 箇所と金額入力 step の 3 箇所を shared ヘルパーに置換
- **MCP**: `@sugara/shared` workspace 依存を追加し、手書き enum 5 種(currency / schedule category / transportMethod / color / expense category、create/update 間の逐語重複含む)を shared の Zod schema に一本化
- **API v1**: `resolveMemberRef` を `lib/external-api/member-no.ts` に、`getActorName` を `v1/shared.ts` に集約。read/write 同形の DTO 構築を新規 `v1/serializers.ts` に統一
- **expense 書き込みの効率化**: ルートで取得済みの member 集合を `createExpenseCore` / `updateExpenseCore` にオプション引数で受け渡し(内部 API は無変更)、レスポンスは service が返す INSERT 済み splits からメモリ構築(PATCH の splits 未変更時のみフォールバック SELECT)、memberNo→userId は逆引き Map で O(1) 解決
- **fix**: `expense_line_item_members` の取得に userId 昇順の ORDER BY を追加し、members 配列の順序を決定的にした

## Test plan

- [x] `bun run check` / `bun run check-types` — 全パッケージ緑
- [x] `bun run test` — shared 248 / api 844 / web 748 / mcp 93 すべて緑
- [x] `bun run --filter @sugara/api test:integration` — 126 件緑(レスポンス形状の black-box 回帰ゲートである v1-writes integration を無修正で通過)
- [x] 新規テスト: shared ヘルパー 3 種、`invertMemberNoMap` / `resolveMemberRef`(集約先)、`toExpenseExportData`、PATCH expense のレスポンス構築(service 結果から構築 / フォールバック SELECT の両経路)

## Notes for reviewer

- 計画では集約(refactor)と往復削減(perf)を別コミットにする想定だったが、`member-no.ts` / `expenses-write.ts` が両方に跨り単独でコンパイル不能な中間状態になるため 1 コミットに統合した
- `CreateExpenseResult` の ok-variant に `splits` を必須追加(呼び忘れを型で防止)、`UpdateExpenseResult` はオプショナル(splits 未変更の partial update では返らないことを型で表現)
- レビューで検出した trip status enum の手書きコピー(MCP `tools.ts` / v1 `write-schemas.ts`)も shared の `tripStatusSchema` に統一済み。`getAmountInputStep` は toFixed 導出にして高 decimals 通貨での指数表記を予防
- ORDER BY 追加は出力順が変わりうるが、不定順を決定的にする修正のため fix 扱い

## Related

- Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)
