### PR TITLE
fix: pollsとbookmarks単体追加のsortOrder採番をMAX+1に変更し削除後の重複を解消

### DIFF
--- a/apps/api/src/__tests__/bookmark-lists.test.ts
+++ b/apps/api/src/__tests__/bookmark-lists.test.ts
@@ -118,11 +118,21 @@ describe("Bookmark list routes", () => {
         createdAt: new Date(),
         updatedAt: new Date(),
       };
-      mockDbInsert.mockReturnValue({
-        values: vi.fn().mockReturnValue({
-          returning: vi.fn().mockResolvedValue([created]),
+      // First select: COUNT (limit check); second: COALESCE(MAX(sortOrder), -1) (#143)
+      mockDbSelect.mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ count: 3 }]),
         }),
       });
+      mockDbSelect.mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ max: 2 }]),
+        }),
+      });
+      const insertValues = vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([created]),
+      });
+      mockDbInsert.mockReturnValue({ values: insertValues });
 
       const app = createTestApp(bookmarkListRoutes, "/api/bookmark-lists");
       const res = await app.request("/api/bookmark-lists", {
@@ -132,6 +142,8 @@ describe("Bookmark list routes", () => {
       });
 
       expect(res.status).toBe(201);
+      // MAX(sortOrder)=2 -> new list gets 3 (gap-safe MAX+1, not COUNT)
+      expect(insertValues).toHaveBeenCalledWith(expect.objectContaining({ sortOrder: 3 }));
     });
 
     it("returns 400 with empty name", async () => {

--- a/apps/api/src/__tests__/bookmarks.test.ts
+++ b/apps/api/src/__tests__/bookmarks.test.ts
@@ -109,11 +109,21 @@ describe("Bookmark routes", () => {
         sortOrder: 0,
         listId,
       };
-      mockDbInsert.mockReturnValue({
-        values: vi.fn().mockReturnValue({
-          returning: vi.fn().mockResolvedValue([created]),
+      // First select: COUNT (limit check); second: COALESCE(MAX(sortOrder), -1) (#143)
+      mockDbSelect.mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ count: 3 }]),
         }),
       });
