### PR TITLE
fix: 予定追加直後のstale refetchによる予定消失を解消 (#123)

### DIFF
--- a/apps/web/app/(authenticated)/trips/[id]/page.tsx
+++ b/apps/web/app/(authenticated)/trips/[id]/page.tsx
@@ -54,6 +54,7 @@ import { usePatternOperations } from "@/lib/hooks/use-pattern-operations";
 import { buildReactionUser, useReaction } from "@/lib/hooks/use-reaction";
 import { useScheduleSelection } from "@/lib/hooks/use-schedule-selection";
 import { useTripDragAndDrop } from "@/lib/hooks/use-trip-drag-and-drop";
+import { useTripMutationCallbacks } from "@/lib/hooks/use-trip-mutation-callbacks";
 import { useTripSync } from "@/lib/hooks/use-trip-sync";
 import { isDialogOpen } from "@/lib/hotkeys";
 import { CATEGORY_ICONS } from "@/lib/icons";
@@ -529,12 +530,13 @@ export default function TripDetailPage() {
   );
   const { reactions, sendReaction, removeReaction, cooldown } = useReaction(channel, reactionUser);
 
-  // Mutation callback: refetch + broadcast to other clients
-  const onMutate = useCallback(async () => {
-    await invalidateTrip();
-    broadcastChange();
-    await queryClient.invalidateQueries({ queryKey: queryKeys.trips.activityLogs(tripId) });
-  }, [invalidateTrip, broadcastChange, queryClient, tripId]);
+  // Mutation callbacks: refetch + broadcast to other clients (see hook for
+  // why schedule adds skip the refetch, #123)
+  const { onMutate, onScheduleAdded } = useTripMutationCallbacks({
+    tripId,
+    invalidateTrip,
+    broadcastChange,
+  });
 
   const handleSaveToBookmark = useCallback((scheduleIds: string[]) => {
     setSaveToBookmarkIds(scheduleIds);
@@ -737,6 +739,7 @@ export default function TripDetailPage() {
                   date={currentDay.date}
                   schedules={dnd.localSchedules}
                   onRefresh={onMutate}
+                  onScheduleAdded={onScheduleAdded}
                   disabled={!online || !canEdit}
                   addScheduleOpen={!isLg ? addScheduleOpen : false}
                   onAddScheduleOpenChange={!isLg ? setAddScheduleOpen : undefined}
@@ -972,6 +975,7 @@ export default function TripDetailPage() {
                           date={currentDay.date}
                           schedules={dnd.localSchedules}
                           onRefresh={onMutate}
+                          onScheduleAdded={onScheduleAdded}
                           disabled={!online || !canEdit}
                           addScheduleOpen={isLg ? addScheduleOpen : false}
                           onAddScheduleOpenChange={isLg ? setAddScheduleOpen : undefined}

--- a/apps/web/app/(sp)/sp/trips/[id]/page.tsx
+++ b/apps/web/app/(sp)/sp/trips/[id]/page.tsx
@@ -66,6 +66,7 @@ import { usePatternOperations } from "@/lib/hooks/use-pattern-operations";
 import { buildReactionUser, useReaction } from "@/lib/hooks/use-reaction";
 import { useScheduleSelection } from "@/lib/hooks/use-schedule-selection";
 import { useTripDragAndDrop } from "@/lib/hooks/use-trip-drag-and-drop";
+import { useTripMutationCallbacks } from "@/lib/hooks/use-trip-mutation-callbacks";
 import { useTripSync } from "@/lib/hooks/use-trip-sync";
 import { QUERY_CONFIG } from "@/lib/query-config";
 import { queryKeys } from "@/lib/query-keys";
@@ -160,11 +161,13 @@ export default function SpTripDetailPage() {
   );
   const { reactions, sendReaction, removeReaction, cooldown } = useReaction(channel, reactionUser);
 
-  const onMutate = useCallback(async () => {
-    await invalidateTrip();
-    broadcastChange();
-    await queryClient.invalidateQueries({ queryKey: queryKeys.trips.activityLogs(tripId ?? "") });
-  }, [invalidateTrip, broadcastChange, queryClient, tripId]);
+  // Mutation callbacks: refetch + broadcast to other clients (see hook for
+  // why schedule adds skip the refetch, #123)
+  const { onMutate, onScheduleAdded } = useTripMutationCallbacks({
+    tripId: tripId ?? "",
+    invalidateTrip,
+    broadcastChange,
+  });
 
   const handleSaveToBookmark = useCallback((scheduleIds: string[]) => {
     setSaveToBookmarkIds(scheduleIds);
@@ -364,6 +367,7 @@ export default function SpTripDetailPage() {
                   date={currentDay.date}
                   schedules={dnd.localSchedules}
                   onRefresh={onMutate}
+                  onScheduleAdded={onScheduleAdded}
                   disabled={!online || !canEdit}
                   addScheduleOpen={addScheduleOpen}
                   onAddScheduleOpenChange={setAddScheduleOpen}

--- a/apps/web/app/sw.ts
+++ b/apps/web/app/sw.ts
@@ -58,10 +58,12 @@ const serwist = new Serwist({
     // fresher client-side cache updates (#123), and it also persists
     // authenticated personal data in Cache Storage. Offline reads are
     // covered by the IndexedDB-persisted TanStack Query cache instead.
+    // networkTimeoutSeconds matches the defaultCache entries this shadows
+    // (including /api/auth/*, which would otherwise lose its 10s timeout).
     {
       matcher: ({ url, sameOrigin }: { url: URL; sameOrigin: boolean }) =>
         sameOrigin && url.pathname.startsWith("/api/"),
-      handler: new NetworkOnly(),
+      handler: new NetworkOnly({ networkTimeoutSeconds: 10 }),
     },
     ...defaultCache,
   ],

--- a/apps/web/app/sw.ts
+++ b/apps/web/app/sw.ts
@@ -3,7 +3,7 @@
 /// <reference lib="webworker" />
 import { defaultCache } from "@serwist/next/worker";
 import type { HandlerDidErrorCallbackParam, PrecacheEntry, SerwistGlobalConfig } from "serwist";
-import { NetworkFirst, Serwist } from "serwist";
+import { NetworkFirst, NetworkOnly, Serwist } from "serwist";
 
 declare global {
   interface WorkerGlobalScope extends SerwistGlobalConfig {
@@ -53,6 +53,16 @@ const serwist = new Serwist({
         ],
       }),
     },
+    // Placed before defaultCache to override its "apis" NetworkFirst handler.
+    // Caching /api/ responses can serve a stale snapshot that clobbers
+    // fresher client-side cache updates (#123), and it also persists
+    // authenticated personal data in Cache Storage. Offline reads are
+    // covered by the IndexedDB-persisted TanStack Query cache instead.
+    {
+      matcher: ({ url, sameOrigin }: { url: URL; sameOrigin: boolean }) =>
+        sameOrigin && url.pathname.startsWith("/api/"),
+      handler: new NetworkOnly(),
+    },
     ...defaultCache,
   ],
   // additionalPrecacheEntries in next.config.ts precaches /offline with revision "1".
@@ -61,6 +71,12 @@ const serwist = new Serwist({
 });
 
 serwist.addEventListeners();
+
+// Purge the legacy "apis" runtime cache left by the previous defaultCache
+// handler: it may hold stale authenticated API responses (#123).
+self.addEventListener("activate", (event) => {
+  event.waitUntil(caches.delete("apis"));
+});
 
 // Push notification handlers (separate from serwist)
 self.addEventListener("push", (event) => {

--- a/apps/web/components/add-schedule-dialog.tsx
+++ b/apps/web/components/add-schedule-dialog.tsx
@@ -150,6 +150,9 @@ export function AddScheduleDialog({
           body: JSON.stringify(data),
         },
       );
+      // Stop any in-flight trip GET: it could resolve after setQueryData with
+      // a stale snapshot and overwrite the just-added schedule (#123).
+      await queryClient.cancelQueries({ queryKey: cacheKey });
       const prev = queryClient.getQueryData<TripResponse>(cacheKey);
       if (prev) {
         queryClient.setQueryData(

--- a/apps/web/components/day-timeline.test.tsx
+++ b/apps/web/components/day-timeline.test.tsx
@@ -99,6 +99,7 @@ function renderTimeline({
             schedules={schedules}
             crossDayEntries={crossDayEntries}
             onRefresh={noop}
+            onScheduleAdded={noop}
             onReorderSchedule={noop}
             scheduleLimitReached
           />

--- a/apps/web/components/day-timeline.tsx
+++ b/apps/web/components/day-timeline.tsx
@@ -60,9 +60,10 @@ type DayTimelineProps = {
   /**
    * Post-add callback that must not refetch the trip detail: the add dialog
    * already wrote the POST response into the cache, and an immediate stale
-   * refetch can clobber it (#123). Falls back to onRefresh when omitted.
+   * refetch can clobber it (#123). Required so new call sites cannot silently
+   * fall back to a refetching callback.
    */
-  onScheduleAdded?: () => void;
+  onScheduleAdded: () => void;
   disabled?: boolean;
   headerContent?: React.ReactNode;
   maxEndDayOffset?: number;
@@ -408,7 +409,7 @@ export function DayTimeline({
                   tripId={tripId}
                   dayId={dayId}
                   patternId={patternId}
-                  onAdd={onScheduleAdded ?? onRefresh}
+                  onAdd={onScheduleAdded}
                   disabled={disabled}
                   maxEndDayOffset={maxEndDayOffset}
                   open={addScheduleOpen}
@@ -421,7 +422,7 @@ export function DayTimeline({
                 tripId={tripId}
                 dayId={dayId}
                 patternId={patternId}
-                onAdd={onScheduleAdded ?? onRefresh}
+                onAdd={onScheduleAdded}
                 disabled={disabled}
                 maxEndDayOffset={maxEndDayOffset}
                 open={addScheduleOpen}

--- a/apps/web/components/day-timeline.tsx
+++ b/apps/web/components/day-timeline.tsx
@@ -57,6 +57,12 @@ type DayTimelineProps = {
   date: string;
   schedules: ScheduleResponse[];
   onRefresh: () => void;
+  /**
+   * Post-add callback that must not refetch the trip detail: the add dialog
+   * already wrote the POST response into the cache, and an immediate stale
+   * refetch can clobber it (#123). Falls back to onRefresh when omitted.
+   */
+  onScheduleAdded?: () => void;
   disabled?: boolean;
   headerContent?: React.ReactNode;
   maxEndDayOffset?: number;
@@ -82,6 +88,7 @@ export function DayTimeline({
   date,
   schedules,
   onRefresh,
+  onScheduleAdded,
   disabled,
   headerContent,
   maxEndDayOffset,
@@ -401,7 +408,7 @@ export function DayTimeline({
                   tripId={tripId}
                   dayId={dayId}
                   patternId={patternId}
-                  onAdd={onRefresh}
+                  onAdd={onScheduleAdded ?? onRefresh}
                   disabled={disabled}
                   maxEndDayOffset={maxEndDayOffset}
                   open={addScheduleOpen}
@@ -414,7 +421,7 @@ export function DayTimeline({
                 tripId={tripId}
                 dayId={dayId}
                 patternId={patternId}
-                onAdd={onRefresh}
+                onAdd={onScheduleAdded ?? onRefresh}
                 disabled={disabled}
                 maxEndDayOffset={maxEndDayOffset}
                 open={addScheduleOpen}

--- a/apps/web/lib/hooks/use-trip-mutation-callbacks.test.ts
+++ b/apps/web/lib/hooks/use-trip-mutation-callbacks.test.ts
@@ -1,0 +1,98 @@
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Mocks ---
+
+const mockInvalidateQueries = vi.fn();
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({
+    invalidateQueries: mockInvalidateQueries,
+  }),
+}));
+
+import { useTripMutationCallbacks } from "./use-trip-mutation-callbacks";
+
+describe("useTripMutationCallbacks", () => {
+  const invalidateTrip = vi.fn();
+  const broadcastChange = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    invalidateTrip.mockResolvedValue(undefined);
+  });
+
+  afterEach(cleanup);
+
+  function setup() {
+    return renderHook(() =>
+      useTripMutationCallbacks({ tripId: "t1", invalidateTrip, broadcastChange }),
+    );
+  }
+
+  it("onMutate refetches the trip detail", async () => {
+    const { result } = setup();
+
+    await act(() => result.current.onMutate());
+
+    expect(invalidateTrip).toHaveBeenCalledTimes(1);
+  });
+
+  it("onMutate broadcasts the change to other clients", async () => {
+    const { result } = setup();
+
+    await act(() => result.current.onMutate());
+
+    expect(broadcastChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("onMutate invalidates the activity logs", async () => {
+    const { result } = setup();
+
+    await act(() => result.current.onMutate());
+
+    expect(mockInvalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["trips", "t1", "activity-logs"],
+    });
+  });
+
+  // Reproduction for #123: the add-schedule dialog has already written the
+  // server-confirmed schedule into the cache. An immediate trip-detail refetch
+  // can return a stale snapshot and clobber that entry, so the schedule-added
+  // callback must NOT trigger one.
+  it("onScheduleAdded does not refetch the trip detail", async () => {
+    const { result } = setup();
+
+    await act(() => result.current.onScheduleAdded());
+
+    expect(invalidateTrip).not.toHaveBeenCalled();
+  });
+
+  it("onScheduleAdded does not invalidate the trip detail query key", async () => {
+    const { result } = setup();
+
+    await act(() => result.current.onScheduleAdded());
+
+    expect(mockInvalidateQueries).not.toHaveBeenCalledWith({
+      queryKey: ["trips", "t1"],
+    });
+  });
+
+  it("onScheduleAdded broadcasts the change to other clients", async () => {
+    const { result } = setup();
+
+    await act(() => result.current.onScheduleAdded());
+
+    expect(broadcastChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("onScheduleAdded invalidates the activity logs", async () => {
+    const { result } = setup();
+
+    await act(() => result.current.onScheduleAdded());
+
+    expect(mockInvalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["trips", "t1", "activity-logs"],
+    });
+  });
+});

--- a/apps/web/lib/hooks/use-trip-mutation-callbacks.test.ts
+++ b/apps/web/lib/hooks/use-trip-mutation-callbacks.test.ts
@@ -46,14 +46,14 @@ describe("useTripMutationCallbacks", () => {
     expect(broadcastChange).toHaveBeenCalledTimes(1);
   });
 
-  it("onMutate invalidates the activity logs", async () => {
+  // invalidateTrip's ["trips", tripId] key prefix-matches the activity-logs
+  // key, so a separate invalidation would refetch the logs a second time.
+  it("onMutate does not invalidate the activity logs separately", async () => {
     const { result } = setup();
 
     await act(() => result.current.onMutate());
 
-    expect(mockInvalidateQueries).toHaveBeenCalledWith({
-      queryKey: ["trips", "t1", "activity-logs"],
-    });
+    expect(mockInvalidateQueries).not.toHaveBeenCalled();
   });
 
   // Reproduction for #123: the add-schedule dialog has already written the

--- a/apps/web/lib/hooks/use-trip-mutation-callbacks.ts
+++ b/apps/web/lib/hooks/use-trip-mutation-callbacks.ts
@@ -28,11 +28,13 @@ export function useTripMutationCallbacks({
 }) {
   const queryClient = useQueryClient();
 
+  // invalidateTrip's ["trips", tripId] key prefix-matches the activity-logs
+  // key, so no separate invalidation is needed here (it would refetch the
+  // logs a second time).
   const onMutate = useCallback(async () => {
     await invalidateTrip();
     broadcastChange();
-    await queryClient.invalidateQueries({ queryKey: queryKeys.trips.activityLogs(tripId) });
-  }, [invalidateTrip, broadcastChange, queryClient, tripId]);
+  }, [invalidateTrip, broadcastChange]);
 
   const onScheduleAdded = useCallback(async () => {
     broadcastChange();

--- a/apps/web/lib/hooks/use-trip-mutation-callbacks.ts
+++ b/apps/web/lib/hooks/use-trip-mutation-callbacks.ts
@@ -1,0 +1,43 @@
+"use client";
+
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+import { queryKeys } from "@/lib/query-keys";
+
+/**
+ * Shared post-mutation callbacks for the trip detail pages (desktop / SP).
+ *
+ * `onMutate` is the default: refetch the trip, broadcast to other clients,
+ * and refresh the activity logs.
+ *
+ * `onScheduleAdded` exists because the add-schedule dialog writes the
+ * server-confirmed POST response into the cache itself. Refetching the trip
+ * right after can return a stale GET (Supavisor read-after-write lag, SW or
+ * IndexedDB snapshots) that clobbers the just-added schedule (#123), so this
+ * variant skips the trip-detail invalidation and only broadcasts + refreshes
+ * the activity logs.
+ */
+export function useTripMutationCallbacks({
+  tripId,
+  invalidateTrip,
+  broadcastChange,
+}: {
+  tripId: string;
+  invalidateTrip: () => Promise<void>;
+  broadcastChange: () => void;
+}) {
+  const queryClient = useQueryClient();
+
+  const onMutate = useCallback(async () => {
+    await invalidateTrip();
+    broadcastChange();
+    await queryClient.invalidateQueries({ queryKey: queryKeys.trips.activityLogs(tripId) });
+  }, [invalidateTrip, broadcastChange, queryClient, tripId]);
+
+  const onScheduleAdded = useCallback(async () => {
+    broadcastChange();
+    await queryClient.invalidateQueries({ queryKey: queryKeys.trips.activityLogs(tripId) });
+  }, [broadcastChange, queryClient, tripId]);
+
+  return { onMutate, onScheduleAdded };
+}


### PR DESCRIPTION
## Summary

Issue #123 の対応。予定追加 API は成功し activity log にも残るのに、旅程に予定が表示されない(リロードしても出ない)ことがある問題を修正する。

### 根本対策: 予定追加後の trip detail refetch をスキップ

- 予定追加ダイアログは POST レスポンス(サーバ確定データ)を `setQueryData` でキャッシュに反映済み。直後の `invalidateTrip` の refetch が stale な GET(Supavisor の read-after-write ラグ / SW キャッシュ / IndexedDB スナップショット)を返すと、この追記を丸ごと上書きして予定が消えていた
- `onScheduleAdded` コールバックを新設し、予定追加後は broadcast + activity logs の invalidate のみ実施(trip detail の refetch はしない)。stale の出所がどれであっても上書きの窓そのものが塞がる
- `setQueryData` 前に `cancelQueries` を追加し、in-flight の stale GET が追記を上書きする残りの窓も閉鎖(他の mutation ハンドラと同じパターンに統一)
- Desktop / SP 両ページで重複していた mutation コールバックを `useTripMutationCallbacks` フックに抽出し、「予定追加後に trip detail を refetch しない」ことをユニットテストで固定
- `DayTimeline.onScheduleAdded` は required。新しい呼び出し元が渡し忘れて stale refetch 経路に退行するのを型で防ぐ

### 補助対策: SW の `/api/` を NetworkOnly 化

- serwist defaultCache の `apis` NetworkFirst ハンドラを NetworkOnly で上書きし、stale 出所候補 (a) を排除
- `networkTimeoutSeconds: 10` を付与(遮蔽される defaultCache の `/api/auth/*` エントリのタイムアウトを維持)
- 認証付き個人データが Cache Storage に残るプライバシー問題も同時に解消(旧 `apis` キャッシュは activate 時に削除)
- オフライン閲覧は IndexedDB 永続の TanStack Query キャッシュ(maxAge 7日)が引き続き担うため、機能的な後退はない

### 付随修正

- `onMutate` の activity logs 個別 invalidate を削除(`invalidateTrip` の prefix マッチが既に対象に含み、毎 mutation で余分な GET を発行していた)

### 既知の限界(別 Issue #155)

共同編集者の broadcast による debouncedSync、visibilitychange / online ハンドラ起点の `invalidateTrip` は、追加直後 ~500ms の窓で同型の上書きを起こしうる(共同編集時のみ・一過性)。他の `setQueryData` 経路(candidate-panel 等)の同型パターンと合わせて #155 で汎用対策を検討する。

### 採用しなかった対策案

- POST レスポンスで完全な trip を返す案: API の変更範囲が大きく、根本対策だけで上書き窓が塞がるため見送り(#155 の対応案として記録)

## Test plan

- [x] 再現テスト: `onScheduleAdded` が trip detail を refetch しない / activity logs の invalidate と broadcast は行う(`use-trip-mutation-callbacks.test.ts` 7 件)
- [x] `bun run --filter @sugara/web test` 785 件 green
- [x] `bun run check` / `bun run check-types` / `bun run build` green
- [x] コードレビュー(7 観点 finder + 検証エージェント)実施、CONFIRMED 4 件をすべて修正済み
- [ ] 本番デプロイ後、再発条件(予定複数件の日への追加)で手動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)