### PR TITLE
fix: 選択・並び替えモード中の宿泊継続アイテムのリンクタップを無効化

### DIFF
--- a/apps/web/components/candidate-item.test.tsx
+++ b/apps/web/components/candidate-item.test.tsx
@@ -127,4 +127,10 @@ describe("CandidateItem reorder link tap guard", () => {
     const link = screen.getByText("example.com/spot").closest("a");
     expect(link?.closest(".pointer-events-none")).not.toBeNull();
   });
+
+  it("hides the item menu while reordering", () => {
+    renderReorderable();
+
+    expect(screen.queryByRole("button", { name: "Tokyo to Kyotoのメニュー" })).toBeNull();
+  });
 });

--- a/apps/web/components/candidate-item.tsx
+++ b/apps/web/components/candidate-item.tsx
@@ -284,6 +284,7 @@ export const CandidateItem = memo(function CandidateItem({
       )}
       {!disabled &&
         !selectable &&
+        !reorderable &&
         (isMobile ? (
           <>
             <ItemMenuButton

--- a/apps/web/components/day-timeline.test.tsx
+++ b/apps/web/components/day-timeline.test.tsx
@@ -1,6 +1,7 @@
 import type { CrossDayEntry, ScheduleResponse } from "@sugara/shared";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, fireEvent, screen } from "@testing-library/react";
+import type { ComponentProps } from "react";
 import { afterEach, describe, expect, it } from "vitest";
 import { SelectionProvider } from "@/lib/hooks/selection-context";
 import { MobileContext } from "@/lib/hooks/use-is-mobile";
@@ -50,9 +51,9 @@ function makeSchedule(
   };
 }
 
-function makeIntermediateEntry(): CrossDayEntry {
+function makeIntermediateEntry(overrides?: Partial<ScheduleResponse>): CrossDayEntry {
   return {
-    schedule: makeSchedule({ id: "hotel1", name: "Hotel", category: "hotel" }),
+    schedule: makeSchedule({ id: "hotel1", name: "Hotel", category: "hotel", ...overrides }),
     sourceDayId: "d0",
     sourcePatternId: "p0",
     sourceDayNumber: 1,
@@ -60,9 +61,15 @@ function makeIntermediateEntry(): CrossDayEntry {
   };
 }
 
-function makeFinalEntry(): CrossDayEntry {
+function makeFinalEntry(overrides?: Partial<ScheduleResponse>): CrossDayEntry {
   return {
-    schedule: makeSchedule({ id: "hotel2", name: "Hotel", category: "hotel", endTime: "10:00" }),
+    schedule: makeSchedule({
+      id: "hotel2",
+      name: "Hotel",
+      category: "hotel",
+      endTime: "10:00",
+      ...overrides,
+    }),
     sourceDayId: "d0",
     sourcePatternId: "p0",
     sourceDayNumber: 1,
@@ -73,15 +80,17 @@ function makeFinalEntry(): CrossDayEntry {
 function renderTimeline({
   schedules,
   crossDayEntries,
+  selection = selectionStub,
 }: {
   schedules: ScheduleResponse[];
   crossDayEntries?: CrossDayEntry[];
+  selection?: ComponentProps<typeof SelectionProvider>["value"];
 }) {
   const queryClient = new QueryClient();
   return renderWithIntl(
     <QueryClientProvider client={queryClient}>
       <MobileContext.Provider value={true}>
-        <SelectionProvider value={selectionStub}>
+        <SelectionProvider value={selection}>
           <DayTimeline
             tripId="t1"
             dayId="d1"
@@ -182,6 +191,28 @@ describe("DayTimeline mobile reorder link tap guard", () => {
     enterReorderMode();
 
     const link = screen.getByText("Tokyo → Kyoto").closest("a");
+    expect(link?.closest(".pointer-events-none")).not.toBeNull();
+  });
+
+  it("disables pointer events on a staying entry address link while reordering", () => {
+    renderTimeline({
+      schedules: [makeSchedule({ id: "s1" }), makeSchedule({ id: "s2", sortOrder: 1 })],
+      crossDayEntries: [makeIntermediateEntry({ address: "Hotel Street 1" })],
+    });
+    enterReorderMode();
+
+    const link = screen.getByText("Hotel Street 1").closest("a");
+    expect(link?.closest(".pointer-events-none")).not.toBeNull();
+  });
+
+  it("disables pointer events on a checkout entry address link in selection mode", () => {
+    renderTimeline({
+      schedules: [makeSchedule({ id: "s1" })],
+      crossDayEntries: [makeFinalEntry({ address: "Hotel Street 1" })],
+      selection: { ...selectionStub, selectionTarget: "timeline" },
+    });
+
+    const link = screen.getByText("Hotel Street 1").closest("a");
     expect(link?.closest(".pointer-events-none")).not.toBeNull();
   });
 });

--- a/apps/web/components/day-timeline.test.tsx
+++ b/apps/web/components/day-timeline.test.tsx
@@ -216,3 +216,49 @@ describe("DayTimeline mobile reorder link tap guard", () => {
     expect(link?.closest(".pointer-events-none")).not.toBeNull();
   });
 });
+
+// Item menus are tap hazards during selection/reorder, same as links. Regular
+// items hide them via selectable/reorderable; cross-day entries never receive
+// those props, so they need the explicit interactionsDisabled prop to match.
+describe("DayTimeline item menu visibility in selection/reorder modes", () => {
+  it("hides the item menu on a checkout entry in selection mode", () => {
+    renderTimeline({
+      schedules: [makeSchedule({ id: "s1" })],
+      crossDayEntries: [makeFinalEntry()],
+      selection: { ...selectionStub, selectionTarget: "timeline" },
+    });
+
+    expect(screen.queryByRole("button", { name: "Hotelのメニュー" })).toBeNull();
+  });
+
+  it("hides the item menu on a staying entry while reordering", () => {
+    renderTimeline({
+      schedules: [makeSchedule({ id: "s1" }), makeSchedule({ id: "s2", sortOrder: 1 })],
+      crossDayEntries: [makeIntermediateEntry()],
+    });
+    enterReorderMode();
+
+    expect(screen.queryByRole("button", { name: "Hotelのメニュー" })).toBeNull();
+  });
+
+  it("hides the item menu on a regular schedule while reordering", () => {
+    renderTimeline({
+      schedules: [
+        makeSchedule({ id: "s1", name: "Castle" }),
+        makeSchedule({ id: "s2", sortOrder: 1 }),
+      ],
+    });
+    enterReorderMode();
+
+    expect(screen.queryByRole("button", { name: "Castleのメニュー" })).toBeNull();
+  });
+
+  it("keeps the item menu on a staying entry outside selection/reorder modes", () => {
+    renderTimeline({
+      schedules: [makeSchedule({ id: "s1" })],
+      crossDayEntries: [makeIntermediateEntry()],
+    });
+
+    expect(screen.getByRole("button", { name: "Hotelのメニュー" })).not.toBeNull();
+  });
+});

--- a/apps/web/components/day-timeline.tsx
+++ b/apps/web/components/day-timeline.tsx
@@ -251,7 +251,7 @@ export function DayTimeline({
             crossDayDisplay
             crossDaySourceDayNumber={sourceDayNumber}
             crossDayPosition={crossDayPosition}
-            linksDisabled={!!opts?.selectable || isReorderable}
+            interactionsDisabled={!!opts?.selectable || isReorderable}
             currency={currency}
           />
         </div>

--- a/apps/web/components/day-timeline.tsx
+++ b/apps/web/components/day-timeline.tsx
@@ -211,6 +211,7 @@ export function DayTimeline({
   function renderItem(item: TimelineItem, i: number, opts?: { selectable?: boolean }) {
     const isFirst = i === 0;
     const isLast = i === merged.length - 1;
+    const isReorderable = isMobile && reorderMode && !disabled;
 
     // Gap k renders above item k; the "after the last item" gap (k === length)
     // renders on the bottom edge of the last item.
@@ -250,6 +251,7 @@ export function DayTimeline({
             crossDayDisplay
             crossDaySourceDayNumber={sourceDayNumber}
             crossDayPosition={crossDayPosition}
+            linksDisabled={!!opts?.selectable || isReorderable}
             currency={currency}
           />
         </div>
@@ -261,7 +263,6 @@ export function DayTimeline({
     const scheduleIdx = scheduleIndexById.get(schedule.id) ?? -1;
     // slice is O(n-k) instead of filter O(n); valid because schedules is in sortOrder order
     const schedulesAfter = scheduleIdx >= 0 ? schedules.slice(scheduleIdx + 1) : [];
-    const isReorderable = isMobile && reorderMode && !disabled;
 
     return (
       <div key={schedule.id} className="relative">

--- a/apps/web/components/schedule-items/place-item.tsx
+++ b/apps/web/components/schedule-items/place-item.tsx
@@ -60,7 +60,7 @@ export const PlaceItem = memo(function PlaceItem({
   onSaveToBookmark,
   draggable,
   reorderable,
-  linksDisabled,
+  interactionsDisabled,
   onMoveUp,
   onMoveDown,
   mapsEnabled,
@@ -137,7 +137,7 @@ export const PlaceItem = memo(function PlaceItem({
             <div
               className={cn(
                 "mt-1 space-y-1",
-                (selectable || reorderable || linksDisabled) && "pointer-events-none",
+                (selectable || reorderable || interactionsDisabled) && "pointer-events-none",
               )}
             >
               {address && (
@@ -157,7 +157,7 @@ export const PlaceItem = memo(function PlaceItem({
             </div>
           )}
         </div>
-        {!selectable && (
+        {!selectable && !reorderable && !interactionsDisabled && (
           <ScheduleMenu
             name={name}
             disabled={disabled}

--- a/apps/web/components/schedule-items/place-item.tsx
+++ b/apps/web/components/schedule-items/place-item.tsx
@@ -60,6 +60,7 @@ export const PlaceItem = memo(function PlaceItem({
   onSaveToBookmark,
   draggable,
   reorderable,
+  linksDisabled,
   onMoveUp,
   onMoveDown,
   mapsEnabled,
@@ -134,7 +135,10 @@ export const PlaceItem = memo(function PlaceItem({
           />
           {(address || urls.length > 0 || memo) && (
             <div
-              className={cn("mt-1 space-y-1", (selectable || reorderable) && "pointer-events-none")}
+              className={cn(
+                "mt-1 space-y-1",
+                (selectable || reorderable || linksDisabled) && "pointer-events-none",
+              )}
             >
               {address && (
                 <a

--- a/apps/web/components/schedule-items/primitives.tsx
+++ b/apps/web/components/schedule-items/primitives.tsx
@@ -93,6 +93,12 @@ export type ScheduleItemProps = {
   draggable?: boolean;
   /** When true, show ReorderControls instead of DragHandle */
   reorderable?: boolean;
+  /**
+   * Disables link/address taps without the selectable/reorderable UI.
+   * Used by cross-day entries, which stay non-selectable and non-reorderable
+   * while the rest of the timeline is in selection/reorder mode.
+   */
+  linksDisabled?: boolean;
   onMoveUp?: () => void;
   onMoveDown?: () => void;
   mapsEnabled?: boolean;

--- a/apps/web/components/schedule-items/primitives.tsx
+++ b/apps/web/components/schedule-items/primitives.tsx
@@ -94,11 +94,12 @@ export type ScheduleItemProps = {
   /** When true, show ReorderControls instead of DragHandle */
   reorderable?: boolean;
   /**
-   * Disables link/address taps without the selectable/reorderable UI.
-   * Used by cross-day entries, which stay non-selectable and non-reorderable
-   * while the rest of the timeline is in selection/reorder mode.
+   * Disables link/address taps and hides the item menu without the
+   * selectable/reorderable UI. Used by cross-day entries, which stay
+   * non-selectable and non-reorderable while the rest of the timeline is in
+   * selection/reorder mode.
    */
-  linksDisabled?: boolean;
+  interactionsDisabled?: boolean;
   onMoveUp?: () => void;
   onMoveDown?: () => void;
   mapsEnabled?: boolean;

--- a/apps/web/components/schedule-items/transport-item.tsx
+++ b/apps/web/components/schedule-items/transport-item.tsx
@@ -65,7 +65,7 @@ export const TransportItem = memo(function TransportItem({
   onSaveToBookmark,
   draggable,
   reorderable,
-  linksDisabled,
+  interactionsDisabled,
   onMoveUp,
   onMoveDown,
   mapsEnabled,
@@ -179,7 +179,7 @@ export const TransportItem = memo(function TransportItem({
             <div
               className={cn(
                 "mt-1 space-y-1",
-                (selectable || reorderable || linksDisabled) && "pointer-events-none",
+                (selectable || reorderable || interactionsDisabled) && "pointer-events-none",
               )}
             >
               {routeStr && (
@@ -214,7 +214,7 @@ export const TransportItem = memo(function TransportItem({
             </div>
           )}
         </div>
-        {!selectable && (
+        {!selectable && !reorderable && !interactionsDisabled && (
           <ScheduleMenu
             name={name}
             disabled={disabled}

--- a/apps/web/components/schedule-items/transport-item.tsx
+++ b/apps/web/components/schedule-items/transport-item.tsx
@@ -65,6 +65,7 @@ export const TransportItem = memo(function TransportItem({
   onSaveToBookmark,
   draggable,
   reorderable,
+  linksDisabled,
   onMoveUp,
   onMoveDown,
   mapsEnabled,
@@ -176,7 +177,10 @@ export const TransportItem = memo(function TransportItem({
           />
           {(routeStr || costStr || urls.length > 0 || memo) && (
             <div
-              className={cn("mt-1 space-y-1", (selectable || reorderable) && "pointer-events-none")}
+              className={cn(
+                "mt-1 space-y-1",
+                (selectable || reorderable || linksDisabled) && "pointer-events-none",
+              )}
             >
               {routeStr && (
                 <span


### PR DESCRIPTION
## Summary

### リンク・住所タップの無効化漏れ(cross-day アイテム)

- PR #147 で選択・並び替えモード中のリンク・住所タップ無効化を入れたが、宿泊 2 日目以降に表示される滞在中・チェックアウト(cross-day)アイテムはタップ可能なまま残っていた
- 原因: cross-day アイテムは `day-timeline.tsx` の `renderItem` で早期 return しており、`selectable` / `reorderable` が渡らないため `pointer-events-none` の条件が成立しなかった
- 対応: `ScheduleItemProps` に `interactionsDisabled` を追加し、選択・並び替えモード中の cross-day アイテムに渡して既存と同じ仕組みでタップを遮断(place / transport 両対応)

### 三点メニューの非表示漏れ(全アイテム)

- SP 版の並び替えモード中、予定・cross-day・候補の全アイテムで三点リーダーメニューがタップ可能なまま残っていた(選択モード中の cross-day アイテムも同様)
- 対応: メニュー表示条件に `reorderable` / `interactionsDisabled` を追加し、選択・並び替えモード中は全アイテムでメニューを非表示にする

cross-day アイテムは選択・並び替えの対象外のままで、タップ遮断とメニュー非表示だけを追加している(SelectionIndicator / ReorderControls は表示しない)。

## Test plan

- [x] 再現テスト追加: 並び替え中の滞在中エントリ / 選択モード中のチェックアウトエントリの住所リンクに `pointer-events-none` が継承される
- [x] 再現テスト追加: 選択モード中のチェックアウトエントリ / 並び替え中の滞在中・通常予定・候補アイテムでメニューが非表示
- [x] 再現テスト追加: 選択・並び替えモード外では cross-day アイテムのメニューが表示される(リグレッション防止)
- [x] `bun run --filter @sugara/web test` 778 件 green
- [x] `bun run check` / `bun run check-types` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)