### PR TITLE
fix: proxyのセッション確認を fail-open 化し429起因の誤ログアウトを解消 (#162)

### DIFF
--- a/apps/web/e2e/delete-account.spec.ts
+++ b/apps/web/e2e/delete-account.spec.ts
@@ -214,14 +214,6 @@ test.describe("Delete Account", () => {
     });
     expect(inBrowserStatus, "pageB session must be valid (in-browser fetch)").toBe(200);
 
-    // Verify via API that pageB's data is intact after User A's deletion.
-    // Navigating to /home would trigger the proxy middleware (proxy.ts) which
-    // calls /api/auth/get-session server-side; this intermittently redirects to
-    // /auth/login even when the session is valid — reproduced after the PR #160
-    // rate-limit fix, root cause tracked in issue #162 (restore the UI-based
-    // assertion once resolved). The diagnostic checks above already confirm the
-    // session is intact, so API calls cover the data-state assertions for now.
-
     // A's trip should be gone (CASCADE deleted with user A's account)
     const aTripResp = await pageB.request.get(`/api/trips/${aTripId}`);
     expect(aTripResp.status(), "A's trip should be gone after account deletion (CASCADE)").toBe(404);
@@ -237,6 +229,19 @@ test.describe("Delete Account", () => {
     const hasUserA =
       Array.isArray(members) && members.some((m: { userId: string }) => m.userId === userAId);
     expect(hasUserA, "User A should not be in B's trip member list after deletion").toBe(false);
+
+    // UI verification, restored per issue #162: the historical flake here was
+    // the proxy treating a rate-limited (429) get-session as "unauthenticated"
+    // and bouncing valid sessions to /auth/login. Fixed by the dedicated
+    // get-session rate limit (#163) and the proxy failing open on non-OK
+    // session checks instead of redirecting.
+    await clearIdbCache(pageB);
+    await pageB.goto("/home");
+    await expect(pageB).toHaveURL(/\/home/);
+    await expect(pageB.getByRole("link", { name: /B's Trip/ }).first()).toBeVisible({
+      timeout: 15000,
+    });
+    await expect(pageB.getByRole("link", { name: /A's Trip/ })).not.toBeVisible();
 
     await contextB.close();
   });

--- a/apps/web/lib/__tests__/proxy.test.ts
+++ b/apps/web/lib/__tests__/proxy.test.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from "next/server";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { proxy } from "../../proxy";
 
 function makeRequest(pathname: string, opts: { viewMode?: string; ua?: string } = {}): NextRequest {
@@ -28,14 +28,15 @@ describe("proxy — SP redirect", () => {
   it("does NOT redirect /trips/[id]/print to SP in SP mode", async () => {
     const req = makeRequest("/trips/abc123/print", { viewMode: "sp" });
     const res = await proxy(req);
-    // Should pass through (no SP redirect), may redirect to /auth/login due to no session
-    expect(res?.headers.get("location")).not.toContain("/sp/");
+    // No SP redirect; the auth guard outcome (redirect or fail-open pass) is
+    // covered by the auth guard suite below, so only assert the SP part here.
+    expect(res?.headers.get("location") ?? "").not.toContain("/sp/");
   });
 
   it("does NOT redirect /trips/[id]/export to SP in SP mode", async () => {
     const req = makeRequest("/trips/abc123/export", { viewMode: "sp" });
     const res = await proxy(req);
-    expect(res?.headers.get("location")).not.toContain("/sp/");
+    expect(res?.headers.get("location") ?? "").not.toContain("/sp/");
   });
 
   it("redirects mobile UA with no cookie to SP for /trips", async () => {
@@ -48,13 +49,13 @@ describe("proxy — SP redirect", () => {
   it("does NOT redirect mobile UA to SP for /trips/[id]/print", async () => {
     const req = makeRequest("/trips/abc123/print", { ua: MOBILE_UA });
     const res = await proxy(req);
-    expect(res?.headers.get("location")).not.toContain("/sp/");
+    expect(res?.headers.get("location") ?? "").not.toContain("/sp/");
   });
 
   it("does NOT redirect mobile UA to SP for /trips/[id]/export", async () => {
     const req = makeRequest("/trips/abc123/export", { ua: MOBILE_UA });
     const res = await proxy(req);
-    expect(res?.headers.get("location")).not.toContain("/sp/");
+    expect(res?.headers.get("location") ?? "").not.toContain("/sp/");
   });
 });
 
@@ -107,6 +108,100 @@ describe("proxy — SP-only route fallback", () => {
     const res = await proxy(req);
     expect(res?.status).toBe(307);
     expect(res?.headers.get("location")).toContain("/trips/abc");
+  });
+});
+
+describe("proxy — auth guard session check", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function stubGetSession(handler: () => Promise<Response>) {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        if (String(input).includes("/api/auth/get-session")) return handler();
+        return Promise.reject(new Error(`unexpected fetch: ${input}`));
+      }),
+    );
+  }
+
+  it("redirects a protected path to login when get-session returns 200 with null", async () => {
+    stubGetSession(() => Promise.resolve(new Response("null", { status: 200 })));
+    const res = await proxy(makeRequest("/home"));
+
+    expect(res?.headers.get("location")).toContain("/auth/login");
+  });
+
+  it("passes a protected path through when get-session returns a session", async () => {
+    stubGetSession(() =>
+      Promise.resolve(new Response(JSON.stringify({ session: { id: "s1" } }), { status: 200 })),
+    );
+    const res = await proxy(makeRequest("/home"));
+
+    expect(res?.headers.get("location")).toBeNull();
+  });
+
+  it("fails open on a protected path when get-session is rate-limited (429)", async () => {
+    // A 429 (or any non-OK) proves nothing about the visitor's session; bouncing
+    // to /auth/login here logged out legitimately authenticated users (#162).
+    stubGetSession(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ error: "Too many requests" }), { status: 429 }),
+      ),
+    );
+    const res = await proxy(makeRequest("/home"));
+
+    expect(res?.headers.get("location")).toBeNull();
+  });
+
+  it("fails open on a protected path when get-session returns a 5xx", async () => {
+    stubGetSession(() => Promise.resolve(new Response("oops", { status: 503 })));
+    const res = await proxy(makeRequest("/home"));
+
+    expect(res?.headers.get("location")).toBeNull();
+  });
+
+  it("fails open on a protected path when the get-session fetch throws", async () => {
+    stubGetSession(() => Promise.reject(new TypeError("fetch failed")));
+    const res = await proxy(makeRequest("/home"));
+
+    expect(res?.headers.get("location")).toBeNull();
+  });
+
+  it("fails open on a protected path when get-session returns 200 with a non-JSON body", async () => {
+    // res.json() throws → caught by the same fail-open catch as network errors.
+    stubGetSession(() => Promise.resolve(new Response("<!DOCTYPE html>", { status: 200 })));
+    const res = await proxy(makeRequest("/home"));
+
+    expect(res?.headers.get("location")).toBeNull();
+  });
+
+  it("still sets CSP headers on a fail-open pass-through", async () => {
+    stubGetSession(() => Promise.resolve(new Response("oops", { status: 503 })));
+    const res = await proxy(makeRequest("/home"));
+
+    expect(res?.headers.get("Content-Security-Policy")).toBeTruthy();
+  });
+
+  it("redirects a guest-only path to home when authenticated", async () => {
+    stubGetSession(() =>
+      Promise.resolve(new Response(JSON.stringify({ session: { id: "s1" } }), { status: 200 })),
+    );
+    const res = await proxy(makeRequest("/auth/login"));
+
+    expect(res?.headers.get("location")).toContain("/home");
+  });
+
+  it("renders a guest-only path when get-session is rate-limited (429)", async () => {
+    stubGetSession(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ error: "Too many requests" }), { status: 429 }),
+      ),
+    );
+    const res = await proxy(makeRequest("/auth/login"));
+
+    expect(res?.headers.get("location")).toBeNull();
   });
 });
 

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -106,11 +106,15 @@ export async function proxy(request: NextRequest) {
     !isPublicArticlePath && protectedPaths.some((path) => pathname.startsWith(path));
   const isGuestOnly = guestOnlyPaths.includes(pathname);
 
-  if (!isProtected && !isGuestOnly) {
+  const passThrough = () => {
     const requestHeaders = new Headers(request.headers);
     requestHeaders.set("x-nonce", nonce);
     const response = NextResponse.next({ request: { headers: requestHeaders } });
     return applyCspHeaders(response, nonce);
+  };
+
+  if (!isProtected && !isGuestOnly) {
+    return passThrough();
   }
 
   const cookieHeader = request.headers.get("cookie") ?? "";
@@ -135,7 +139,22 @@ export async function proxy(request: NextRequest) {
       headers: sessionHeaders,
     });
 
-    const body = res.ok ? await res.json() : null;
+    // Only a 200 response is evidence about the session: get-session returns
+    // 200 with a null body for unauthenticated visitors. A non-OK response
+    // (429 rate limit, 5xx) proves nothing about the visitor, so fail open —
+    // treating it as "logged out" bounced legitimately authenticated users to
+    // /auth/login whenever the per-IP rate limit tripped (issue #162). Auth is
+    // actually enforced by requireAuth on every API route; the worst case of
+    // failing open is an anonymous visitor seeing an empty page shell whose
+    // API calls all return 401.
+    if (!res.ok) {
+      console.error(
+        `[Proxy] Session check unavailable (${pathname}, status ${res.status}); failing open`,
+      );
+      return passThrough();
+    }
+
+    const body = await res.json();
     const isAuthenticated = !!body?.session;
 
     if (isProtected && !isAuthenticated) {
@@ -146,21 +165,12 @@ export async function proxy(request: NextRequest) {
       return NextResponse.redirect(new URL("/home", request.url));
     }
 
-    const requestHeaders = new Headers(request.headers);
-    requestHeaders.set("x-nonce", nonce);
-    const response = NextResponse.next({ request: { headers: requestHeaders } });
-    return applyCspHeaders(response, nonce);
+    return passThrough();
   } catch (err) {
-    console.error("[Proxy] Session check failed:", err);
-    // Treat session check failure as unauthenticated for all routes that require auth.
-    // This includes both explicitly protected paths and any other path in the matcher.
-    if (isGuestOnly) {
-      const requestHeaders = new Headers(request.headers);
-      requestHeaders.set("x-nonce", nonce);
-      const response = NextResponse.next({ request: { headers: requestHeaders } });
-      return applyCspHeaders(response, nonce);
-    }
-    return NextResponse.redirect(new URL("/auth/login", request.url));
+    // Same reasoning as the non-OK branch: a network failure on the internal
+    // get-session fetch says nothing about the visitor's session.
+    console.error(`[Proxy] Session check failed (${pathname}); failing open:`, err);
+    return passThrough();
   }
 }
 