+      mockDbSelect.mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ max: 2 }]),
+        }),
+      });
+      const insertValues = vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([created]),
+      });
+      mockDbInsert.mockReturnValue({ values: insertValues });
 
       const app = createTestApp(bookmarkRoutes, "/api/bookmark-lists");
       const res = await app.request(`/api/bookmark-lists/${listId}/bookmarks`, {
@@ -123,6 +133,8 @@ describe("Bookmark routes", () => {
       });
 
       expect(res.status).toBe(201);
+      // MAX(sortOrder)=2 -> new bookmark gets 3 (gap-safe MAX+1, not COUNT)
+      expect(insertValues).toHaveBeenCalledWith(expect.objectContaining({ sortOrder: 3 }));
     });
 
     it("returns 409 when bookmark limit reached", async () => {

--- a/apps/api/src/__tests__/integration/bookmarks.integration.test.ts
+++ b/apps/api/src/__tests__/integration/bookmarks.integration.test.ts
@@ -20,12 +20,15 @@ vi.mock("../../lib/auth", () => ({
   },
 }));
 
+import { asc, eq } from "drizzle-orm";
 import { bookmarkLists } from "../../db/schema";
+import { bookmarkListRoutes } from "../../routes/bookmark-lists";
 import { bookmarkRoutes } from "../../routes/bookmarks";
 import { cleanupTables, createTestUser, getTestDb, teardownTestDb } from "./setup";
 
 function createApp() {
   const app = new Hono();
+  app.route("/api/bookmark-lists", bookmarkListRoutes);
   app.route("/api/bookmark-lists", bookmarkRoutes);
   return app;
 }
@@ -59,7 +62,6 @@ describe("Bookmarks Integration", () => {
 
   afterAll(async () => {
     await cleanupTables();
-    await teardownTestDb();
   });
 
   async function createBookmark(name: string) {
@@ -84,4 +86,78 @@ describe("Bookmarks Integration", () => {
     // Assert: MAX+1, not COUNT (COUNT=2 would collide with C's sortOrder)
     expect(d.sortOrder).toBe(3);
   });
+});
+
+describe("Bookmark list sortOrder after deletion", () => {
+  const app = createApp();
+  let owner: { id: string; name: string; email: string };
+
+  beforeEach(async () => {
+    await cleanupTables();
+    owner = await createTestUser({ name: "Owner", email: "owner@test.com" });
+    mockGetSession.mockImplementation(() => ({
+      user: owner,
+      session: { id: "test-session" },
+    }));
+  });
+
+  afterAll(async () => {
+    await cleanupTables();
+  });
+
+  async function createList(name: string) {
+    const res = await app.request("/api/bookmark-lists", json({ name }));
+    expect(res.status).toBe(201);
+    return res.json();
+  }
+
+  /** Create lists A/B/C (sortOrder 0/1/2), delete B, return remaining lists. */
+  async function arrangeGap() {
+    const a = await createList("A");
+    const b = await createList("B");
+    const c = await createList("C");
+    await app.request(`/api/bookmark-lists/${b.id}`, { method: "DELETE" });
+    return { a, c };
+  }
+
+  it("assigns a non-colliding sortOrder to a list created after deleting a middle list", async () => {
+    await arrangeGap();
+
+    const d = await createList("D");
+
+    // MAX+1, not COUNT (COUNT=2 would collide with C's sortOrder)
+    expect(d.sortOrder).toBe(3);
+  });
+
+  it("assigns a non-colliding sortOrder when duplicating a list after deleting a middle list", async () => {
+    const { a } = await arrangeGap();
+
+    const res = await app.request(`/api/bookmark-lists/${a.id}/duplicate`, { method: "POST" });
+    const copy = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(copy.sortOrder).toBe(3);
+  });
+
+  it("assigns non-colliding sequential sortOrders when batch-duplicating after deleting a middle list", async () => {
+    const { a, c } = await arrangeGap();
+
+    const res = await app.request(
+      "/api/bookmark-lists/batch-duplicate",
+      json({ listIds: [a.id, c.id] }),
+    );
+
+    expect(res.status).toBe(201);
+    const rows = await getTestDb()
+      .select({ name: bookmarkLists.name, sortOrder: bookmarkLists.sortOrder })
+      .from(bookmarkLists)
+      .where(eq(bookmarkLists.userId, owner.id))
+      .orderBy(asc(bookmarkLists.sortOrder));
+    // A(0), C(2) survive; the two copies continue from MAX+1 = 3
+    expect(rows.map((r) => r.sortOrder)).toEqual([0, 2, 3, 4]);
+  });
+});
+
+afterAll(async () => {
+  await teardownTestDb();
 });

--- a/apps/api/src/__tests__/integration/bookmarks.integration.test.ts
+++ b/apps/api/src/__tests__/integration/bookmarks.integration.test.ts
@@ -1,0 +1,87 @@
+// Integration tests for bookmark routes against a real PostgreSQL database.
+// Focus: sortOrder assignment must survive deletions (#143) — COUNT-based
+// numbering collides with existing rows after a non-last bookmark is removed.
+
+import { Hono } from "hono";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetSession = vi.fn();
+
+vi.mock("../../db/index", async () => {
+  const { getTestDb } = await import("./setup");
+  return { db: getTestDb() };
+});
+
+vi.mock("../../lib/auth", () => ({
+  auth: {
+    api: {
+      getSession: (...args: unknown[]) => mockGetSession(...args),
+    },
+  },
+}));
+
+import { bookmarkLists } from "../../db/schema";
+import { bookmarkRoutes } from "../../routes/bookmarks";
+import { cleanupTables, createTestUser, getTestDb, teardownTestDb } from "./setup";
+
+function createApp() {
+  const app = new Hono();
+  app.route("/api/bookmark-lists", bookmarkRoutes);
+  return app;
+}
+
+function json(body: unknown) {
+  return {
+    method: "POST" as const,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  };
+}
+
+describe("Bookmarks Integration", () => {
+  const app = createApp();
+  let owner: { id: string; name: string; email: string };
+  let listId: string;
+
+  beforeEach(async () => {
+    await cleanupTables();
+    owner = await createTestUser({ name: "Owner", email: "owner@test.com" });
+    mockGetSession.mockImplementation(() => ({
+      user: owner,
+      session: { id: "test-session" },
+    }));
+    const [list] = await getTestDb()
+      .insert(bookmarkLists)
+      .values({ userId: owner.id, name: "My List" })
+      .returning();
+    listId = list.id;
+  });
+
+  afterAll(async () => {
+    await cleanupTables();
+    await teardownTestDb();
+  });
+
+  async function createBookmark(name: string) {
+    const res = await app.request(
+      `/api/bookmark-lists/${listId}/bookmarks`,
+      json({ name, urls: [] }),
+    );
+    expect(res.status).toBe(201);
+    return res.json();
+  }
+
+  it("assigns a non-colliding sortOrder to a bookmark created after deleting a middle bookmark", async () => {
+    // Arrange: bookmarks A/B/C get sortOrder 0/1/2; deleting B leaves a gap
+    await createBookmark("A");
+    const b = await createBookmark("B");
+    await createBookmark("C");
+    await app.request(`/api/bookmark-lists/${listId}/bookmarks/${b.id}`, { method: "DELETE" });
+
+    // Act
+    const d = await createBookmark("D");
+
+    // Assert: MAX+1, not COUNT (COUNT=2 would collide with C's sortOrder)
+    expect(d.sortOrder).toBe(3);
+  });
+});

--- a/apps/api/src/__tests__/integration/polls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/polls.integration.test.ts
@@ -170,6 +170,30 @@ describe("Polls Integration", () => {
     expect(poll.myParticipantId).toBeTruthy();
   });
 
+  it("assigns a non-colliding sortOrder to an option added after deleting a middle option", async () => {
+    // Arrange: options A/B/C get sortOrder 0/1/2; deleting B leaves a gap
+    const { pollId, poll } = await createTripWithPoll(app, {
+      pollOptions: [
+        { startDate: "2025-07-01", endDate: "2025-07-03" },
+        { startDate: "2025-07-10", endDate: "2025-07-12" },
+        { startDate: "2025-07-20", endDate: "2025-07-22" },
+      ],
+    });
+    const middle = poll.options[1];
+    await app.request(`/api/polls/${pollId}/options/${middle.id}`, { method: "DELETE" });
+
+    // Act
+    const res = await app.request(
+      `/api/polls/${pollId}/options`,
+      json({ startDate: "2025-08-01", endDate: "2025-08-03" }),
+    );
+    const option = await res.json();
+
+    // Assert: MAX+1, not COUNT (COUNT=2 would collide with option C's sortOrder)
+    expect(res.status).toBe(201);
+    expect(option.sortOrder).toBe(3);
+  });
+
   it("updates poll note", async () => {
     const { pollId } = await createTripWithPoll(app);
 

--- a/apps/api/src/__tests__/polls.test.ts
+++ b/apps/api/src/__tests__/polls.test.ts
@@ -147,20 +147,25 @@ describe("Poll routes", () => {
           where: vi.fn().mockResolvedValue([]),
         }),
       });
-
-      mockDbInsert.mockReturnValue({
-        values: vi.fn().mockReturnValue({
-          returning: vi.fn().mockResolvedValue([
-            {
-              id: "new-opt",
-              pollId: "poll-1",
-              startDate: "2026-02-05",
-              endDate: "2026-02-07",
-              sortOrder: 1,
-            },
-          ]),
+      // Third select: COALESCE(MAX(sortOrder), -1) for gap-safe numbering (#143)
+      mockDbSelect.mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ max: 1 }]),
         }),
       });
