### PR TITLE
feat: v1 APIの旅行上限エラーにreasonとdetails.maxを追加

### DIFF
--- a/apps/api/src/__tests__/v1-write-routes.test.ts
+++ b/apps/api/src/__tests__/v1-write-routes.test.ts
@@ -387,6 +387,8 @@ describe("POST /trips", () => {
     const body = await res.json();
 
     // Assert
+    expect(res.status).toBe(409);
+    expect(body.error.code).toBe("conflict");
     expect(body.error.reason).toBe("trip_limit_reached");
     expect(body.error.details).toEqual({ max: 5 });
   });

--- a/apps/api/src/__tests__/v1-write-routes.test.ts
+++ b/apps/api/src/__tests__/v1-write-routes.test.ts
@@ -367,6 +367,29 @@ describe("POST /trips", () => {
     expect(res.status).toBe(409);
     expect(body.error.code).toBe("conflict");
   });
+
+  it("includes trip_limit_reached reason and details.max in the 409 body", async () => {
+    // Arrange
+    mockVerifyApiKey.mockResolvedValue(WRITE_KEY);
+    mockResolveTripLimit.mockResolvedValue(5);
+    mockDbSelect.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([{ count: 5 }]),
+      }),
+    });
+
+    // Act
+    const res = await jsonPost("/trips", {
+      title: "Overflow Trip",
+      startDate: "2026-07-01",
+      endDate: "2026-07-03",
+    });
+    const body = await res.json();
+
+    // Assert
+    expect(body.error.reason).toBe("trip_limit_reached");
+    expect(body.error.details).toEqual({ max: 5 });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/api/src/lib/external-api/errors.ts
+++ b/apps/api/src/lib/external-api/errors.ts
@@ -33,19 +33,52 @@ export type ApiV1ErrorCode =
   | "rate_limited"
   | "internal_error";
 
+// Fine-grained machine-readable reason carried alongside the coarse `code`.
+// The top-level `code` set is frozen for backward compatibility (consumers
+// branch on it), so new distinctions are expressed as an additive `reason`
+// instead of new top-level codes.
+export type ApiV1ErrorReason = "trip_limit_reached";
+
+export type ApiV1ErrorOptions = {
+  reason?: ApiV1ErrorReason;
+  details?: unknown;
+};
+
 export class ApiV1Error extends Error {
+  readonly reason?: ApiV1ErrorReason;
+  readonly details?: unknown;
+
   constructor(
     public readonly status: ContentfulStatusCode,
     public readonly code: ApiV1ErrorCode,
     message: string,
+    options?: ApiV1ErrorOptions,
   ) {
     super(message);
     this.name = "ApiV1Error";
+    this.reason = options?.reason;
+    this.details = options?.details;
   }
 }
 
