### PR TITLE
fix: get-sessionを広域レート制限(30/分)から分離し専用の300回/分を割り当てる

### DIFF
--- a/apps/api/src/__tests__/auth-rate-limit.test.ts
+++ b/apps/api/src/__tests__/auth-rate-limit.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/redis", () => ({
+  getRedis: vi.fn(() => null),
+}));
+
+vi.mock("../lib/auth", () => ({
+  auth: {
+    handler: vi.fn(() => new Response(JSON.stringify({ session: null }), { status: 200 })),
+  },
+}));
+
+vi.mock("../lib/app-settings", () => ({
+  getAppSettings: vi.fn(() => Promise.resolve({ signupEnabled: true })),
+}));
+
+const { authRoutes } = await import("../routes/auth");
+
+// The in-memory rate-limit store is keyed by "window:max" and shared across
+// tests in this file, so each test uses a distinct IP to stay isolated.
+async function request(path: string, ip: string): Promise<Response> {
+  return authRoutes.request(path, { headers: { "x-real-ip": ip } });
+}
+
+describe("auth route rate limits", () => {
+  it("does not block get-session at the broad 30/min ceiling", async () => {
+    const ip = "10.0.0.1";
+    for (let i = 0; i < 31; i++) {
+      await request("/api/auth/get-session", ip);
+    }
+    const res = await request("/api/auth/get-session", ip);
+
+    expect(res.status).toBe(200);
+  });
+
+  it("caps get-session at its dedicated 300/min ceiling", async () => {
+    const ip = "10.0.0.2";
+    // 300 requests fill the bucket exactly (count == max); the 301st exceeds it.
+    for (let i = 0; i < 300; i++) {
+      await request("/api/auth/get-session", ip);
+    }
+    const res = await request("/api/auth/get-session", ip);
+
+    expect(res.status).toBe(429);
+  });
+
+  it("does not count get-session against the broad auth bucket", async () => {
+    const ip = "10.0.0.3";
+    for (let i = 0; i < 30; i++) {
+      await request("/api/auth/get-session", ip);
+    }
+    const res = await request("/api/auth/list-sessions", ip);
+
+    expect(res.status).toBe(200);
+  });
+
+  it("still applies the broad 30/min ceiling to other auth paths", async () => {
+    const ip = "10.0.0.4";
+    for (let i = 0; i < 30; i++) {
+      await request("/api/auth/list-sessions", ip);
+    }
+    const res = await request("/api/auth/list-sessions", ip);
+
+    expect(res.status).toBe(429);
+  });
+});

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -12,14 +12,27 @@ const authRoutes = new Hono();
 // order, so a request to /api/auth/sign-in/anonymous consumes all three
 // matching counters (max:3, max:5, max:30). When tuning these values, treat
 // the broader buckets (max:30) as a global ceiling for the whole auth surface
-// rather than as an additional allowance.
+// rather than as an additional allowance. get-session is the one exception:
+// it has its own dedicated bucket and is excluded from the broad ceiling (see
+// below).
 authRoutes.use("/api/auth/sign-in/anonymous", rateLimitByIp({ window: 60, max: 3 }));
 authRoutes.use("/api/auth/sign-up/*", rateLimitByIp({ window: 60, max: 3 }));
 authRoutes.use("/api/auth/change-password", rateLimitByIp({ window: 60, max: 3 }));
 authRoutes.use("/api/auth/sign-in/*", rateLimitByIp({ window: 60, max: 5 }));
-// The broad ceiling counts every session check a full page load makes (proxy
-// guard + client bootstrap). E2E suites drive far more full page loads per
-// IP-minute than real browsing, so they may raise it explicitly via env;
+// get-session is a side-effect-free read that fires multiple times per page
+// load (proxy guard + client bootstrap), so its cost model is nothing like the
+// write-path endpoints above. Counting it against the broad 30/min ceiling
+// capped legitimate browsing at ~15 page loads per IP-minute, which 429s users
+// behind shared egress IPs (offices, schools, mobile CGNAT). It gets its own
+// high ceiling instead — same order of magnitude as the v1 API read limit (#161).
+const GET_SESSION_PATH = "/api/auth/get-session";
+// Hono's use() with a literal path matches that exact path only (no prefix /
+// trailing-slash matching), which keeps it consistent with the strict-equality
+// guard in the broad middleware below. Keep both in sync if this ever changes.
+authRoutes.use(GET_SESSION_PATH, rateLimitByIp({ window: 60, max: 300 }));
+// The broad ceiling covers every other auth operation. E2E suites drive far
+// more sign-ups/sign-ins per IP-minute than real browsing (one fresh account
+// per test from a single runner IP), so they may raise it explicitly via env;
 // production never sets this and keeps the default of 30. Only positive
 // integers are honored (a stray "-5" or "0" must not zero out the auth
 // surface). No NODE_ENV gate: CI runs the e2e suite against a production
@@ -28,7 +41,13 @@ function resolveBroadAuthLimit(): number {
   const parsed = Number(process.env.E2E_AUTH_RATE_LIMIT_MAX);
   return Number.isInteger(parsed) && parsed > 0 ? parsed : 30;
 }