+
+      const insertValues = vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([
+          {
+            id: "new-opt",
+            pollId: "poll-1",
+            startDate: "2026-02-05",
+            endDate: "2026-02-07",
+            sortOrder: 2,
+          },
+        ]),
+      });
+      mockDbInsert.mockReturnValue({ values: insertValues });
 
       mockDbUpdate.mockReturnValue({
         set: vi.fn().mockReturnValue({
@@ -179,6 +184,8 @@ describe("Poll routes", () => {
       });
 
       expect(res.status).toBe(201);
+      // MAX(sortOrder)=1 → next option gets 2 (gap-safe MAX+1, not COUNT)
+      expect(insertValues).toHaveBeenCalledWith(expect.objectContaining({ sortOrder: 2 }));
     });
   });
 

--- a/apps/api/src/routes/bookmark-lists.ts
+++ b/apps/api/src/routes/bookmark-lists.ts
@@ -12,6 +12,7 @@ import { bookmarkLists, bookmarks } from "../db/schema";
 import { ERROR_MSG } from "../lib/constants";
 import { hasChanges } from "../lib/has-changes";
 import { getParam } from "../lib/params";
+import { getNextSortOrder } from "../lib/sort-order";
 import { requireAuth } from "../middleware/auth";
 import { requireNonGuest } from "../middleware/require-non-guest";
 import type { AppEnv } from "../types";
