### PR TITLE
fix: SP版並び替えモード中のリンク・住所タップを無効化

### DIFF
--- a/apps/web/components/candidate-item.test.tsx
+++ b/apps/web/components/candidate-item.test.tsx
@@ -95,3 +95,34 @@ describe("CandidateItem transport cost", () => {
     expect(screen.queryByText("￥500")).toBeNull();
   });
 });
+
+describe("CandidateItem reorder link tap guard", () => {
+  function renderReorderable(overrides: Partial<CandidateResponse> = {}) {
+    renderWithIntl(
+      <MobileContext.Provider value={true}>
+        <CandidateItem spot={makeCandidate(overrides)} onEdit={noop} onDelete={noop} reorderable />
+      </MobileContext.Provider>,
+    );
+  }
+
+  it("disables pointer events on the address link while reordering", () => {
+    renderReorderable({ category: "sightseeing", address: "Tokyo Station" });
+
+    const link = screen.getByText("Tokyo Station").closest("a");
+    expect(link?.closest(".pointer-events-none")).not.toBeNull();
+  });
+
+  it("disables pointer events on the transit route link while reordering", () => {
+    renderReorderable();
+
+    const link = screen.getByText("Tokyo → Kyoto").closest("a");
+    expect(link?.closest(".pointer-events-none")).not.toBeNull();
+  });
+
+  it("disables pointer events on the URL link while reordering", () => {
+    renderReorderable({ urls: ["https://example.com/spot"] });
+
+    const link = screen.getByText("example.com/spot").closest("a");
+    expect(link?.closest(".pointer-events-none")).not.toBeNull();
+  });
+});

--- a/apps/web/components/candidate-item.test.tsx
+++ b/apps/web/components/candidate-item.test.tsx
@@ -96,6 +96,8 @@ describe("CandidateItem transport cost", () => {
   });
 });
 