### PR DESCRIPTION
## Summary
- Issue #162(断続的な get-session null)の根本原因を**実証ベースで特定**: get-session の 429(レート制限)を proxy が「未認証」と誤解釈し、有効なセッションのユーザーを `/auth/login` に誤リダイレクトしていた
- proxy の認証ガードを「200 + null ボディのみを未認証の証拠」とし、429 / 5xx / ネットワークエラーは fail-open(pass-through)に変更
- Issue のチェック項目だった delete-account.spec.ts の UI ベース最終検証を復元

## Why — 根本原因の特定過程
- 合成リクエストでの再現試行(高頻度 1,800 req・アイドル間隔バースト・削除直後パターン 360 req)はすべて再現せず、better-auth 1.6.15 ソース精査の cookieCache 署名失敗説も「API 直叩き(requireAuth、同じ getSession)は成功していた」という観測と矛盾するため棄却
- 観測時の構成(get-session が広域 30回/分 バケット内・ローカルは E2E knob 未設定)では、ページロード多発テストが 1 分あたり 30+ の auth ヒットを発生させ 429 に到達。`/api/trips` 直叩きは auth バケットを消費しないため「API は 200 なのにナビゲーションだけ落ちる」という #162 の謎が完全に説明できる
- **決定的再現**: get-session 専用上限を一時的に 30 に下げ、計装した proxy で再現 spec を実行 → ナビゲーションが `/auth/login` に飛び、計装ログに `status: 429, cookieNames: [session_token, session_data]` を記録。上限 300(#163)では 19 回連続 green
- 「断続的」だった理由: 60 秒ウィンドウのタイミング依存 + dev サーバーのモジュール再評価が in-memory カウンタをリセットするため
- PR #163(get-session 専用 300回/分)が主要因を既に解消済み。本 PR は残る構造的欠陥「transient 失敗 = 未認証という誤同一視」を塞ぐ

## Changes
- `apps/web/proxy.ts`: 非 2xx とネットワークエラーを fail-open に変更。CSP nonce 付与を `passThrough` ヘルパーに集約し全経路で保証。失敗ログに pathname を追加
- `apps/web/lib/__tests__/proxy.test.ts`: 認証ガードのテストスイートを新設(200+null → リダイレクト / 200+session → 通過 / 429・5xx・throw・非JSON → fail-open / guestOnly 系)。旧テストの「fetch 失敗 → リダイレクト」への偶然依存を解消
- `apps/web/e2e/delete-account.spec.ts`: UI ベースの最終検証(`/home` で B の旅行が見え A の旅行が消えている)を復元し、古い flake 注記を撤去

## セキュリティ評価(security-auditor 監査済み)
- fail-open の最悪ケースは「匿名訪問者が空のページシェルを見る」に限定。保護ページは全て `"use client"` でデータは requireAuth 付き API 経由、SSR でのデータ埋め込みなし(裏取り済み)
- レート制限キーは偽装不能な x-real-ip ベースのため、攻撃者が他者の fail-open を誘発してもデータ露出には繋がらない
- 判定: Critical/High ゼロ、リリース可

## Test plan
- [x] proxy 単体テスト 9 件追加(うち fail-open 系 4 件は TDD で Red → Green を確認)
- [x] delete-account.spec.ts(UI 検証復元込み)×2 周 = 6/6 pass をローカルで確認
- [x] `bun run check` / `bun run check-types` / 全パッケージ unit テスト green(web 799 / api 858 / shared 248 / mcp 95)
- [x] 一時計装・一時実験ファイルはすべて除去済み(working tree は本変更 3 ファイルのみ)

## Notes for reviewer
- guestOnly ページの transient 失敗時挙動は実質不変(旧コードも catch 時は素通し)。失われるのは「429 時に認証済みユーザーをログイン画面から /home へ追い出す」UX のみ
- 監査で見つかった既存の別件(admin ページの Server Component が `/api/admin/stats` の 429 を `notFound()` にしない)はスコープ外として Issue #162 のクローズコメントに記録予定

## Related
- Closes #162
- 関連: #161 / PR #163(get-session 専用レート制限)、PR #160(flake の初観測)

🤖 Generated with [Claude Code](https://claude.com/claude-code)