### PR TITLE
feat: APIエラーコードを標準化しcodeベースのi18n出し分けを導入

### DIFF
--- a/apps/api/src/__tests__/groups.test.ts
+++ b/apps/api/src/__tests__/groups.test.ts
@@ -43,7 +43,7 @@ vi.mock("../db/index", () => {
   };
 });
 
-import { MAX_GROUPS_PER_USER, MAX_MEMBERS_PER_GROUP } from "@sugara/shared";
+import { ERROR_CODE, MAX_GROUPS_PER_USER, MAX_MEMBERS_PER_GROUP } from "@sugara/shared";
 import { groupRoutes } from "../routes/groups";
 
 const userId = "00000000-0000-0000-0000-000000000001";
@@ -399,6 +399,34 @@ describe("Group routes", () => {
       expect(res.status).toBe(409);
     });
 
+    it("returns ALREADY_GROUP_MEMBER code when already a member", async () => {
+      mockDbQuery.groups.findFirst.mockResolvedValue({
+        id: groupId,
+        ownerId: userId,
+        name: "Family",
+      });
+      mockDbQuery.users.findFirst.mockResolvedValue({
+        id: otherUserId,
+        name: "Friend A",
+      });
+      setupCountQuery(0);
+      const pgError = new Error("duplicate key");
+      Object.assign(pgError, { code: "23505" });
+      mockDbInsert.mockReturnValue({
+        values: vi.fn().mockRejectedValue(pgError),
+      });
+
+      const app = createTestApp(groupRoutes, "/api/groups");
+      const res = await app.request(`/api/groups/${groupId}/members`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ userId: otherUserId }),
+      });
+      const body = await res.json();
+
+      expect(body.code).toBe(ERROR_CODE.ALREADY_GROUP_MEMBER);
+    });
+
     it("returns 409 when member limit reached", async () => {
       mockDbQuery.groups.findFirst.mockResolvedValue({
         id: groupId,
@@ -420,6 +448,52 @@ describe("Group routes", () => {
       });
 
       expect(res.status).toBe(409);
+    });
+
+    it("returns LIMIT_GROUP_MEMBERS code when member limit reached", async () => {
+      mockDbQuery.groups.findFirst.mockResolvedValue({
+        id: groupId,
+        ownerId: userId,
+        name: "Family",
+      });
+      mockDbQuery.users.findFirst.mockResolvedValue({
+        id: otherUserId,
+        name: "Friend A",
+      });
+      setupCountQuery(MAX_MEMBERS_PER_GROUP);
+
+      const app = createTestApp(groupRoutes, "/api/groups");
+      const res = await app.request(`/api/groups/${groupId}/members`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ userId: otherUserId }),
+      });
+      const body = await res.json();
+
+      expect(body.code).toBe(ERROR_CODE.LIMIT_GROUP_MEMBERS);
+    });
+
+    it("returns details.max equal to MAX_MEMBERS_PER_GROUP when limit reached", async () => {
+      mockDbQuery.groups.findFirst.mockResolvedValue({
+        id: groupId,
+        ownerId: userId,
+        name: "Family",
+      });
+      mockDbQuery.users.findFirst.mockResolvedValue({
+        id: otherUserId,
+        name: "Friend A",
+      });
+      setupCountQuery(MAX_MEMBERS_PER_GROUP);
+
+      const app = createTestApp(groupRoutes, "/api/groups");
+      const res = await app.request(`/api/groups/${groupId}/members`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ userId: otherUserId }),
+      });
+      const body = await res.json();
+
+      expect(body.details.max).toBe(MAX_MEMBERS_PER_GROUP);
     });
   });
 

--- a/apps/api/src/__tests__/integration/members.integration.test.ts
+++ b/apps/api/src/__tests__/integration/members.integration.test.ts
@@ -16,6 +16,7 @@ vi.mock("../../lib/auth", () => ({
   },
 }));
 
+import { handleError } from "../../lib/error-handler";
 import { memberRoutes } from "../../routes/members";
 import { tripRoutes } from "../../routes/trips";
 import { cleanupTables, createTestUser, teardownTestDb } from "./setup";
@@ -24,6 +25,9 @@ function createApp() {
   const app = new Hono();
   app.route("/api/trips", tripRoutes);
   app.route("/api/trips", memberRoutes);
+  // Mirror production error handling (app.ts registers the same handler);
+  // routes now surface conflicts by throwing AppError instead of returning.
+  app.onError(handleError);
   return app;
 }
 

--- a/apps/api/src/__tests__/members.test.ts
+++ b/apps/api/src/__tests__/members.test.ts
@@ -70,7 +70,7 @@ vi.mock("../lib/notifications", () => ({
     mockNotifyArticleOwnersOnMemberAdded(...args),
 }));
 
-import { MAX_MEMBERS_PER_TRIP } from "@sugara/shared";
+import { ERROR_CODE, MAX_MEMBERS_PER_TRIP } from "@sugara/shared";
 import { articleTrips } from "../db/schema";
 import { memberRoutes } from "../routes/members";
 