-export function apiV1ErrorBody(code: ApiV1ErrorCode, message: string) {
-  return { error: { code, message } };
+export type ApiV1ErrorBody = {
+  error: {
+    code: ApiV1ErrorCode;
+    message: string;
+    reason?: ApiV1ErrorReason;
+    details?: unknown;
+  };
+};
+
+export function apiV1ErrorBody(
+  code: ApiV1ErrorCode,
+  message: string,
+  options?: ApiV1ErrorOptions,
+): ApiV1ErrorBody {
+  const body: ApiV1ErrorBody = { error: { code, message } };
+  if (options?.reason !== undefined) body.error.reason = options.reason;
+  if (options?.details !== undefined) body.error.details = options.details;
+  return body;
 }
 
 // Isolated error handler for v1App. Must not inherit or delegate to the global
@@ -53,7 +86,10 @@ export function apiV1ErrorBody(code: ApiV1ErrorCode, message: string) {
 // strings are never exposed to external callers.
 export const v1ErrorHandler: ErrorHandler<V1Env> = (err, c) => {
   if (err instanceof ApiV1Error) {
-    return c.json(apiV1ErrorBody(err.code, err.message), err.status);
+    return c.json(
+      apiV1ErrorBody(err.code, err.message, { reason: err.reason, details: err.details }),
+      err.status,
+    );
   }
   // All other exceptions — DB errors, unexpected throws, etc. — are collapsed
   // to 500 internal_error with no detail leak.

--- a/apps/api/src/lib/external-api/errors.ts
+++ b/apps/api/src/lib/external-api/errors.ts
@@ -41,6 +41,9 @@ export type ApiV1ErrorReason = "trip_limit_reached";
 
 export type ApiV1ErrorOptions = {
   reason?: ApiV1ErrorReason;
+  // Serialized verbatim into the public error response by v1ErrorHandler —
+  // must contain only externally safe values (no internal ids, constraint
+  // names, or other infrastructure detail).
   details?: unknown;
 };
 

--- a/apps/api/src/routes/v1/openapi-schemas.ts
+++ b/apps/api/src/routes/v1/openapi-schemas.ts
@@ -15,11 +15,16 @@ export const paginationSchema = z.object({
   total: z.number().int(),
 });
 
-// All v1 error responses share this shape: { error: { code, message } }
+// All v1 error responses share this shape: { error: { code, message } }.
+// `reason` (fine-grained machine-readable code, e.g. "trip_limit_reached") and
+// `details` (structured data such as { max }) are additive and optional so the
+// frozen top-level `code` set stays backward compatible.
 export const errorResponseSchema = z.object({
   error: z.object({
     code: z.string(),
     message: z.string(),
+    reason: z.string().optional(),
+    details: z.unknown().optional(),
   }),
 });
 

--- a/apps/api/src/routes/v1/trips-write.ts
+++ b/apps/api/src/routes/v1/trips-write.ts
@@ -45,7 +45,7 @@ tripsWriteApp.post(
     tags: ["Trips"],
     summary: "Create a trip",
     description:
-      "Creates a trip with the API key owner as the owner member. Returns 409 when the user has reached their trip limit. Supply startDate and endDate as YYYY-MM-DD strings. Requires `trips:write` scope.",
+      'Creates a trip with the API key owner as the owner member. Returns 409 with `error.reason: "trip_limit_reached"` and `error.details.max` (the effective per-user limit) when the user has reached their trip limit. Supply startDate and endDate as YYYY-MM-DD strings. Requires `trips:write` scope.',
     security: [{ bearerAuth: [] }],
     requestBody: {
       required: true,
@@ -76,7 +76,8 @@ tripsWriteApp.post(
         content: { "application/json": { schema: resolver(errorResponseSchema) } },
       },
       409: {
-        description: "Trip limit reached",
+        description:
+          "Trip limit reached (error.reason: trip_limit_reached, error.details.max: effective per-user limit)",
         content: { "application/json": { schema: resolver(errorResponseSchema) } },
       },
     },
@@ -102,7 +103,12 @@ tripsWriteApp.post(
 
       const limit = await resolveTripLimit(tx, userId);
       if (tripCountRow.count >= limit) {
-        return null;
+        // Thrown inside the transaction (nothing written yet) so the per-user
+        // limit resolved here can travel to the response as details.max.
+        throw new ApiV1Error(409, "conflict", "Trip limit reached for this account", {
+          reason: "trip_limit_reached",
+          details: { max: limit },
+        });
       }
 
       const [created] = await tx
@@ -128,10 +134,6 @@ tripsWriteApp.post(
 
       return created;
     });
-
-    if (!trip) {
-      throw new ApiV1Error(409, "conflict", "Trip limit reached for this account");
-    }
 
     logActivity({
       tripId: trip.id,

--- a/apps/mcp/src/__tests__/client.test.ts
+++ b/apps/mcp/src/__tests__/client.test.ts
@@ -180,6 +180,63 @@ describe("ApiClient", () => {
       expect(errorMessage).toContain("競合");
     });
 
+    it("includes the trip limit value when reason is trip_limit_reached", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(
+        makeResponse(
+          {
+            error: {
+              code: "conflict",
+              reason: "trip_limit_reached",
+              message: "Trip limit reached for this account",
+              details: { max: 10 },
+            },
+          },
+          409,
+        ),
+      );
+
+      // Act
+      let errorMessage = "";
+      try {
+        await client.createTrip({
+          title: "Test",
+          startDate: "2025-01-01",
+          endDate: "2025-01-03",
+        });
+      } catch (err) {
+        errorMessage = err instanceof Error ? err.message : "";
+      }
+
+      // Assert
+      expect(errorMessage).toContain("10");
+    });
+
+    it("falls back to the generic conflict message when details.max is absent", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(
+        makeResponse(
+          { error: { code: "conflict", reason: "trip_limit_reached", message: "limit" } },
+          409,
+        ),
+      );
+
+      // Act
+      let errorMessage = "";
+      try {
+        await client.createTrip({
+          title: "Test",
+          startDate: "2025-01-01",
+          endDate: "2025-01-03",
+        });
+      } catch (err) {
+        errorMessage = err instanceof Error ? err.message : "";
+      }
+
+      // Assert
+      expect(errorMessage).toContain("競合");
+    });
+
     it("maps 429 rate_limited to Japanese message", async () => {
       // Arrange
       mockFetch.mockResolvedValue(

--- a/apps/mcp/src/client.ts
+++ b/apps/mcp/src/client.ts
@@ -1,12 +1,18 @@
 import { z } from "zod";
 
-// Error response schema from the v1 API
+// Error response schema from the v1 API.
+// `reason` and `details` are additive fields carried alongside the frozen
+// top-level code set (e.g. reason "trip_limit_reached" with details.max).
 const v1ErrorBodySchema = z.object({
   error: z.object({
     code: z.string(),
     message: z.string(),
+    reason: z.string().optional(),
+    details: z.unknown().optional(),
   }),
 });
+
+const limitDetailsSchema = z.object({ max: z.number() });
 
 type V1ErrorCode =
   | "unauthorized"
@@ -48,7 +54,13 @@ async function buildApiError(response: Response): Promise<Error> {
   }
   const parsed = v1ErrorBodySchema.safeParse(body);
   if (parsed.success) {
-    const code = parsed.data.error.code;
+    const { code, reason, details } = parsed.data.error;
+    if (reason === "trip_limit_reached") {
+      const limit = limitDetailsSchema.safeParse(details);
+      if (limit.success) {
+        return new Error(`旅行の作成上限（${limit.data.max}件）に達しました`);
+      }
+    }
     const message = isV1ErrorCode(code)
       ? ERROR_MESSAGES[code]
       : `Server error (${response.status})`;

--- a/docs/architecture/external-api.md
+++ b/docs/architecture/external-api.md
@@ -106,7 +106,7 @@ Web UI は設定画面の「API キー」タブ（`apps/web/components/api-keys-
 ## エラーモデル
 
 ```json
-{ "error": { "code": "...", "message": "..." } }
+{ "error": { "code": "...", "message": "...", "reason": "...", "details": { } } }
 ```
 
 | HTTP | code | 用途 |
@@ -118,6 +118,12 @@ Web UI は設定画面の「API キー」タブ（`apps/web/components/api-keys-
 | 409 | `conflict` | 現在の状態と矛盾する書き込み（旅行数上限・費用がある旅行の通貨変更・日程未確定の旅行への予定追加等） |
 | 429 | `rate_limited` | レート超過 |
 | 500 | `internal_error` | 詳細は返さない |
+
+`code` の集合は後方互換のため凍結し、エラー種別の細分化は optional な `reason`（機械可読な細分化コード）と `details`（構造化データ）の追加で表現する。現在の `reason`:
+
+| reason | 付随する code | details |
+|---|---|---|
+| `trip_limit_reached` | `conflict` (409) | `{ "max": <ユーザー毎の旅行数上限の実値> }` |
 
 v1 は独立した `onError` を持ち、グローバルの `handleError`（内部エラー形・日本語メッセージ）を継承しない。
 

--- a/docs/architecture/external-api.md
+++ b/docs/architecture/external-api.md
@@ -119,7 +119,7 @@ Web UI は設定画面の「API キー」タブ（`apps/web/components/api-keys-
 | 429 | `rate_limited` | レート超過 |
 | 500 | `internal_error` | 詳細は返さない |
 
-`code` の集合は後方互換のため凍結し、エラー種別の細分化は optional な `reason`（機械可読な細分化コード）と `details`（構造化データ）の追加で表現する。現在の `reason`:
+`reason` と `details` は省略可能（該当しないエラーでは key 自体が含まれない）。`code` の集合は後方互換のため凍結し、エラー種別の細分化は optional な `reason`（機械可読な細分化コード）と `details`（構造化データ）の追加で表現する。現在の `reason`:
 
 | reason | 付随する code | details |
 |---|---|---|


### PR DESCRIPTION
## Summary

- 公開 v1 API の trip 作成上限エラー(409)に、細分化コード `error.reason: "trip_limit_reached"` と per-user 上限実値 `error.details: { max }` を追加した(#150 / PR #156 の内部 API 標準化の積み残し)
- トップレベル `error.code` は `"conflict"` のまま凍結し、`reason` / `details` は optional な追加フィールドとして導入(code で分岐する既存消費者に対して後方互換)
- `ApiV1Error` に optional な `reason` / `details` を持たせる汎用的な仕組みとして実装し、適用は Issue スコープの LIMIT_TRIPS 分岐のみ
- 上限値をレスポンスへ伝搬するため、上限分岐をトランザクション内 throw に変更(内部ルート `routes/trips.ts` と同型。書き込み前なので rollback の実害なし)
- MCP クライアントは `reason` + `details.max` を解釈し、上限値入りメッセージ「旅行の作成上限(N件)に達しました」を表示する
- OpenAPI スキーマ(`errorResponseSchema`)と `docs/architecture/external-api.md` のエラーモデル節を追従

## Backward compatibility

- 既存の `error.code === "conflict"` アサーションのテストは無変更で green を維持
- MCP の Zod パースは未知キーを strip するため、旧クライアントは新フィールドの影響を受けない

## Test plan

- [x] `apps/api/src/__tests__/v1-write-routes.test.ts`: 409 body に `reason` / `details.max` が含まれる(新規)、既存の `code: "conflict"` テスト維持
- [x] `apps/mcp/src/__tests__/client.test.ts`: `trip_limit_reached` + `details.max` で上限値入りメッセージ、`details.max` 欠落時は従来の conflict メッセージにフォールバック(新規)
- [x] `bun run check` / `bun run check-types` / `bun run test` 全パッケージ green

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)