@@ -63,13 +64,22 @@ bookmarkListRoutes.post("/", async (c) => {
       return null;
     }
 
+    // MAX+1, not COUNT: deleting a non-last list leaves a gap, and a
+    // COUNT-based value would collide with an existing sortOrder (#143).
+    const sortOrder = await getNextSortOrder(
+      tx,
+      bookmarkLists.sortOrder,
+      bookmarkLists,
+      eq(bookmarkLists.userId, user.id),
+    );
+
     const [result] = await tx
       .insert(bookmarkLists)
       .values({
         userId: user.id,
         name: parsed.data.name,
         visibility: parsed.data.visibility,
-        sortOrder: listCount,
+        sortOrder,
       })
       .returning();
 
@@ -170,13 +180,21 @@ bookmarkListRoutes.post("/:listId/duplicate", async (c) => {
       return null;
     }
 
+    // MAX+1, not COUNT: see the create handler above (#143).
+    const sortOrder = await getNextSortOrder(
+      tx,
+      bookmarkLists.sortOrder,
+      bookmarkLists,
+      eq(bookmarkLists.userId, user.id),
+    );
+
     const [newList] = await tx
       .insert(bookmarkLists)
       .values({
         userId: user.id,
         name: `${source.name} (copy)`,
         visibility: source.visibility,
-        sortOrder: listCount,
+        sortOrder,
       })
       .returning();
 
@@ -253,6 +271,14 @@ bookmarkListRoutes.post("/batch-duplicate", async (c) => {
       return null;
     }
 
+    // MAX+1, not COUNT: see the create handler above (#143).
+    const baseSortOrder = await getNextSortOrder(
+      tx,
+      bookmarkLists.sortOrder,
+      bookmarkLists,
+      eq(bookmarkLists.userId, user.id),
+    );
+
     for (let i = 0; i < sources.length; i++) {
       const source = sources[i];
       const [newList] = await tx
@@ -261,7 +287,7 @@ bookmarkListRoutes.post("/batch-duplicate", async (c) => {
           userId: user.id,
           name: `${source.name} (copy)`,
           visibility: source.visibility,
-          sortOrder: listCount + i,
+          sortOrder: baseSortOrder + i,
         })
         .returning();
 

--- a/apps/api/src/routes/bookmarks.ts
+++ b/apps/api/src/routes/bookmarks.ts
@@ -15,6 +15,7 @@ import { ERROR_MSG } from "../lib/constants";
 import { hasChanges } from "../lib/has-changes";
 import { getParam } from "../lib/params";
 import { checkTripAccess } from "../lib/permissions";
+import { getNextSortOrder } from "../lib/sort-order";
 import { requireAuth } from "../middleware/auth";
 import { requireNonGuest } from "../middleware/require-non-guest";
 import type { AppEnv } from "../types";
@@ -63,6 +64,16 @@ bookmarkRoutes.post("/:listId/bookmarks", async (c) => {
       return null;
     }
 
+    // MAX+1, not COUNT: deleting a non-last bookmark leaves a gap, and a
+    // COUNT-based value would collide with an existing sortOrder (#143).
+    // The batch path below (from-schedules) already numbers this way.
+    const sortOrder = await getNextSortOrder(
+      tx,
+      bookmarks.sortOrder,
+      bookmarks,
+      eq(bookmarks.listId, listId),
+    );
+
     const [result] = await tx
       .insert(bookmarks)
       .values({
@@ -70,7 +81,7 @@ bookmarkRoutes.post("/:listId/bookmarks", async (c) => {
         name: parsed.data.name,
         memo: parsed.data.memo ?? null,
         urls: parsed.data.urls,
-        sortOrder: bmCount,
+        sortOrder,
       })
       .returning();
 

--- a/apps/api/src/routes/polls.ts
+++ b/apps/api/src/routes/polls.ts
@@ -28,6 +28,7 @@ import { createNotification, notifyArticleOwnersOnMemberAdded } from "../lib/not
 import { getParam } from "../lib/params";
 import { findPollAsEditor, findPollAsOwner, findPollAsParticipant } from "../lib/poll-access";
 import { generateShareToken, shareExpiresAt } from "../lib/share-token";
+import { getNextSortOrder } from "../lib/sort-order";
 import { createInitialTripDays } from "../lib/trip-days";
 import { requireAuth } from "../middleware/auth";
 import type { AppEnv } from "../types";
@@ -274,39 +275,62 @@ pollRoutes.post("/:pollId/options", async (c) => {
   if (!poll) return c.json({ error: ERROR_MSG.POLL_NOT_FOUND }, 404);
   if (poll.status !== "open") return c.json({ error: ERROR_MSG.POLL_NOT_OPEN }, 400);
 
-  const [optionCount] = await db
-    .select({ count: count() })
-    .from(schedulePollOptions)
-    .where(eq(schedulePollOptions.pollId, pollId));
-  if (optionCount.count >= MAX_OPTIONS_PER_POLL) {
-    return c.json({ error: ERROR_MSG.LIMIT_POLL_OPTIONS }, 409);
-  }
+  // Limit check, duplicate check, and insert share one transaction so that a
+  // concurrent request cannot slip past the limit between the check and the insert.
+  const result = await db.transaction(async (tx) => {
+    const [optionCount] = await tx
+      .select({ count: count() })
+      .from(schedulePollOptions)
+      .where(eq(schedulePollOptions.pollId, pollId));
+    if (optionCount.count >= MAX_OPTIONS_PER_POLL) {
+      return { error: ERROR_MSG.LIMIT_POLL_OPTIONS };
+    }
 
-  const [duplicate] = await db
-    .select({ id: schedulePollOptions.id })
-    .from(schedulePollOptions)
-    .where(
-      and(
-        eq(schedulePollOptions.pollId, pollId),
-        eq(schedulePollOptions.startDate, parsed.data.startDate),
-        eq(schedulePollOptions.endDate, parsed.data.endDate),
-      ),
+    const [duplicate] = await tx
+      .select({ id: schedulePollOptions.id })
+      .from(schedulePollOptions)
+      .where(
+        and(
+          eq(schedulePollOptions.pollId, pollId),
+          eq(schedulePollOptions.startDate, parsed.data.startDate),
+          eq(schedulePollOptions.endDate, parsed.data.endDate),
+        ),
+      );
+    if (duplicate) {
+      return { error: ERROR_MSG.POLL_OPTION_DUPLICATE };
+    }
+
+    // MAX+1, not COUNT: deleting a non-last option leaves a gap, and a
+    // COUNT-based value would collide with an existing sortOrder (#143).
+    const sortOrder = await getNextSortOrder(
+      tx,
+      schedulePollOptions.sortOrder,
+      schedulePollOptions,
+      eq(schedulePollOptions.pollId, pollId),
     );
-  if (duplicate) {
-    return c.json({ error: ERROR_MSG.POLL_OPTION_DUPLICATE }, 409);
+
+    const [option] = await tx
+      .insert(schedulePollOptions)
+      .values({
+        pollId,
+        startDate: parsed.data.startDate,
+        endDate: parsed.data.endDate,
+        sortOrder,
+      })
+      .returning();
+
+    await tx
+      .update(schedulePolls)
+      .set({ updatedAt: new Date() })
+      .where(eq(schedulePolls.id, pollId));
+
+    return { option };
+  });
+
+  if ("error" in result) {
+    return c.json({ error: result.error }, 409);
   }
-
-  const [option] = await db
-    .insert(schedulePollOptions)
-    .values({
-      pollId,
-      startDate: parsed.data.startDate,
-      endDate: parsed.data.endDate,
-      sortOrder: optionCount.count,
-    })
-    .returning();
-
-  await db.update(schedulePolls).set({ updatedAt: new Date() }).where(eq(schedulePolls.id, pollId));
+  const { option } = result;
 
   logActivity({
     tripId: poll.tripId,


### PR DESCRIPTION
## Summary

- #137(記事)と同種の COUNT ベース sortOrder 採番バグが残存していた 2 箇所(poll options 追加・bookmarks 単体追加)を、#140 と同じ `getNextSortOrder`(COALESCE(MAX, -1)+1)に置換
- poll options は COUNT(上限チェック)・重複チェック・INSERT がトランザクション外だったため、`db.transaction()` に収めて整合性も確保
- 末尾以外を削除して歯抜けが生じた後の新規作成で、既存行と sortOrder が重複し表示順が不定になる問題が解消

## Why

PR #140 のレビューで、COUNT ベース採番の実装パターンが他 2 箇所に残存していることが確認された(Issue #143)。再現: オプション A/B/C(sortOrder 0/1/2)→ B を削除 → D を作成 → COUNT=2 で D.sortOrder=2 が C と衝突。bookmarks は同ファイルのバッチ追加パス(from-schedules)が既に MAX+1 を使っており、単体追加パスだけ COUNT のままという非対称も解消した。

## Changes

- `apps/api/src/routes/polls.ts` — POST /:pollId/options を `db.transaction()` 化し、上限チェック・重複チェック・MAX+1 採番・INSERT・updatedAt 更新を同一トランザクションに集約
- `apps/api/src/routes/bookmarks.ts` — 単体追加の sortOrder を既存トランザクション内で `getNextSortOrder` により採番(COUNT は上限チェック専用に)
- `apps/api/src/routes/bookmark-lists.ts` — レビューで検出した同一パターンの残存 3 箇所(作成・複製・一括複製)も `getNextSortOrder` に統一(batch-duplicate の実DB再現では `[0,2,2,3]` の衝突を確認)

## Test plan

- [x] TDD: 再現テストを先に書き red を確認(両方 `expected 2 to be 3` で COUNT 衝突を再現)→ 修正後 green
  - `polls.integration.test.ts` — 中間オプション削除後の追加が sortOrder 3(MAX+1)になること
  - `bookmarks.integration.test.ts`(新規)— 中間ブックマーク削除後の作成が sortOrder 3 になること、bookmark list の作成・複製・一括複製の 3 経路も同様に再現→修正確認
- [x] `polls.test.ts` の unit テストを新実装(MAX select 追加)に追従させ、採番値のアサーションを強化
- [x] `bun run check` / `bun run check-types` — 全パッケージ緑
- [x] `bun run --filter @sugara/api test` — 844 件緑 / `test:integration` — 128 件緑

## Notes for reviewer

- 既存行の歯抜け sortOrder はそのまま(採番ロジックの修正のみ)。表示順は sortOrder の相対順で決まるため migration は不要
- poll options のレスポンス形状・エラーコード(409 limit / 409 duplicate)は不変

## Related

- Closes #143
- 同種修正の前例: #140(記事)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