-authRoutes.use("/api/auth/*", rateLimitByIp({ window: 60, max: resolveBroadAuthLimit() }));
+const broadAuthRateLimit = rateLimitByIp({ window: 60, max: resolveBroadAuthLimit() });
+authRoutes.use("/api/auth/*", (c, next) => {
+  // get-session is governed solely by its dedicated bucket above; letting it
+  // also drain the broad bucket would starve sign-in/sign-up for the same IP.
+  if (c.req.path === GET_SESSION_PATH) return next();
+  return broadAuthRateLimit(c, next);
+});
 
 // Block email/password signup when the admin has disabled new registrations.
 // Anonymous sign-in (/api/auth/sign-in/anonymous) is intentionally not blocked

--- a/apps/web/e2e/shared-trip.spec.ts
+++ b/apps/web/e2e/shared-trip.spec.ts
@@ -82,7 +82,7 @@ test.describe("Shared Trip", () => {
   }) => {
     // Create the member user.
     // Assign a unique synthetic IP so the proxy's session check requests
-    // (to /api/auth/get-session, rate-limited 30/min per IP) don't collapse to
+    // (to /api/auth/get-session, rate-limited 300/min per IP) don't collapse to
     // "unknown" and trigger redirect loops that land the member at /home instead
     // of the requested page.
     const memberContext = await browser.newContext({

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -120,7 +120,11 @@ export async function proxy(request: NextRequest) {
     // Forward the caller's identity headers alongside the cookie: the session
     // check is rate-limited per IP (apps/api/src/middleware/rate-limit.ts), and
     // without these every proxy-originated request collapses into one shared
-    // bucket — throttling all users behind a single 30/min ceiling.
+    // bucket — throttling all users behind get-session's single per-IP ceiling
+    // (apps/api/src/routes/auth.ts). Whether Vercel's edge preserves these
+    // headers on re-entry in production is unverified (#161 M-1); even if it
+    // does not, get-session's dedicated 300/min bucket keeps the shared-bucket
+    // failure mode far less likely than under the old 30/min broad ceiling.
     const sessionHeaders: Record<string, string> = { cookie: cookieHeader };
     const realIp = request.headers.get("x-real-ip");
     if (realIp) sessionHeaders["x-real-ip"] = realIp;


### PR DESCRIPTION
## Summary
- `/api/auth/get-session` を広域 `/api/auth/*` レート制限(30回/分/IP)から分離し、専用の 300回/分/IP を割り当てた
- 共有 IP 環境(オフィス・学校・モバイル CGNAT)で正規ユーザーがページロードだけで 429 → ログイン画面に飛ばされる構造的な可用性リスク(#161 M-2)を解消する
- 副次効果として、広域バケットが sign-in / sign-up 等の保護専用になり、get-session がそれらの枠を食い潰さなくなる

## Why
- get-session は副作用なしの読み取りで、1 ページロードあたり複数回(proxy 認証ガード + クライアント bootstrap)発火する。サインイン(5/分)・サインアップ(3/分)とはコストモデルが桁違いなのに、同じ広域 30回/分 の天井に入っていたため、1 IP あたり実質 ~15 ページロード/分 が上限だった
- 専用上限 300回/分 は、既存の v1 API read 上限(`apps/api/src/routes/v1/index.ts` の 300/min)と同水準に揃えた
- 分離方式は「広域ミドルウェアが get-session をスキップ + 専用バケットを新設」とした。Hono は登録順に一致する全ミドルウェアを実行するため、スキップしないと両方のバケットを消費してしまう
- Hono の `use()`(literal path)は exact match のみで、trailing slash / subpath は広域側にフォールバックする(より厳しい側に倒れる)。両制限をすり抜ける経路がないことは code-reviewer の実地検証で確認済み

## Changes
- `apps/api/src/routes/auth.ts`: get-session 専用バケット(60s / 300)を新設し、広域バケット(60s / 30、E2E は env で可変)は get-session をスキップ
- `apps/api/src/__tests__/auth-rate-limit.test.ts`: 分離挙動の単体テスト 4 件を新規追加(TDD、Red → Green)
- `apps/web/proxy.ts` / `apps/web/e2e/shared-trip.spec.ts`: 旧 30/分 前提のコメントを実態に更新(挙動変更なし)

## Test plan
- [x] 新規テスト: get-session が広域 30/分 でブロックされない / 専用 300/分 で 429 になる / 広域バケットを消費しない / 他の auth パスには広域 30/分 が引き続き効く
- [x] `bun run --filter @sugara/api test` 858 件 green(回帰なし)
- [x] `bun run check` / `bun run check-types` green
- [x] E2E 整合: CI の `E2E_AUTH_RATE_LIMIT_MAX=120` は広域側にのみ作用。従来は get-session 込みで 120/分 に収まっていたため、専用 300/分 は十分な余裕がある

## Notes for reviewer
- 429 の判定は `count > max` なので、専用バケットはちょうど 300 回目まで通り 301 回目で 429 になる(テストのループ数はこれを前提)
- `use()` の exact match と広域側の strict equality ガードが対になっている設計のため、将来 get-session 側を wildcard 化する場合は両方を揃える必要がある(コードコメントに明記済み)
- #161 の M-1(本番での proxy → get-session 内部 fetch における x-real-ip 伝搬の実測、必要ならエッジ再入回避)は本 PR のスコープ外。ただし本 PR により、仮に IP 伝搬が no-op でも共有バケットの天井が 30 → 300/分 になるため顕在化リスクは大幅に低下する

## Related
- #161(M-2 対応。M-1 が残るため Issue は閉じない)
- 関連 PR: #160(x-real-ip 転送・E2E knob の導入元)

🤖 Generated with [Claude Code](https://claude.com/claude-code)