@@ -234,6 +234,26 @@ describe("Member routes", () => {
       expect(res.status).toBe(409);
     });
 
+    it("returns ALREADY_MEMBER code when user is already a member", async () => {
+      mockDbQuery.users.findFirst.mockResolvedValue({
+        id: fakeUser2Id,
+        name: "Existing",
+      });
+      mockDbQuery.tripMembers.findFirst
+        .mockResolvedValueOnce({ tripId, userId: fakeUserId, role: "owner" })
+        .mockResolvedValueOnce({ tripId, userId: fakeUser2Id, role: "editor" });
+
+      const app = createTestApp(memberRoutes, "/api/trips");
+      const res = await app.request(basePath, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ userId: fakeUser2Id, role: "editor" }),
+      });
+      const body = await res.json();
+
+      expect(body.code).toBe(ERROR_CODE.ALREADY_MEMBER);
+    });
+
     it("returns 400 with invalid userId", async () => {
       const app = createTestApp(memberRoutes, "/api/trips");
       const res = await app.request(basePath, {
@@ -260,6 +280,60 @@ describe("Member routes", () => {
       });
 
       expect(res.status).toBe(409);
+    });
+
+    it("returns LIMIT_MEMBERS code when member limit reached", async () => {
+      mockDbQuery.users.findFirst.mockResolvedValue({
+        id: fakeUser2Id,
+        name: "New Member",
+      });
+      mockDbQuery.tripMembers.findFirst.mockResolvedValueOnce({
+        tripId,
+        userId: fakeUserId,
+        role: "owner",
+      });
+      mockDbSelect.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ count: MAX_MEMBERS_PER_TRIP }]),
+        }),
+      });
+
+      const app = createTestApp(memberRoutes, "/api/trips");
+      const res = await app.request(basePath, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ userId: fakeUser2Id, role: "editor" }),
+      });
+      const body = await res.json();
+
+      expect(body.code).toBe(ERROR_CODE.LIMIT_MEMBERS);
+    });
+
+    it("returns details.max equal to MAX_MEMBERS_PER_TRIP when member limit reached", async () => {
+      mockDbQuery.users.findFirst.mockResolvedValue({
+        id: fakeUser2Id,
+        name: "New Member",
+      });
+      mockDbQuery.tripMembers.findFirst.mockResolvedValueOnce({
+        tripId,
+        userId: fakeUserId,
+        role: "owner",
+      });
+      mockDbSelect.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ count: MAX_MEMBERS_PER_TRIP }]),
+        }),
+      });
+
+      const app = createTestApp(memberRoutes, "/api/trips");
+      const res = await app.request(basePath, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ userId: fakeUser2Id, role: "editor" }),
+      });
+      const body = await res.json();
+
+      expect(body.details.max).toBe(MAX_MEMBERS_PER_TRIP);
     });
 
     it("POST: メンバー追加時に createNotification を呼ぶ", async () => {

--- a/apps/api/src/__tests__/trips.test.ts
+++ b/apps/api/src/__tests__/trips.test.ts
@@ -355,6 +355,85 @@ describe("Trip routes", () => {
 
       expect(res.status).toBe(409);
     });
+
+    it("returns LIMIT_TRIPS code when trip limit reached", async () => {
+      const { ERROR_CODE, MAX_TRIPS_PER_USER } = await import("@sugara/shared");
+      mockDbSelect.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ count: MAX_TRIPS_PER_USER }]),
+        }),
+      });
+
+      const app = createTestApp(tripRoutes, "/api/trips");
+      const res = await app.request("/api/trips", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: "Tokyo Trip",
+          destination: "Tokyo",
+          startDate: "2025-07-01",
+          endDate: "2025-07-03",
+        }),
+      });
+      const body = await res.json();
+
+      expect(body.code).toBe(ERROR_CODE.LIMIT_TRIPS);
+    });
+
+    it("returns details.max equal to MAX_TRIPS_PER_USER when trip limit reached", async () => {
+      const { MAX_TRIPS_PER_USER } = await import("@sugara/shared");
+      mockDbSelect.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ count: MAX_TRIPS_PER_USER }]),
+        }),
+      });
+
+      const app = createTestApp(tripRoutes, "/api/trips");
+      const res = await app.request("/api/trips", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: "Tokyo Trip",
+          destination: "Tokyo",
+          startDate: "2025-07-01",
+          endDate: "2025-07-03",
+        }),
+      });
+      const body = await res.json();
+
+      expect(body.details.max).toBe(MAX_TRIPS_PER_USER);
+    });
+
+    it("returns details.max equal to override value when per-user trip limit reached", async () => {
+      const overrideLimit = 50;
+      // 1st select: trip count at the override limit
+      mockDbSelect.mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ count: overrideLimit }]),
+        }),
+      });
+      // 2nd select: resolveTripLimit returns the override value
+      mockDbSelect.mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ tripLimit: overrideLimit }]),
+        }),
+      });
+
+      const app = createTestApp(tripRoutes, "/api/trips");
+      const res = await app.request("/api/trips", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: "Tokyo Trip",
+          destination: "Tokyo",
+          startDate: "2025-07-01",
+          endDate: "2025-07-03",
+        }),
+      });
+      const body = await res.json();
+
+      expect(body.details.max).toBe(overrideLimit);
+    });
   });
 
   describe("GET /api/trips", () => {

--- a/apps/api/src/routes/groups.ts
+++ b/apps/api/src/routes/groups.ts
@@ -1,7 +1,9 @@
 import {
+  AppError,
   addGroupMemberSchema,
   addGroupMembersBulkSchema,
   createGroupSchema,
+  ERROR_CODE,
   MAX_GROUPS_PER_USER,
   MAX_MEMBERS_PER_GROUP,
   updateGroupSchema,
@@ -193,13 +195,15 @@ groupRoutes.post("/:groupId/members", async (c) => {
     return c.json({ error: ERROR_MSG.USER_NOT_FOUND }, 404);
   }
 
-  const result = await db.transaction(async (tx) => {
+  await db.transaction(async (tx) => {
     const [{ count: memberCount }] = await tx
       .select({ count: count() })
       .from(groupMembers)
       .where(eq(groupMembers.groupId, groupId));
     if (memberCount >= MAX_MEMBERS_PER_GROUP) {
-      return "limit" as const;
+      throw new AppError(ERROR_MSG.LIMIT_GROUP_MEMBERS, ERROR_CODE.LIMIT_GROUP_MEMBERS, 409, {
+        max: MAX_MEMBERS_PER_GROUP,
+      });
     }
 
     try {
@@ -209,20 +213,11 @@ groupRoutes.post("/:groupId/members", async (c) => {
       });
     } catch (e) {
       if (e instanceof Error && "code" in e && e.code === PG_UNIQUE_VIOLATION) {
-        return "duplicate" as const;
+        throw new AppError(ERROR_MSG.ALREADY_GROUP_MEMBER, ERROR_CODE.ALREADY_GROUP_MEMBER, 409);
       }
       throw e;
     }
-
-    return "ok" as const;
   });
-
-  if (result === "limit") {
-    return c.json({ error: ERROR_MSG.LIMIT_GROUP_MEMBERS }, 409);
-  }
-  if (result === "duplicate") {
-    return c.json({ error: ERROR_MSG.ALREADY_GROUP_MEMBER }, 409);
-  }
 
   return c.json({ ok: true }, 201);
 });
@@ -253,7 +248,9 @@ groupRoutes.post("/:groupId/members/bulk", async (c) => {
 
     const remainingSlots = MAX_MEMBERS_PER_GROUP - currentCount;
     if (remainingSlots <= 0) {
-      return { added: 0, failed: userIds.length, limitReached: true } as const;
+      throw new AppError(ERROR_MSG.LIMIT_GROUP_MEMBERS, ERROR_CODE.LIMIT_GROUP_MEMBERS, 409, {
+        max: MAX_MEMBERS_PER_GROUP,
+      });
     }
 
     const existingMembers = await tx
@@ -279,16 +276,8 @@ groupRoutes.post("/:groupId/members/bulk", async (c) => {
       await tx.insert(groupMembers).values(toAdd.map((uid) => ({ groupId, userId: uid })));
     }
 
-    return {
-      added: toAdd.length,
-      failed: userIds.length - toAdd.length,
-      limitReached: false,
-    } as const;
+    return { added: toAdd.length, failed: userIds.length - toAdd.length };
   });
-
-  if (result.limitReached) {
-    return c.json({ error: ERROR_MSG.LIMIT_GROUP_MEMBERS }, 409);
-  }
 
   return c.json({ added: result.added, failed: result.failed }, 201);
 });

--- a/apps/api/src/routes/members.ts
+++ b/apps/api/src/routes/members.ts
@@ -1,5 +1,7 @@
 import {
+  AppError,
   addMemberSchema,
+  ERROR_CODE,
   MAX_MEMBERS_PER_TRIP,
   ROLE_LABELS,
   updateMemberRoleSchema,
@@ -81,7 +83,7 @@ memberRoutes.post("/:tripId/members", requireTripAccess("owner"), async (c) => {
     return c.json({ error: ERROR_MSG.USER_NOT_FOUND }, 404);
   }
 
-  const result = await db.transaction(async (tx) => {
+  await db.transaction(async (tx) => {
     const [[{ count: memberCount }], existing] = await Promise.all([
       tx.select({ count: count() }).from(tripMembers).where(eq(tripMembers.tripId, tripId)),
       tx.query.tripMembers.findFirst({
@@ -89,10 +91,12 @@ memberRoutes.post("/:tripId/members", requireTripAccess("owner"), async (c) => {
       }),
     ]);
     if (memberCount >= MAX_MEMBERS_PER_TRIP) {
-      return "limit" as const;
+      throw new AppError(ERROR_MSG.LIMIT_MEMBERS, ERROR_CODE.LIMIT_MEMBERS, 409, {
+        max: MAX_MEMBERS_PER_TRIP,
+      });
     }
     if (existing) {
-      return "duplicate" as const;
+      throw new AppError(ERROR_MSG.ALREADY_MEMBER, ERROR_CODE.ALREADY_MEMBER, 409);
     }
 
     await tx.insert(tripMembers).values({
@@ -100,16 +104,7 @@ memberRoutes.post("/:tripId/members", requireTripAccess("owner"), async (c) => {
       userId: targetUser.id,
       role: parsed.data.role,
     });
-
-    return "ok" as const;
   });
-
-  if (result === "limit") {
-    return c.json({ error: ERROR_MSG.LIMIT_MEMBERS }, 409);
-  }
-  if (result === "duplicate") {
-    return c.json({ error: ERROR_MSG.ALREADY_MEMBER }, 409);
-  }
 
   logActivity({
     tripId,

--- a/apps/api/src/routes/trips.ts
+++ b/apps/api/src/routes/trips.ts
@@ -1,4 +1,10 @@
-import { createTripSchema, createTripWithPollSchema, updateTripSchema } from "@sugara/shared";
+import {
+  AppError,
+  createTripSchema,
+  createTripWithPollSchema,
+  ERROR_CODE,
+  updateTripSchema,
+} from "@sugara/shared";
 import { and, count, desc, eq, getTableColumns, ne, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { db } from "../db/index";
@@ -133,7 +139,10 @@ tripRoutes.post("/", async (c) => {
       // catch race conditions and return the same error code as the pre-check.
       const limit = user.isAnonymous ? 1 : await resolveTripLimit(tx, user.id);
       if (tripCount.count >= limit) {
-        return user.isAnonymous ? ("GUEST_LIMIT" as const) : null;
+        if (!user.isAnonymous) {
+          throw new AppError(ERROR_MSG.LIMIT_TRIPS, ERROR_CODE.LIMIT_TRIPS, 409, { max: limit });
+        }
+        return "GUEST_LIMIT" as const;
       }
 
       const [created] = await tx
@@ -185,9 +194,6 @@ tripRoutes.post("/", async (c) => {
     if (trip === "GUEST_LIMIT") {
       return c.json({ error: ERROR_MSG.GUEST_TRIP_LIMIT }, 403);
     }
-    if (!trip) {
-      return c.json({ error: ERROR_MSG.LIMIT_TRIPS }, 409);
-    }
 
     logActivity({
       tripId: trip.id,
@@ -233,7 +239,10 @@ tripRoutes.post("/", async (c) => {
     // catch race conditions and return the same error code as the pre-check.
     const limit = user.isAnonymous ? 1 : await resolveTripLimit(tx, user.id);
     if (tripCount.count >= limit) {
-      return user.isAnonymous ? ("GUEST_LIMIT" as const) : null;
+      if (!user.isAnonymous) {
+        throw new AppError(ERROR_MSG.LIMIT_TRIPS, ERROR_CODE.LIMIT_TRIPS, 409, { max: limit });
+      }
+      return "GUEST_LIMIT" as const;
     }
 
     const [created] = await tx
@@ -264,9 +273,6 @@ tripRoutes.post("/", async (c) => {
 
   if (trip === "GUEST_LIMIT") {
     return c.json({ error: ERROR_MSG.GUEST_TRIP_LIMIT }, 403);
-  }
-  if (!trip) {
-    return c.json({ error: ERROR_MSG.LIMIT_TRIPS }, 409);
   }
 
   logActivity({
@@ -435,9 +441,9 @@ tripRoutes.post("/:id/duplicate", requireTripAccess("viewer", "id"), async (c) =
       .select({ count: count() })
       .from(trips)
       .where(eq(trips.ownerId, user.id));
-    const limit = user.isAnonymous ? 1 : await resolveTripLimit(tx, user.id);
+    const limit = await resolveTripLimit(tx, user.id);
     if (tripCount.count >= limit) {
-      return null;
+      throw new AppError(ERROR_MSG.LIMIT_TRIPS, ERROR_CODE.LIMIT_TRIPS, 409, { max: limit });
     }
 
     const [created] = await tx
@@ -538,10 +544,6 @@ tripRoutes.post("/:id/duplicate", requireTripAccess("viewer", "id"), async (c) =
 
     return created;
   });
-
-  if (!newTrip) {
-    return c.json({ error: ERROR_MSG.LIMIT_TRIPS }, 409);
-  }
 
   // Copy cover image file in Storage (outside transaction to avoid holding locks)
   if (source.coverImageUrl) {

--- a/apps/web/app/(authenticated)/friends/_components/group-detail-modal.tsx
+++ b/apps/web/app/(authenticated)/friends/_components/group-detail-modal.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import type { FriendResponse, GroupMemberResponse, GroupResponse } from "@sugara/shared";
+import {
+  ERROR_CODE,
+  type FriendResponse,
+  type GroupMemberResponse,
+  type GroupResponse,
+  MAX_MEMBERS_PER_GROUP,
+} from "@sugara/shared";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { UserMinus, UserPlus } from "lucide-react";
 import { useTranslations } from "next-intl";
@@ -59,6 +65,12 @@ export function GroupDetailModal({ group, onOpenChange }: Props) {
     queryClient.invalidateQueries({ queryKey: queryKeys.groups.list() });
   };
 
+  const groupMemberErrorByCode = {
+    [ERROR_CODE.ALREADY_GROUP_MEMBER]: tm("groupMemberAlready"),
+    [ERROR_CODE.LIMIT_GROUP_MEMBERS]: (max: number | undefined) =>
+      tm("limitGroupMembers", { max: max ?? MAX_MEMBERS_PER_GROUP }),
+  };
+
   async function handleRemoveMember(memberId: string) {
     setRemovingMemberId(memberId);
 
@@ -104,6 +116,7 @@ export function GroupDetailModal({ group, onOpenChange }: Props) {
           badRequest: tm("invalidUserId") as string,
           notFound: tm("userNotFound") as string,
           conflict: tm("groupMemberAlready") as string,
+          byCode: groupMemberErrorByCode,
         }),
       );
     } finally {
@@ -121,7 +134,11 @@ export function GroupDetailModal({ group, onOpenChange }: Props) {
       toast.success(tm("groupMemberAdded"));
       invalidateAll();
     } catch (err) {
-      toast.error(getApiErrorMessage(err, tm("groupMemberAddFailed") as string));
+      toast.error(
+        getApiErrorMessage(err, tm("groupMemberAddFailed") as string, {
+          byCode: groupMemberErrorByCode,
+        }),
+      );
     } finally {
       setAddingFriendId(null);
     }

--- a/apps/web/app/(sp)/sp/friends/groups/[id]/add/page.tsx
+++ b/apps/web/app/(sp)/sp/friends/groups/[id]/add/page.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import type {
-  BulkAddMembersResponse,
-  FriendResponse,
-  GroupMemberResponse,
-  GroupResponse,
+import {
+  type BulkAddMembersResponse,
+  ERROR_CODE,
+  type FriendResponse,
+  type GroupMemberResponse,
+  type GroupResponse,
+  MAX_MEMBERS_PER_GROUP,
 } from "@sugara/shared";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowLeft, CheckCheck, SquareMousePointer, UserPlus, X } from "lucide-react";
@@ -66,6 +68,12 @@ export default function SpGroupAddMemberPage() {
     queryClient.invalidateQueries({ queryKey: queryKeys.groups.list() });
   };
 
+  const groupMemberErrorByCode = {
+    [ERROR_CODE.ALREADY_GROUP_MEMBER]: tm("groupMemberAlready"),
+    [ERROR_CODE.LIMIT_GROUP_MEMBERS]: (max: number | undefined) =>
+      tm("limitGroupMembers", { max: max ?? MAX_MEMBERS_PER_GROUP }),
+  };
+
   function exitSelectionMode() {
     setSelectionMode(false);
     setSelectedIds(new Set());
@@ -90,7 +98,11 @@ export default function SpGroupAddMemberPage() {
       toast.success(tm("groupMemberAdded"));
       invalidateAll();
     } catch (err) {
-      toast.error(getApiErrorMessage(err, tm("groupMemberAddFailed") as string));
+      toast.error(
+        getApiErrorMessage(err, tm("groupMemberAddFailed") as string, {
+          byCode: groupMemberErrorByCode,
+        }),
+      );
     } finally {
       setAdding(false);
     }
@@ -112,7 +124,11 @@ export default function SpGroupAddMemberPage() {
       exitSelectionMode();
       invalidateAll();
     } catch (err) {
-      toast.error(getApiErrorMessage(err, tm("groupMemberAddFailed") as string));
+      toast.error(
+        getApiErrorMessage(err, tm("groupMemberAddFailed") as string, {
+          byCode: groupMemberErrorByCode,
+        }),
+      );
     } finally {
       setAdding(false);
     }
@@ -133,7 +149,11 @@ export default function SpGroupAddMemberPage() {
       setUserId("");
       invalidateAll();
     } catch (err) {
-      toast.error(getApiErrorMessage(err, tm("groupMemberAddFailed") as string));
+      toast.error(
+        getApiErrorMessage(err, tm("groupMemberAddFailed") as string, {
+          byCode: groupMemberErrorByCode,
+        }),
+      );
     } finally {
       setAdding(false);
     }

--- a/apps/web/app/(sp)/sp/trips/[id]/members/page.tsx
+++ b/apps/web/app/(sp)/sp/trips/[id]/members/page.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import type {
-  FriendResponse,
-  GroupMemberResponse,
-  GroupResponse,
-  MemberResponse,
+import {
+  ERROR_CODE,
+  type FriendResponse,
+  type GroupMemberResponse,
+  type GroupResponse,
+  MAX_MEMBERS_PER_TRIP,
+  type MemberResponse,
 } from "@sugara/shared";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowLeft, ChevronRight, Pencil, UserMinus, UserPlus, Users, X } from "lucide-react";
@@ -125,6 +127,11 @@ export default function SpTripMembersPage() {
           badRequest: tm("invalidUserId"),
           notFound: tm("userNotFound"),
           conflict: tm("memberAlready"),
+          byCode: {
+            [ERROR_CODE.ALREADY_MEMBER]: tm("memberAlready"),
+            [ERROR_CODE.LIMIT_MEMBERS]: (max) =>
+              tm("limitMembers", { max: max ?? MAX_MEMBERS_PER_TRIP }),
+          },
         }),
       );
     } finally {
@@ -146,6 +153,11 @@ export default function SpTripMembersPage() {
         getApiErrorMessage(err, tm("memberAddFailed"), {
           notFound: tm("userNotFound"),
           conflict: tm("memberAlready"),
+          byCode: {
+            [ERROR_CODE.ALREADY_MEMBER]: tm("memberAlready"),
+            [ERROR_CODE.LIMIT_MEMBERS]: (max) =>
+              tm("limitMembers", { max: max ?? MAX_MEMBERS_PER_TRIP }),
+          },
         }),
       );
     } finally {

--- a/apps/web/components/create-trip-dialog.tsx
+++ b/apps/web/components/create-trip-dialog.tsx
@@ -3,6 +3,8 @@
 import {
   CURRENCIES,
   type CurrencyCode,
+  ERROR_CODE,
+  MAX_TRIPS_PER_USER,
   TRIP_DESTINATION_MAX_LENGTH,
   TRIP_TITLE_MAX_LENGTH,
 } from "@sugara/shared";
@@ -155,7 +157,14 @@ export function CreateTripDialog({ open, onOpenChange, onCreated }: CreateTripDi
         if (err instanceof ApiError && err.status === 403 && err.message.includes("Guest")) {
           setError(tm("authGuestTripLimit"));
         } else {
-          setError(getApiErrorMessage(err, tm("tripCreateFailed")));
+          setError(
+            getApiErrorMessage(err, tm("tripCreateFailed"), {
+              byCode: {
+                [ERROR_CODE.LIMIT_TRIPS]: (max) =>
+                  tm("limitTrips", { max: max ?? MAX_TRIPS_PER_USER }),
+              },
+            }),
+          );
         }
       } finally {
         setLoading(false);
@@ -198,7 +207,14 @@ export function CreateTripDialog({ open, onOpenChange, onCreated }: CreateTripDi
         if (err instanceof ApiError && err.status === 403 && err.message.includes("Guest")) {
           setError(tm("authGuestTripLimit"));
         } else {
-          setError(getApiErrorMessage(err, tm("tripCreateFailed")));
+          setError(
+            getApiErrorMessage(err, tm("tripCreateFailed"), {
+              byCode: {
+                [ERROR_CODE.LIMIT_TRIPS]: (max) =>
+                  tm("limitTrips", { max: max ?? MAX_TRIPS_PER_USER }),
+              },
+            }),
+          );
         }
       } finally {
         setLoading(false);

--- a/apps/web/components/member-dialog.tsx
+++ b/apps/web/components/member-dialog.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import type {
-  FriendResponse,
-  GroupMemberResponse,
-  GroupResponse,
-  MemberResponse,
+import {
+  ERROR_CODE,
+  type FriendResponse,
+  type GroupMemberResponse,
+  type GroupResponse,
+  MAX_MEMBERS_PER_TRIP,
+  type MemberResponse,
 } from "@sugara/shared";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { UserPlus, X } from "lucide-react";
@@ -114,6 +116,11 @@ export function MemberDialog({
       badRequest: tm("invalidUserId"),
       notFound: tm("userNotFound"),
       conflict: tm("memberAlready"),
+      byCode: {
+        [ERROR_CODE.ALREADY_MEMBER]: tm("memberAlready"),
+        [ERROR_CODE.LIMIT_MEMBERS]: (max) =>
+          tm("limitMembers", { max: max ?? MAX_MEMBERS_PER_TRIP }),
+      },
     });
 
   async function handleAdd(e: React.FormEvent) {
@@ -345,7 +352,9 @@ export function MemberDialog({
             <div className="space-y-3 border-t pt-3">
               <Label className="text-sm font-medium">{tme("addMember")}</Label>
               {memberLimitReached ? (
-                <p className="text-sm text-muted-foreground">{tm("limitMembers", { max: 20 })}</p>
+                <p className="text-sm text-muted-foreground">
+                  {tm("limitMembers", { max: MAX_MEMBERS_PER_TRIP })}
+                </p>
               ) : (
                 <Tabs defaultValue="friends">
                   <TabsList className="w-full">

--- a/apps/web/lib/__tests__/api.test.ts
+++ b/apps/web/lib/__tests__/api.test.ts
@@ -199,6 +199,54 @@ describe("getApiErrorMessage", () => {
 
     expect(getApiErrorMessage(error, "通信に失敗しました")).toBe("通信に失敗しました");
   });
+
+  it("byCode string value takes priority over conflict opts", () => {
+    const error = new ApiError("Already a member", 409, "ALREADY_MEMBER");
+
+    expect(
+      getApiErrorMessage(error, "fallback", {
+        conflict: "conflict msg",
+        byCode: { ALREADY_MEMBER: "すでにメンバーです" },
+      }),
+    ).toBe("すでにメンバーです");
+  });
+
+  it("byCode function receives details.max when present", () => {
+    const error = new ApiError("limit", 409, "LIMIT_MEMBERS", { max: 20 });
+    const handler = vi.fn().mockReturnValue("20人まで");
+
+    getApiErrorMessage(error, "fallback", { byCode: { LIMIT_MEMBERS: handler } });
+
+    expect(handler).toHaveBeenCalledWith(20);
+  });
+
+  it("byCode function receives undefined when details are missing", () => {
+    const error = new ApiError("limit", 409, "LIMIT_MEMBERS");
+    const handler = vi.fn().mockReturnValue("上限に達しました");
+
+    getApiErrorMessage(error, "fallback", { byCode: { LIMIT_MEMBERS: handler } });
+
+    expect(handler).toHaveBeenCalledWith(undefined);
+  });
+
+  it("falls back to conflict opts when code is not in byCode map", () => {
+    const error = new ApiError("Already a member", 409, "ALREADY_MEMBER");
+
+    expect(
+      getApiErrorMessage(error, "fallback", {
+        conflict: "conflict msg",
+        byCode: { LIMIT_MEMBERS: "limit msg" },
+      }),
+    ).toBe("conflict msg");
+  });
+
+  it("returns fallback when neither byCode nor status opts match", () => {
+    const error = new ApiError("Already a member", 409, "ALREADY_MEMBER");
+
+    expect(getApiErrorMessage(error, "fallback", { byCode: { LIMIT_MEMBERS: "limit msg" } })).toBe(
+      "fallback",
+    );
+  });
 });
 
 describe("fetchApi error shape parsing", () => {

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -1,3 +1,4 @@
+import { type ErrorCode, LimitDetailsSchema } from "@sugara/shared";
 import { reportError } from "@/lib/report-error";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || "";
@@ -107,6 +108,15 @@ export async function apiVoid(path: string, options: FetchOptions = {}): Promise
   await fetchApi(path, options);
 }
 
+// Type guard: narrows a string to ErrorCode if it is a key in the given map.
+// Using hasOwnProperty avoids matching prototype-chain properties.
+function isKnownErrorCode(
+  code: string,
+  map: Partial<Record<ErrorCode, unknown>>,
+): code is ErrorCode {
+  return Object.hasOwn(map, code);
+}
+
 /**
  * Extract a user-facing error message from an unknown catch value.
  *
@@ -115,13 +125,32 @@ export async function apiVoid(path: string, options: FetchOptions = {}): Promise
  * shown to users. Callers supply a localized {@link fallback} and may pass
  * per-status overrides; when no override matches, the localized fallback is
  * returned. This guarantees the user always sees a translated message.
+ *
+ * The optional {@link opts.byCode} map takes priority over status-based opts.
+ * Values may be a string or a function that receives `details.max` (if the
+ * error carries a {@link LimitDetailsSchema}-shaped details payload).
  */
 export function getApiErrorMessage(
   err: unknown,
   fallback: string,
-  opts?: { badRequest?: string; conflict?: string; notFound?: string },
+  opts?: {
+    badRequest?: string;
+    conflict?: string;
+    notFound?: string;
+    byCode?: Partial<Record<ErrorCode, string | ((max: number | undefined) => string)>>;
+  },
 ): string {
   if (err instanceof ApiError) {
+    if (err.code !== undefined && opts?.byCode !== undefined) {
+      if (isKnownErrorCode(err.code, opts.byCode)) {
+        const handler = opts.byCode[err.code];
+        if (handler !== undefined) {
+          if (typeof handler === "string") return handler;
+          const parsed = LimitDetailsSchema.safeParse(err.details);
+          return handler(parsed.success ? parsed.data.max : undefined);
+        }
+      }
+    }
     if (err.status === 400) return opts?.badRequest ?? fallback;
     if (err.status === 409) return opts?.conflict ?? fallback;
     if (err.status === 404) return opts?.notFound ?? fallback;

--- a/packages/shared/src/errors.ts
+++ b/packages/shared/src/errors.ts
@@ -1,9 +1,10 @@
 import { z } from "zod";
 
 // ─── Error code taxonomy ──────────────────────────────────────────────────────
-// HTTP-semantic classification of API errors. The human-readable detail stays in
-// ERROR_MSG (messages.ts) and is carried in the `message` field; `code` lets the
-// frontend branch on the *kind* of error without parsing message strings.
+// HTTP-semantic classification of API errors + frontend domain codes.
+// The human-readable detail stays in ERROR_MSG (messages.ts) and is carried in
+// the `message` field; `code` lets the frontend branch on the *kind* of error
+// without parsing message strings.
 
 export const ERROR_CODE = {
   VALIDATION: "VALIDATION",
@@ -15,6 +16,14 @@ export const ERROR_CODE = {
   INTERNAL: "INTERNAL",
   INVALID_JSON: "INVALID_JSON",
   INVALID_ID_FORMAT: "INVALID_ID_FORMAT",
+  // Domain-specific codes for limit and membership conflicts.
+  // Carried in the `code` field so the frontend can show context-specific messages
+  // (e.g. per-user limit value from `details.max`) without parsing message strings.
+  LIMIT_TRIPS: "LIMIT_TRIPS",
+  LIMIT_MEMBERS: "LIMIT_MEMBERS",
+  ALREADY_MEMBER: "ALREADY_MEMBER",
+  LIMIT_GROUP_MEMBERS: "LIMIT_GROUP_MEMBERS",
+  ALREADY_GROUP_MEMBER: "ALREADY_GROUP_MEMBER",
 } as const;
 
 export type ErrorCode = (typeof ERROR_CODE)[keyof typeof ERROR_CODE];
@@ -32,6 +41,14 @@ export const ErrorResponseSchema = z.object({
 });
 
 export type ErrorResponse = z.infer<typeof ErrorResponseSchema>;
+
+// ─── Limit error details ──────────────────────────────────────────────────────
+// Attached as `details` when throwing AppError for limit-reached codes
+// (LIMIT_TRIPS, LIMIT_MEMBERS, LIMIT_GROUP_MEMBERS). The `max` value is the
+// effective cap resolved at request time (may be a per-user override).
+
+export const LimitDetailsSchema = z.object({ max: z.number().int().positive() });
+export type LimitDetails = z.infer<typeof LimitDetailsSchema>;
 
 // ─── AppError hierarchy ───────────────────────────────────────────────────────
 // Throw an AppError from a route to have app.onError serialize it into the


### PR DESCRIPTION
## Summary
- メンバー追加・グループメンバー追加の 409 で「上限到達」と「既にメンバー」が正しく出し分けられるようになった(従来はどちらも「すでにメンバーです」と誤表示されうる)
- trip 作成の上限到達時に、ユーザーごとに可変な実際の上限値入りメッセージが ja/en で表示される
- `getApiErrorMessage` に code 優先マッピング(`byCode`)を導入し、status ベースの opts は fallback として温存

## Why
- HTTP status だけではエラー種別を判別できないケース(409 の多義)が残っており、上限到達でも「すでにメンバーです」と誤表示されていた(#150)
- サーバー側の `AppError`/`errorBody()`({ code, message, details })とクライアント側の `ApiError.code` は既に存在しており、未配線なだけだった。本 PR は新基盤の追加ではなく既存基盤への配線
- trips の上限分岐は transaction 戻り値が `resolveTripLimit` の実値を捨てていたため、判別ユニオン化ではなく transaction 内 throw 方式を採用(Drizzle は throw を rollback 後に再 throw し `app.onError` が処理)。post-tx 分岐が消え侵襲が最小になる
- `byCode` の値は「翻訳済み文字列 or `(max) => string`」とし、`details` の safeParse は `getApiErrorMessage` 内に集約。呼び出し側の boilerplate を抑えつつ関数を i18n 非依存に保つ

## Changes
- shared: `ERROR_CODE` に 5 code 追加(LIMIT_TRIPS / LIMIT_MEMBERS / ALREADY_MEMBER / LIMIT_GROUP_MEMBERS / ALREADY_GROUP_MEMBER)、`LimitDetailsSchema` を追加
- API: members(単体)/ groups(単体 + bulk)/ trips(create 2 経路 + copy)の上限・重複分岐を `throw new AppError(...)` に移行。legacy `error` フィールドは `errorBody()` が温存し後方互換
- Web: `getApiErrorMessage` に `byCode` opts を追加(code 優先 → status opts → fallback)。配線サイトは PC/SP 両方の全 5 画面(member-dialog / sp members / group-detail-modal / sp group add / create-trip-dialog)
- `member-dialog` のマジックナンバー `max: 20` を shared 定数 `MAX_MEMBERS_PER_TRIP` に置換
- i18n キーは新規追加ゼロ(既存の `limitMembers`/`limitGroupMembers`/`limitTrips` 等が `{max}` placeholder 付きで ja/en に存在)

## Test plan
- [x] API: 上限到達時に `code` + `details.max` を返すことを members / groups(単体・bulk)/ trips(per-user override 含む)でテスト(TDD Red→Green)
- [x] Web: `getApiErrorMessage` の byCode 優先・details parse・legacy fallback をユニットテストで検証
- [x] `bun run check` / `bun run check-types`: 全パッケージ green
- [x] `bun run --filter @sugara/api test`: 853 passed
- [x] `bun run --filter @sugara/web test`: 790 passed
- [x] `bun run --filter @sugara/shared test`: 248 passed

## Notes for reviewer
- guest 403 分岐(`"GUEST_LIMIT"` / `includes("Guest")`)は意図的に不変。throw 化は上限・重複分岐のみ
- bulk 追加の partial-success パス(フィルタ・スライス)は変更なし。throw はスロット残数ゼロ時のみ
- `v1/trips-write.ts` の LIMIT_TRIPS は旧形式のまま(スコープ外、follow-up Issue で追跡予定)
- 対象外の legacy `{ error }` 返却(USER_NOT_FOUND 等)は据え置き(段階的移行の方針)

## Related
- Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)