+// jsdom doesn't simulate pointer-events hit-testing, so these assert the CSS class
+// (inherited by descendant links) rather than actual click suppression.
 describe("CandidateItem reorder link tap guard", () => {
   function renderReorderable(overrides: Partial<CandidateResponse> = {}) {
     renderWithIntl(

--- a/apps/web/components/candidate-item.tsx
+++ b/apps/web/components/candidate-item.tsx
@@ -171,7 +171,7 @@ export const CandidateItem = memo(function CandidateItem({
             rel="noopener noreferrer"
             className={cn(
               "flex w-fit max-w-full items-center gap-1.5 text-xs text-blue-600 hover:underline dark:text-blue-400",
-              selectable && "pointer-events-none",
+              (selectable || reorderable) && "pointer-events-none",
             )}
           >
             <MapPin className="h-3 w-3 shrink-0 text-muted-foreground/70" />
@@ -198,7 +198,7 @@ export const CandidateItem = memo(function CandidateItem({
               <span
                 className={cn(
                   "flex w-fit max-w-full items-center gap-1.5 text-xs text-muted-foreground",
-                  selectable && "pointer-events-none",
+                  (selectable || reorderable) && "pointer-events-none",
                 )}
               >
                 <Route className="h-3 w-3 shrink-0 text-muted-foreground/70" />
@@ -232,7 +232,7 @@ export const CandidateItem = memo(function CandidateItem({
             rel="noopener noreferrer"
             className={cn(
               "flex w-fit max-w-full items-center gap-1.5 text-xs text-blue-600 hover:underline dark:text-blue-400",
-              selectable && "pointer-events-none",
+              (selectable || reorderable) && "pointer-events-none",
             )}
           >
             <ExternalLink className="h-3 w-3 shrink-0 text-muted-foreground/70" />

--- a/apps/web/components/day-timeline.test.tsx
+++ b/apps/web/components/day-timeline.test.tsx
@@ -150,3 +150,36 @@ describe("DayTimeline mobile reorder with cross-day entries", () => {
     expect(sortButton.hasAttribute("disabled")).toBe(false);
   });
 });
+
+describe("DayTimeline mobile reorder link tap guard", () => {
+  it("disables pointer events on the address link while reordering", () => {
+    renderTimeline({
+      schedules: [
+        makeSchedule({ id: "s1", address: "Tokyo Station" }),
+        makeSchedule({ id: "s2", sortOrder: 1 }),
+      ],
+    });
+    enterReorderMode();
+
+    const link = screen.getByText("Tokyo Station").closest("a");
+    expect(link?.closest(".pointer-events-none")).not.toBeNull();
+  });
+
+  it("disables pointer events on the transit route link while reordering", () => {
+    renderTimeline({
+      schedules: [
+        makeSchedule({
+          id: "s1",
+          category: "transport",
+          departurePlace: "Tokyo",
+          arrivalPlace: "Kyoto",
+        }),
+        makeSchedule({ id: "s2", sortOrder: 1 }),
+      ],
+    });
+    enterReorderMode();
+
+    const link = screen.getByText("Tokyo → Kyoto").closest("a");
+    expect(link?.closest(".pointer-events-none")).not.toBeNull();
+  });
+});

--- a/apps/web/components/day-timeline.test.tsx
+++ b/apps/web/components/day-timeline.test.tsx
@@ -151,6 +151,8 @@ describe("DayTimeline mobile reorder with cross-day entries", () => {
   });
 });
 
+// jsdom doesn't simulate pointer-events hit-testing, so these assert the CSS class
+// (inherited by descendant links) rather than actual click suppression.
 describe("DayTimeline mobile reorder link tap guard", () => {
   it("disables pointer events on the address link while reordering", () => {
     renderTimeline({

--- a/apps/web/components/schedule-items/place-item.tsx
+++ b/apps/web/components/schedule-items/place-item.tsx
@@ -133,7 +133,9 @@ export const PlaceItem = memo(function PlaceItem({
             timeStr={timeStr}
           />
           {(address || urls.length > 0 || memo) && (
-            <div className={cn("mt-1 space-y-1", selectable && "pointer-events-none")}>
+            <div
+              className={cn("mt-1 space-y-1", (selectable || reorderable) && "pointer-events-none")}
+            >
               {address && (
                 <a
                   href={buildMapsSearchUrl(address)}

--- a/apps/web/components/schedule-items/transport-item.tsx
+++ b/apps/web/components/schedule-items/transport-item.tsx
@@ -175,7 +175,9 @@ export const TransportItem = memo(function TransportItem({
             timeStr={timeStr}
           />
           {(routeStr || costStr || urls.length > 0 || memo) && (
-            <div className={cn("mt-1 space-y-1", selectable && "pointer-events-none")}>
+            <div
+              className={cn("mt-1 space-y-1", (selectable || reorderable) && "pointer-events-none")}
+            >
               {routeStr && (
                 <span
                   className="flex w-fit max-w-full items-center gap-1.5 text-xs text-muted-foreground"


### PR DESCRIPTION
## Summary
- SP版の並び替えモード中に予定・候補カードのリンク(URL)・住所・経路リンクがタップ可能なまま残り、並び替え操作中の誤タップで地図や外部サイトに飛んでしまう問題を修正
- 選択モードで既に使っている `pointer-events-none` の仕組みに `reorderable` を加えるだけの最小修正

## Why
- リンク無効化の条件が `selectable && "pointer-events-none"` で、並び替えモード(`reorderable`)が条件に含まれていなかった
- 新しい無効化機構を導入するのではなく、選択モードと同一のパターンに相乗りすることで挙動の一貫性を保ち、差分を最小化した
- 調査の結果、予定(place / transport)だけでなく候補リスト(candidate)にも全く同じ問題があったため、同一PRでまとめて修正(bookmark / souvenir パネルは並び替えモード自体がないため対象外)

## Changes
- 予定カード: 住所・URL・経路リンクの wrapper の無効化条件に `reorderable` を追加(`place-item.tsx` / `transport-item.tsx`)
- 候補カード: 住所・経路・URLリンクの3箇所に同様の条件を追加(`candidate-item.tsx`)
- TDD で再現テストを先に追加(red 確認後に修正で green): `day-timeline.test.tsx` に2件、`candidate-item.test.tsx` に3件

## Test plan
- [x] 再現テスト追加 → red を確認 → 修正 → green を確認
  - `DayTimeline mobile reorder link tap guard`: 住所リンク / 経路リンクが並び替えモード中に `pointer-events-none` 配下にあること
  - `CandidateItem reorder link tap guard`: 住所 / 経路 / URLリンクの3種で同様
- [x] `bun run --filter @sugara/web test` — 75 files / 753 tests passed
- [x] `bun run check` / `bun run check-types` — green

## Notes for reviewer
- `pointer-events-none` は CSS のみの無効化で、キーボードフォーカスは残る。ただしSP版の並び替えモード限定のタッチ誤操作対策であり、既存の選択モードも同じ割り切りのため許容と判断
- 並び替えモードの出入りや ReorderControls の表示制御は既存ロジックのまま変更していない

🤖 Generated with [Claude Code](https://claude.com/claude-code)