### PR TITLE
fix: 宿泊継続アンカー付き予定の並び替えが反映されない問題を解消

### DIFF
--- a/apps/web/app/(authenticated)/trips/[id]/page.tsx
+++ b/apps/web/app/(authenticated)/trips/[id]/page.tsx
@@ -531,12 +531,13 @@ export default function TripDetailPage() {
   const { reactions, sendReaction, removeReaction, cooldown } = useReaction(channel, reactionUser);
 
   // Mutation callbacks: refetch + broadcast to other clients (see hook for
-  // why schedule adds skip the refetch, #123)
-  const { onMutate, onScheduleAdded } = useTripMutationCallbacks({
-    tripId,
-    invalidateTrip,
-    broadcastChange,
-  });
+  // why schedule adds and reorders skip the refetch, #123 / #166)
+  const { onMutate, onScheduleAdded, onSchedulesReordered, onCandidatesReordered } =
+    useTripMutationCallbacks({
+      tripId,
+      invalidateTrip,
+      broadcastChange,
+    });
 
   const handleSaveToBookmark = useCallback((scheduleIds: string[]) => {
     setSaveToBookmarkIds(scheduleIds);
@@ -618,6 +619,8 @@ export default function TripDetailPage() {
     candidates: dndCandidates,
     crossDayEntries: dndCrossDayEntries,
     onDone: onMutate,
+    onSchedulesReordered,
+    onCandidatesReordered,
   });
 
   const patternOps = usePatternOperations({

--- a/apps/web/app/(sp)/sp/trips/[id]/page.tsx
+++ b/apps/web/app/(sp)/sp/trips/[id]/page.tsx
@@ -162,12 +162,13 @@ export default function SpTripDetailPage() {
   const { reactions, sendReaction, removeReaction, cooldown } = useReaction(channel, reactionUser);
 
   // Mutation callbacks: refetch + broadcast to other clients (see hook for
-  // why schedule adds skip the refetch, #123)
-  const { onMutate, onScheduleAdded } = useTripMutationCallbacks({
-    tripId: tripId ?? "",
-    invalidateTrip,
-    broadcastChange,
-  });
+  // why schedule adds and reorders skip the refetch, #123 / #166)
+  const { onMutate, onScheduleAdded, onSchedulesReordered, onCandidatesReordered } =
+    useTripMutationCallbacks({
+      tripId: tripId ?? "",
+      invalidateTrip,
+      broadcastChange,
+    });
 
   const handleSaveToBookmark = useCallback((scheduleIds: string[]) => {
     setSaveToBookmarkIds(scheduleIds);
@@ -247,6 +248,8 @@ export default function SpTripDetailPage() {
     candidates: dndCandidates,
     crossDayEntries: dndCrossDayEntries,
     onDone: onMutate,
+    onSchedulesReordered,
+    onCandidatesReordered,
   });
 
   const patternOps = usePatternOperations({

--- a/apps/web/lib/__tests__/drop-position.test.ts
+++ b/apps/web/lib/__tests__/drop-position.test.ts
@@ -1,6 +1,8 @@
+import { arrayMove } from "@dnd-kit/sortable";
 import type { CrossDayEntry, ScheduleResponse } from "@sugara/shared";
 import { describe, expect, it } from "vitest";
 import {
+  applyOptimisticReorder,
   computeCandidateDropResult,
   computeCandidateInsertIndex,
   computeScheduleReorderIndex,
@@ -10,6 +12,7 @@ import {
   isOverUpperHalf,
   timelineEdge,
 } from "../drop-position";
+import { buildMergedTimeline } from "../merge-timeline";
 
 function makeSchedule(overrides: Partial<ScheduleResponse> = {}): ScheduleResponse {
   return {
@@ -620,5 +623,103 @@ describe("indicatorGapIndex", () => {
 
   it("returns null when overId is not in the list", () => {
     expect(indicatorGapIndex(ids, "missing", true)).toBeNull();
+  });
+});
+
+describe("applyOptimisticReorder", () => {
+  function anchoredAfterHotel(overrides: Partial<ScheduleResponse>): ScheduleResponse {
+    return makeSchedule({
+      crossDayAnchor: "after",
+      crossDayAnchorSourceId: "hotel-1",
+      ...overrides,
+    });
+  }
+
+  const keepAnchor = { anchor: "after" as const, anchorSourceId: "hotel-1" };
+
+  it("rewrites sortOrder to the array index for every schedule", () => {
+    const reordered = [
+      makeSchedule({ id: "s1", sortOrder: 2 }),
+      makeSchedule({ id: "s2", sortOrder: 0 }),
+      makeSchedule({ id: "s3", sortOrder: 1 }),
+    ];
+
+    const result = applyOptimisticReorder(reordered, "s1", {
+      anchor: null,
+      anchorSourceId: null,
+    });
+
+    expect(result.map((s) => s.sortOrder)).toEqual([0, 1, 2]);
+  });
+
+  it("writes the new anchor onto the active schedule", () => {
+    const reordered = [makeSchedule({ id: "s1" }), makeSchedule({ id: "s2" })];
+
+    const result = applyOptimisticReorder(reordered, "s2", keepAnchor);
+
+    expect(result[1]).toMatchObject({
+      crossDayAnchor: "after",
+      crossDayAnchorSourceId: "hotel-1",
+    });
+  });
+
+  it("clears the active schedule's anchor when the update is null", () => {
+    const reordered = [anchoredAfterHotel({ id: "s1" })];
+
+    const result = applyOptimisticReorder(reordered, "s1", {
+      anchor: null,
+      anchorSourceId: null,
+    });
+
+    expect(result[0]).toMatchObject({ crossDayAnchor: null, crossDayAnchorSourceId: null });
+  });
+
+  it("leaves other schedules' anchors untouched", () => {
+    const reordered = [
+      anchoredAfterHotel({ id: "s1", sortOrder: 1 }),
+      makeSchedule({ id: "s2", sortOrder: 0 }),
+    ];
+
+    const result = applyOptimisticReorder(reordered, "s2", {
+      anchor: null,
+      anchorSourceId: null,
+    });
+
+    expect(result[0]).toMatchObject({
+      crossDayAnchor: "after",
+      crossDayAnchorSourceId: "hotel-1",
+    });
+  });
+
+  it("does not mutate the input array or its schedules", () => {
+    const original = makeSchedule({ id: "s1", sortOrder: 5 });
+    const reordered = [original];
+
+    applyOptimisticReorder(reordered, "s1", keepAnchor);
+
+    expect(original.sortOrder).toBe(5);
+  });
+
+  it("makes a swap inside an anchored-after cluster visible in the merged timeline (issue #166)", () => {
+    // Day-2 layout from the report: breakfast, [staying hotel], two transit
+    // schedules anchored "after" the hotel. The cluster renders by sortOrder,
+    // so a bare arrayMove (array order changes, sortOrder values don't) is a
+    // visual no-op — the dragged card snaps straight back.
+    const schedules = [
+      makeSchedule({ id: "b", name: "朝食", sortOrder: 0, startTime: "07:00" }),
+      anchoredAfterHotel({ id: "t1", sortOrder: 1, startTime: "08:25" }),
+      anchoredAfterHotel({ id: "t2", sortOrder: 2, startTime: "08:36" }),
+    ];
+    const crossDayEntries = [
+      makeCrossDayEntry({ id: "hotel-1", startTime: "15:00", endTime: "10:00" }),
+    ];
+
+    // Drag t2 above t1 (destIndex 1, activeIdx 2), keeping the same anchor.
+    const optimistic = applyOptimisticReorder(arrayMove(schedules, 2, 1), "t2", keepAnchor);
+
+    const displayedIds = buildMergedTimeline(optimistic, crossDayEntries).map((item) =>
+      item.type === "crossDay" ? `cross-${item.entry.schedule.id}` : item.schedule.id,
+    );
+    expect(displayedIds).toEqual(["b", "cross-hotel-1", "t2", "t1"]);
   });
 });

--- a/apps/web/lib/__tests__/trip-cache.test.ts
+++ b/apps/web/lib/__tests__/trip-cache.test.ts
@@ -13,6 +13,8 @@ import {
   moveScheduleToCandidate,
   removeCandidate,
   removeScheduleFromPattern,
+  reorderCandidates,
+  reorderSchedulesInPattern,
   toCandidateResponse,
   toScheduleResponse,
   updateCandidate,
@@ -364,5 +366,144 @@ describe("moveCandidateToSchedule", () => {
 
     expect(result.days[0].patterns[0].schedules[0].sortOrder).toBe(42);
     expect(result.days[0].patterns[0].schedules[0].updatedAt).toBe("new");
+  });
+});
+
+describe("reorderSchedulesInPattern", () => {
+  function tripWithSchedules(schedules: ScheduleResponse[]): TripResponse {
+    return makeTrip({ days: [makeDay({ patterns: [makePattern({ schedules })] })] });
+  }
+
+  it("reorders schedules to the given id order with sortOrder rewritten", () => {
+    const trip = tripWithSchedules([
+      makeSchedule({ id: "s1", sortOrder: 0 }),
+      makeSchedule({ id: "s2", sortOrder: 1 }),
+      makeSchedule({ id: "s3", sortOrder: 2 }),
+    ]);
+
+    const result = reorderSchedulesInPattern(trip, "d1", "p1", ["s1", "s3", "s2"]);
+
+    expect(result.days[0].patterns[0].schedules.map((s) => [s.id, s.sortOrder])).toEqual([
+      ["s1", 0],
+      ["s3", 1],
+      ["s2", 2],
+    ]);
+  });
+
+  it("applies an anchor update to the targeted schedule", () => {
+    const trip = tripWithSchedules([makeSchedule({ id: "s1" })]);
+
+    const result = reorderSchedulesInPattern(
+      trip,
+      "d1",
+      "p1",
+      ["s1"],
+      [{ scheduleId: "s1", anchor: "after", anchorSourceId: "hotel-1" }],
+    );
+
+    expect(result.days[0].patterns[0].schedules[0]).toMatchObject({
+      crossDayAnchor: "after",
+      crossDayAnchorSourceId: "hotel-1",
+    });
+  });
+
+  it("clears the anchor when the update carries nulls", () => {
+    const trip = tripWithSchedules([
+      makeSchedule({ id: "s1", crossDayAnchor: "after", crossDayAnchorSourceId: "hotel-1" }),
+    ]);
+
+    const result = reorderSchedulesInPattern(
+      trip,
+      "d1",
+      "p1",
+      ["s1"],
+      [{ scheduleId: "s1", anchor: null, anchorSourceId: null }],
+    );
+
+    expect(result.days[0].patterns[0].schedules[0]).toMatchObject({
+      crossDayAnchor: null,
+      crossDayAnchorSourceId: null,
+    });
+  });
+
+  it("keeps schedules missing from scheduleIds, ordered by their existing sortOrder", () => {
+    // A concurrent add from another client may have put a schedule in the
+    // cache that the reordering client didn't know about; it must survive.
+    const trip = tripWithSchedules([
+      makeSchedule({ id: "s1", sortOrder: 0 }),
+      makeSchedule({ id: "unknown", sortOrder: 1 }),
+      makeSchedule({ id: "s2", sortOrder: 2 }),
+    ]);
+
+    const result = reorderSchedulesInPattern(trip, "d1", "p1", ["s2", "s1"]);
+
+    expect(result.days[0].patterns[0].schedules.map((s) => s.id)).toEqual(["s2", "s1", "unknown"]);
+  });
+
+  it("returns the trip unchanged when the pattern is not found", () => {
+    const trip = tripWithSchedules([makeSchedule({ id: "s1" })]);
+
+    const result = reorderSchedulesInPattern(trip, "d1", "missing", ["s1"]);
+
+    expect(result).toBe(trip);
+  });
+
+  it("does not touch schedules in other patterns", () => {
+    const otherPattern = makePattern({
+      id: "p2",
+      schedules: [makeSchedule({ id: "x1", sortOrder: 9 })],
+    });
+    const trip = makeTrip({
+      days: [
+        makeDay({
+          patterns: [makePattern({ schedules: [makeSchedule({ id: "s1" })] }), otherPattern],
+        }),
+      ],
+    });
+
+    const result = reorderSchedulesInPattern(trip, "d1", "p1", ["s1"]);
+
+    expect(result.days[0].patterns[1].schedules[0].sortOrder).toBe(9);
+  });
+});
+
+describe("reorderCandidates", () => {
+  it("reorders candidates to the given id order with sortOrder rewritten", () => {
+    const trip = makeTrip({
+      candidates: [
+        makeCandidate({ id: "c1", sortOrder: 0 }),
+        makeCandidate({ id: "c2", sortOrder: 1 }),
+      ],
+    });
+
+    const result = reorderCandidates(trip, ["c2", "c1"]);
+
+    expect(result.candidates.map((c) => [c.id, c.sortOrder])).toEqual([
+      ["c2", 0],
+      ["c1", 1],
+    ]);
+  });
+
+  it("preserves reaction fields on reordered candidates", () => {
+    const trip = makeTrip({
+      candidates: [makeCandidate({ id: "c1", likeCount: 3, myReaction: "like" })],
+    });
+
+    const result = reorderCandidates(trip, ["c1"]);
+
+    expect(result.candidates[0]).toMatchObject({ likeCount: 3, myReaction: "like" });
+  });
+
+  it("keeps candidates missing from scheduleIds", () => {
+    const trip = makeTrip({
+      candidates: [
+        makeCandidate({ id: "c1", sortOrder: 0 }),
+        makeCandidate({ id: "unknown", sortOrder: 1 }),
+      ],
+    });
+
+    const result = reorderCandidates(trip, ["c1"]);
+
+    expect(result.candidates.map((c) => c.id)).toEqual(["c1", "unknown"]);
   });
 });

--- a/apps/web/lib/drop-position.ts
+++ b/apps/web/lib/drop-position.ts
@@ -266,6 +266,35 @@ function extractAnchor(
   return { anchor: null, anchorSourceId: null };
 }
 
+/**
+ * Normalize an optimistically reordered schedules array so the merged
+ * timeline renders it in the new order.
+ *
+ * `buildMergedTimeline` sorts schedules anchored to a crossDay entry by their
+ * `sortOrder` FIELD, not by array position. A bare `arrayMove` changes only
+ * the array order, so a reorder inside an anchored cluster was a visual no-op
+ * (the dragged card snapped straight back — issue #166). Rewriting sortOrder
+ * to the array index mirrors what the server's reorder endpoint persists, and
+ * writing the new anchor onto the active schedule makes anchor changes (e.g.
+ * dragging across the crossDay boundary) visible immediately as well.
+ */
+export function applyOptimisticReorder(
+  reordered: ScheduleResponse[],
+  activeId: string,
+  anchor: AnchorUpdate,
+): ScheduleResponse[] {
+  return reordered.map((s, i) =>
+    s.id === activeId
+      ? {
+          ...s,
+          sortOrder: i,
+          crossDayAnchor: anchor.anchor,
+          crossDayAnchorSourceId: anchor.anchorSourceId,
+        }
+      : { ...s, sortOrder: i },
+  );
+}
+
 function anchoredScheduleAnchor(item: TimelineItem | null): AnchorUpdate | null {
   if (item?.type !== "schedule") return null;
   const { crossDayAnchor, crossDayAnchorSourceId } = item.schedule;

--- a/apps/web/lib/hooks/use-trip-drag-and-drop.test.ts
+++ b/apps/web/lib/hooks/use-trip-drag-and-drop.test.ts
@@ -724,6 +724,9 @@ describe("useTripDragAndDrop — null-based snapshot isolation", () => {
 describe("useTripDragAndDrop — post-mutation callback routing (#166)", () => {
   afterEach(() => vi.clearAllMocks());
 
+  // Drops s1 onto s2's lower half: the over rect has height 0 and the
+  // activator PointerEvent has clientY 0, so isOverUpperHalf resolves false
+  // (0 < 0 fails) → insert below s2 → expected order ["s2", "s1"].
   function dragS1OverS2(result: { current: ReturnType<typeof useTripDragAndDrop> }): Promise<void> {
     act(() => {
       result.current.handleDragStart({
@@ -806,6 +809,65 @@ describe("useTripDragAndDrop — post-mutation callback routing (#166)", () => {
 
     expect(onDone).toHaveBeenCalledTimes(1);
     expect(onSchedulesReordered).not.toHaveBeenCalled();
+  });
+
+  it("routes a successful keyboard reorder to onSchedulesReordered, not onDone", async () => {
+    const onDone = vi.fn();
+    const onSchedulesReordered = vi.fn();
+    const { result } = renderHook(() =>
+      useTripDragAndDrop({
+        tripId: "trip1",
+        currentDayId: "day1",
+        currentPatternId: "pattern1",
+        schedules: [s1, s2],
+        candidates: [],
+        onDone,
+        onSchedulesReordered,
+        onCandidatesReordered: vi.fn(),
+      }),
+    );
+
+    await act(() => result.current.reorderSchedule("s2", "up"));
+
+    expect(onSchedulesReordered).toHaveBeenCalledWith({
+      dayId: "day1",
+      patternId: "pattern1",
+      scheduleIds: ["s2", "s1"],
+      anchors: [{ scheduleId: "s2", anchor: null, anchorSourceId: null }],
+    });
+    expect(onDone).not.toHaveBeenCalled();
+  });
+
+  it("keeps the cluster anchor when a keyboard step swaps with an anchored schedule", async () => {
+    // Stepping within an anchored cluster must join/stay in the cluster like
+    // the drag path does (extractAnchor: a drop on an anchored schedule joins
+    // its cluster). Clearing the anchor here ejected the schedule from the
+    // cluster and re-placed it by the time-based merge.
+    const anchorFields = { crossDayAnchor: "after" as const, crossDayAnchorSourceId: "h1" };
+    const t1 = { ...makeSchedule("t1"), ...anchorFields };
+    const t2 = { ...makeSchedule("t2"), ...anchorFields };
+    const onSchedulesReordered = vi.fn();
+    const { result } = renderHook(() =>
+      useTripDragAndDrop({
+        tripId: "trip1",
+        currentDayId: "day1",
+        currentPatternId: "pattern1",
+        schedules: [t1, t2],
+        candidates: [],
+        onDone: vi.fn(),
+        onSchedulesReordered,
+        onCandidatesReordered: vi.fn(),
+      }),
+    );
+
+    await act(() => result.current.reorderSchedule("t2", "up"));
+
+    expect(onSchedulesReordered).toHaveBeenCalledWith({
+      dayId: "day1",
+      patternId: "pattern1",
+      scheduleIds: ["t2", "t1"],
+      anchors: [{ scheduleId: "t2", anchor: "after", anchorSourceId: "h1" }],
+    });
   });
 
   it("routes a successful candidate reorder to onCandidatesReordered, not onDone", async () => {

--- a/apps/web/lib/hooks/use-trip-drag-and-drop.test.ts
+++ b/apps/web/lib/hooks/use-trip-drag-and-drop.test.ts
@@ -92,6 +92,8 @@ describe("useTripDragAndDrop — null-based snapshot isolation", () => {
           schedules,
           candidates: [],
           onDone: vi.fn(),
+          onSchedulesReordered: vi.fn(),
+          onCandidatesReordered: vi.fn(),
         }),
       { initialProps: { schedules: [s1, s2] } },
     );
@@ -113,6 +115,8 @@ describe("useTripDragAndDrop — null-based snapshot isolation", () => {
           schedules,
           candidates: [],
           onDone: vi.fn(),
+          onSchedulesReordered: vi.fn(),
+          onCandidatesReordered: vi.fn(),
         }),
       { initialProps: { schedules: [s1, s2] } },
     );
@@ -167,6 +171,8 @@ describe("useTripDragAndDrop — null-based snapshot isolation", () => {
         schedules: [s1, s2],
         candidates: [],
         onDone: vi.fn(),
+        onSchedulesReordered: vi.fn(),
+        onCandidatesReordered: vi.fn(),
       }),
     );
 
@@ -215,6 +221,8 @@ describe("useTripDragAndDrop — null-based snapshot isolation", () => {
         schedules: [s1, s2],
         candidates: [],
         onDone: vi.fn(),
+        onSchedulesReordered: vi.fn(),
+        onCandidatesReordered: vi.fn(),
       }),
     );
 
@@ -284,6 +292,8 @@ describe("useTripDragAndDrop — null-based snapshot isolation", () => {
         schedules: [s1, s2],
         candidates: [],
         onDone: vi.fn(),
+        onSchedulesReordered: vi.fn(),
+        onCandidatesReordered: vi.fn(),
       }),
     );
 
@@ -334,6 +344,8 @@ describe("useTripDragAndDrop — null-based snapshot isolation", () => {
         schedules: [s1, s2],
         candidates: [],
         onDone: vi.fn(),
+        onSchedulesReordered: vi.fn(),
+        onCandidatesReordered: vi.fn(),
       }),
     );
 
@@ -399,6 +411,8 @@ describe("useTripDragAndDrop — null-based snapshot isolation", () => {
         schedules: [s1, s2],
         candidates: [],
         onDone: vi.fn(),
+        onSchedulesReordered: vi.fn(),
+        onCandidatesReordered: vi.fn(),
       }),
     );
 
@@ -466,6 +480,8 @@ describe("useTripDragAndDrop — null-based snapshot isolation", () => {
         schedules: [s1, s2],
         candidates: [],
         onDone: vi.fn(),
+        onSchedulesReordered: vi.fn(),
+        onCandidatesReordered: vi.fn(),
       }),
     );
 
@@ -521,13 +537,14 @@ describe("useTripDragAndDrop — null-based snapshot isolation", () => {
     expect(result.current.overScheduleId).toBe("s2");
   });
 
-  it("does not snap back to old order while onDone (refetch) is pending after reorderSchedule", async () => {
-    // onDone returns a pending promise — simulates an in-flight refetch.
-    let resolveOnDone: (() => void) | undefined;
-    const onDone = vi.fn(
+  it("does not snap back to old order while the cache write is pending after reorderSchedule", async () => {
+    // onSchedulesReordered returns a pending promise — simulates the cache
+    // write (or its invalidate fallback) still being in flight.
+    let resolveReordered: (() => void) | undefined;
+    const onSchedulesReordered = vi.fn(
       () =>
         new Promise<void>((res) => {
-          resolveOnDone = res;
+          resolveReordered = res;
         }),
     );
 
@@ -538,7 +555,9 @@ describe("useTripDragAndDrop — null-based snapshot isolation", () => {
         currentPatternId: "pattern1",
         schedules: [s1, s2],
         candidates: [],
-        onDone,
+        onDone: vi.fn(),
+        onSchedulesReordered,
+        onCandidatesReordered: vi.fn(),
       }),
     );
 
@@ -548,23 +567,23 @@ describe("useTripDragAndDrop — null-based snapshot isolation", () => {
     });
 
     // Flush microtasks so the optimistic setLocalSchedules and the awaited
-    // api() both settle. `onDone` is still pending.
+    // api() both settle. `onSchedulesReordered` is still pending.
     await act(async () => {
       await Promise.resolve();
       await Promise.resolve();
     });
 
-    // Bug repro: while the refetch driven by onDone is pending, the schedules
-    // prop has not been updated yet. If finally runs before onDone resolves,
+    // Bug repro: while the post-mutation callback is pending, the schedules
+    // prop has not been updated yet. If finally runs before it resolves,
     // localSchedules falls back to the stale prop (= old order [s1, s2]),
-    // causing a brief snap-back before the refetch completes.
-    // The onDone-was-called assertion guards against a degenerate fix where
-    // the test passes only because onDone never ran.
-    expect(onDone).toHaveBeenCalledTimes(1);
+    // causing a brief snap-back before the cache reflects the new order.
+    // The was-called assertion guards against a degenerate fix where the
+    // test passes only because the callback never ran.
+    expect(onSchedulesReordered).toHaveBeenCalledTimes(1);
     expect(result.current.localSchedules.map((s) => s.id)).toEqual(["s2", "s1"]);
 
     await act(async () => {
-      resolveOnDone?.();
+      resolveReordered?.();
       await pending;
     });
   });
@@ -587,6 +606,8 @@ describe("useTripDragAndDrop — null-based snapshot isolation", () => {
         schedules: [s1, s2, s3],
         candidates: [],
         onDone: vi.fn(),
+        onSchedulesReordered: vi.fn(),
+        onCandidatesReordered: vi.fn(),
       }),
     );
 
@@ -627,6 +648,8 @@ describe("useTripDragAndDrop — null-based snapshot isolation", () => {
         schedules: [],
         candidates: [c1, c2, c3],
         onDone: vi.fn(),
+        onSchedulesReordered: vi.fn(),
+        onCandidatesReordered: vi.fn(),
       }),
     );
 
@@ -658,6 +681,8 @@ describe("useTripDragAndDrop — null-based snapshot isolation", () => {
         schedules: [s1, s2],
         candidates: [],
         onDone: vi.fn(),
+        onSchedulesReordered: vi.fn(),
+        onCandidatesReordered: vi.fn(),
       }),
     );
 
@@ -693,5 +718,117 @@ describe("useTripDragAndDrop — null-based snapshot isolation", () => {
 
     // After API resolves, finally resets local state to null → falls back to schedules prop
     expect(result.current.localSchedules).toStrictEqual([s1, s2]);
+  });
+});
+
+describe("useTripDragAndDrop — post-mutation callback routing (#166)", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  function dragS1OverS2(result: { current: ReturnType<typeof useTripDragAndDrop> }): Promise<void> {
+    act(() => {
+      result.current.handleDragStart({
+        active: {
+          id: "s1",
+          data: { current: { type: "schedule" } },
+          rect: { current: { initial: null, translated: null } },
+        },
+        activatorEvent: new PointerEvent("pointerdown"),
+      } as Parameters<typeof result.current.handleDragStart>[0]);
+    });
+    return act(() =>
+      result.current.handleDragEnd({
+        active: {
+          id: "s1",
+          data: { current: { type: "schedule" } },
+          rect: { current: { initial: null, translated: null } },
+        },
+        over: {
+          id: "s2",
+          data: { current: { type: "schedule" } },
+          rect: { width: 0, height: 0, top: 0, left: 0, bottom: 0, right: 0 },
+          disabled: false,
+        },
+        delta: { x: 0, y: 0 },
+        activatorEvent: new PointerEvent("pointerup"),
+        collisions: null,
+      } as Parameters<typeof result.current.handleDragEnd>[0]),
+    );
+  }
+
+  it("routes a successful schedule reorder to onSchedulesReordered, not onDone", async () => {
+    // The success path must write the confirmed order into the cache instead
+    // of refetching: an immediate GET can return a stale read that visually
+    // reverts the reorder (#166).
+    const onDone = vi.fn();
+    const onSchedulesReordered = vi.fn();
+    const { result } = renderHook(() =>
+      useTripDragAndDrop({
+        tripId: "trip1",
+        currentDayId: "day1",
+        currentPatternId: "pattern1",
+        schedules: [s1, s2],
+        candidates: [],
+        onDone,
+        onSchedulesReordered,
+        onCandidatesReordered: vi.fn(),
+      }),
+    );
+
+    await dragS1OverS2(result);
+
+    expect(onSchedulesReordered).toHaveBeenCalledWith({
+      dayId: "day1",
+      patternId: "pattern1",
+      scheduleIds: ["s2", "s1"],
+      anchors: [{ scheduleId: "s1", anchor: null, anchorSourceId: null }],
+    });
+    expect(onDone).not.toHaveBeenCalled();
+  });
+
+  it("falls back to onDone (refetch resync) when the reorder API fails", async () => {
+    vi.mocked(api).mockRejectedValueOnce(new Error("network"));
+    const onDone = vi.fn();
+    const onSchedulesReordered = vi.fn();
+    const { result } = renderHook(() =>
+      useTripDragAndDrop({
+        tripId: "trip1",
+        currentDayId: "day1",
+        currentPatternId: "pattern1",
+        schedules: [s1, s2],
+        candidates: [],
+        onDone,
+        onSchedulesReordered,
+        onCandidatesReordered: vi.fn(),
+      }),
+    );
+
+    await dragS1OverS2(result);
+
+    expect(onDone).toHaveBeenCalledTimes(1);
+    expect(onSchedulesReordered).not.toHaveBeenCalled();
+  });
+
+  it("routes a successful candidate reorder to onCandidatesReordered, not onDone", async () => {
+    const onDone = vi.fn();
+    const onCandidatesReordered = vi.fn();
+    const c1 = makeCandidate("c1");
+    const c2 = makeCandidate("c2");
+    const { result } = renderHook(() =>
+      useTripDragAndDrop({
+        tripId: "trip1",
+        currentDayId: "day1",
+        currentPatternId: "pattern1",
+        schedules: [],
+        candidates: [c1, c2],
+        onDone,
+        onSchedulesReordered: vi.fn(),
+        onCandidatesReordered,
+      }),
+    );
+
+    await act(() => result.current.reorderCandidate("c2", "up"));
+
+    expect(onCandidatesReordered).toHaveBeenCalledWith(["c2", "c1"]);
+    expect(onDone).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/lib/hooks/use-trip-drag-and-drop.ts
+++ b/apps/web/lib/hooks/use-trip-drag-and-drop.ts
@@ -608,14 +608,22 @@ export function useTripDragAndDrop({
         anchorSourceId: targetItem.entry.schedule.id,
       };
     } else {
-      // Swap with a regular schedule: swap sortOrder and clear anchor so the
-      // explicit reorder wins over any prior pin.
-      const targetId = targetItem.schedule.id;
+      // Swap with a regular schedule. When the target is anchored, the step
+      // lands inside its anchored cluster — join it, mirroring the drag
+      // path's extractAnchor rule (a drop on an anchored schedule joins its
+      // cluster). Clearing the anchor here would eject the schedule from the
+      // cluster and let the time-based merge re-place it far from the
+      // intended one-step move. For an unanchored target, clear the anchor
+      // so the explicit reorder wins over any prior pin.
+      const target = targetItem.schedule;
       const scheduleIdx = current.findIndex((s) => s.id === id);
-      const targetIdx = current.findIndex((s) => s.id === targetId);
+      const targetIdx = current.findIndex((s) => s.id === target.id);
       if (scheduleIdx === -1 || targetIdx === -1) return;
       reordered = arrayMove(current, scheduleIdx, targetIdx);
-      anchor = { anchor: null, anchorSourceId: null };
+      anchor =
+        target.crossDayAnchor && target.crossDayAnchorSourceId
+          ? { anchor: target.crossDayAnchor, anchorSourceId: target.crossDayAnchorSourceId }
+          : { anchor: null, anchorSourceId: null };
     }
     // Rewrite sortOrder + the moved schedule's anchor so the merged timeline
     // reflects the step immediately (issue #166). The crossDay branch

--- a/apps/web/lib/hooks/use-trip-drag-and-drop.ts
+++ b/apps/web/lib/hooks/use-trip-drag-and-drop.ts
@@ -24,6 +24,7 @@ import { useRef, useState } from "react";
 import { toast } from "sonner";
 import { ApiError, api } from "@/lib/api";
 import {
+  applyOptimisticReorder,
   computeCandidateDropResult,
   computeScheduleReorderResult,
   type DropTarget,
@@ -31,6 +32,7 @@ import {
   timelineEdge,
 } from "@/lib/drop-position";
 import { buildMergedTimeline, timelineSortableIds } from "@/lib/merge-timeline";
+import type { ScheduleAnchorUpdate } from "@/lib/trip-cache";
 
 type ActiveDragItem = {
   id: string;
@@ -51,8 +53,20 @@ type UseTripDragAndDropArgs = {
   // (typically `invalidateQueries`) so the schedules prop already reflects
   // the new server order by the time the local snapshot is released —
   // otherwise the list briefly snaps back to the pre-mutation order while
-  // the refetch is still in flight.
+  // the refetch is still in flight. Used by the move (assign/unassign)
+  // branches and by every error path as the resync mechanism.
   onDone: () => void | Promise<void>;
+  // Successful pure reorders skip the refetch entirely: the client already
+  // knows the confirmed order, and an immediate GET after the PATCH can
+  // return a stale read that visually reverts it (#166). These callbacks
+  // write the order into the trip cache directly (useTripMutationCallbacks).
+  onSchedulesReordered: (args: {
+    dayId: string;
+    patternId: string;
+    scheduleIds: string[];
+    anchors: ScheduleAnchorUpdate[];
+  }) => void | Promise<void>;
+  onCandidatesReordered: (scheduleIds: string[]) => void | Promise<void>;
 };
 
 // MouseSensor (not PointerSensor) so that touch input is handled exclusively
@@ -118,6 +132,8 @@ export function useTripDragAndDrop({
   candidates,
   crossDayEntries,
   onDone,
+  onSchedulesReordered,
+  onCandidatesReordered,
 }: UseTripDragAndDropArgs) {
   const tm = useTranslations("messages");
   const [activeDragItem, setActiveDragItem] = useState<ActiveDragItem | null>(null);
@@ -186,9 +202,12 @@ export function useTripDragAndDrop({
     setOverScheduleId(null);
     setOverCandidateId(null);
     setLastOverZone(null);
-    // Capture snapshot so optimistic updates have a stable baseline during drag
-    setLocalSchedules([...schedules]);
-    setLocalCandidates([...candidates]);
+    // Capture snapshot so optimistic updates have a stable baseline during
+    // drag. Base it on the current optimistic state, not the raw props: while
+    // a previous op is still awaiting its refetch, props hold the pre-mutation
+    // order, and snapshotting them would compute this drag against stale data.
+    setLocalSchedules([...currentSchedules]);
+    setLocalCandidates([...currentCandidates]);
   }
 
   // First sortable id of the merged timeline (crossDay entries included) —
@@ -315,28 +334,39 @@ export function useTripDragAndDrop({
           (activeSchedule.crossDayAnchorSourceId ?? null) !== anchor.anchorSourceId;
         if (destIndex === activeIdx && !anchorChanged) return;
 
-        const reordered = arrayMove(currentSchedules, activeIdx, destIndex);
+        // applyOptimisticReorder rewrites sortOrder (and the active schedule's
+        // anchor) so the merged timeline — which sorts anchored clusters by
+        // the sortOrder field, not array position — renders the new order
+        // immediately instead of snapping back (issue #166).
+        const reordered = applyOptimisticReorder(
+          arrayMove(currentSchedules, activeIdx, destIndex),
+          activeId,
+          anchor,
+        );
         setLocalSchedules(reordered);
 
         const scheduleIds = reordered.map((s) => s.id);
+        const anchors = [
+          {
+            scheduleId: activeId,
+            anchor: anchor.anchor,
+            anchorSourceId: anchor.anchorSourceId,
+          },
+        ];
         try {
           await api(
             `/api/trips/${tripId}/days/${currentDayId}/patterns/${currentPatternId}/schedules/reorder`,
             {
               method: "PATCH",
-              body: JSON.stringify({
-                scheduleIds,
-                anchors: [
-                  {
-                    scheduleId: activeId,
-                    anchor: anchor.anchor,
-                    anchorSourceId: anchor.anchorSourceId,
-                  },
-                ],
-              }),
+              body: JSON.stringify({ scheduleIds, anchors }),
             },
           );
-          await onDone();
+          await onSchedulesReordered({
+            dayId: currentDayId,
+            patternId: currentPatternId,
+            scheduleIds,
+            anchors,
+          });
         } catch (err) {
           if (err instanceof ApiError && (err.status === 400 || err.status === 404)) {
             toast.error(tm("conflictStale"));
@@ -448,7 +478,7 @@ export function useTripDragAndDrop({
 
         const insertedSchedules = [...currentSchedules];
         insertedSchedules.splice(insertIdx, 0, newSchedule);
-        setLocalSchedules(insertedSchedules);
+        setLocalSchedules(applyOptimisticReorder(insertedSchedules, String(active.id), anchor));
         toast.success(tm("candidateAssigned"));
 
         try {
@@ -526,7 +556,7 @@ export function useTripDragAndDrop({
             method: "PATCH",
             body: JSON.stringify({ scheduleIds }),
           });
-          await onDone();
+          await onCandidatesReordered(scheduleIds);
         } catch (err) {
           if (err instanceof ApiError && (err.status === 400 || err.status === 404)) {
             toast.error(tm("conflictStale"));
@@ -571,8 +601,8 @@ export function useTripDragAndDrop({
     if (targetItem.type === "crossDay") {
       // Swap target is a crossDay — can't swap sortOrder (crossDay isn't in
       // this day's schedules). Express "one step past crossDay" as an
-      // anchor: before when moving up, after when moving down. sortOrder is
-      // unchanged — the rendered position shifts via the anchor.
+      // anchor: before when moving up, after when moving down. The array
+      // order is unchanged — the rendered position shifts via the anchor.
       anchor = {
         anchor: direction === "up" ? "before" : "after",
         anchorSourceId: targetItem.entry.schedule.id,
@@ -585,22 +615,31 @@ export function useTripDragAndDrop({
       const targetIdx = current.findIndex((s) => s.id === targetId);
       if (scheduleIdx === -1 || targetIdx === -1) return;
       reordered = arrayMove(current, scheduleIdx, targetIdx);
-      setLocalSchedules(reordered);
       anchor = { anchor: null, anchorSourceId: null };
     }
+    // Rewrite sortOrder + the moved schedule's anchor so the merged timeline
+    // reflects the step immediately (issue #166). The crossDay branch
+    // previously had no optimistic update at all — the anchor flip only
+    // became visible after the refetch.
+    reordered = applyOptimisticReorder(reordered, id, anchor);
+    setLocalSchedules(reordered);
 
+    const scheduleIds = reordered.map((s) => s.id);
+    const anchors = [{ scheduleId: id, ...anchor }];
     try {
       await api(
         `/api/trips/${tripId}/days/${currentDayId}/patterns/${currentPatternId}/schedules/reorder`,
         {
           method: "PATCH",
-          body: JSON.stringify({
-            scheduleIds: reordered.map((s) => s.id),
-            anchors: [{ scheduleId: id, ...anchor }],
-          }),
+          body: JSON.stringify({ scheduleIds, anchors }),
         },
       );
-      await onDone();
+      await onSchedulesReordered({
+        dayId: currentDayId,
+        patternId: currentPatternId,
+        scheduleIds,
+        anchors,
+      });
     } catch (err) {
       if (err instanceof ApiError && (err.status === 400 || err.status === 404)) {
         toast.error(tm("conflictStale"));
@@ -626,12 +665,13 @@ export function useTripDragAndDrop({
     const reordered = arrayMove(current, idx, newIdx);
     setLocalCandidates(reordered);
 
+    const scheduleIds = reordered.map((c) => c.id);
     try {
       await api(`/api/trips/${tripId}/candidates/reorder`, {
         method: "PATCH",
-        body: JSON.stringify({ scheduleIds: reordered.map((c) => c.id) }),
+        body: JSON.stringify({ scheduleIds }),
       });
-      await onDone();
+      await onCandidatesReordered(scheduleIds);
     } catch (err) {
       if (err instanceof ApiError && (err.status === 400 || err.status === 404)) {
         toast.error(tm("conflictStale"));

--- a/apps/web/lib/hooks/use-trip-mutation-callbacks.test.ts
+++ b/apps/web/lib/hooks/use-trip-mutation-callbacks.test.ts
@@ -4,10 +4,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // --- Mocks ---
 
 const mockInvalidateQueries = vi.fn();
+const mockCancelQueries = vi.fn();
+const mockGetQueryData = vi.fn();
+const mockSetQueryData = vi.fn();
 
 vi.mock("@tanstack/react-query", () => ({
   useQueryClient: () => ({
     invalidateQueries: mockInvalidateQueries,
+    cancelQueries: mockCancelQueries,
+    getQueryData: mockGetQueryData,
+    setQueryData: mockSetQueryData,
   }),
 }));
 
@@ -93,6 +99,130 @@ describe("useTripMutationCallbacks", () => {
 
     expect(mockInvalidateQueries).toHaveBeenCalledWith({
       queryKey: ["trips", "t1", "activity-logs"],
+    });
+  });
+
+  // The reorder endpoints return no body, but the client already knows the
+  // confirmed order — write it into the cache instead of refetching, because
+  // an immediate GET can return a stale read that reverts the reorder (#166,
+  // same mechanism as #123).
+  describe("onSchedulesReordered", () => {
+    const cachedTrip = {
+      id: "t1",
+      candidates: [],
+      days: [
+        {
+          id: "d1",
+          patterns: [
+            {
+              id: "p1",
+              schedules: [
+                { id: "s1", sortOrder: 0 },
+                { id: "s2", sortOrder: 1 },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const args = {
+      dayId: "d1",
+      patternId: "p1",
+      scheduleIds: ["s2", "s1"],
+      anchors: [],
+    };
+
+    it("writes the confirmed order into the trip detail cache", async () => {
+      mockGetQueryData.mockReturnValue(cachedTrip);
+      const { result } = setup();
+
+      await act(() => result.current.onSchedulesReordered(args));
+
+      const written = mockSetQueryData.mock.calls[0];
+      expect(written[0]).toEqual(["trips", "t1"]);
+      expect(written[1].days[0].patterns[0].schedules.map((s: { id: string }) => s.id)).toEqual([
+        "s2",
+        "s1",
+      ]);
+    });
+
+    it("cancels in-flight trip queries before writing", async () => {
+      mockGetQueryData.mockReturnValue(cachedTrip);
+      const { result } = setup();
+
+      await act(() => result.current.onSchedulesReordered(args));
+
+      expect(mockCancelQueries).toHaveBeenCalledWith({ queryKey: ["trips", "t1"] });
+    });
+
+    it("does not refetch the trip detail when the cache holds the trip", async () => {
+      mockGetQueryData.mockReturnValue(cachedTrip);
+      const { result } = setup();
+
+      await act(() => result.current.onSchedulesReordered(args));
+
+      expect(invalidateTrip).not.toHaveBeenCalled();
+    });
+
+    it("broadcasts the change to other clients", async () => {
+      mockGetQueryData.mockReturnValue(cachedTrip);
+      const { result } = setup();
+
+      await act(() => result.current.onSchedulesReordered(args));
+
+      expect(broadcastChange).toHaveBeenCalledTimes(1);
+    });
+
+    it("falls back to a refetch when the cache has no trip", async () => {
+      mockGetQueryData.mockReturnValue(undefined);
+      const { result } = setup();
+
+      await act(() => result.current.onSchedulesReordered(args));
+
+      expect(invalidateTrip).toHaveBeenCalledTimes(1);
+      expect(mockSetQueryData).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("onCandidatesReordered", () => {
+    const cachedTrip = {
+      id: "t1",
+      days: [],
+      candidates: [
+        { id: "c1", sortOrder: 0 },
+        { id: "c2", sortOrder: 1 },
+      ],
+    };
+
+    it("writes the confirmed candidate order into the cache", async () => {
+      mockGetQueryData.mockReturnValue(cachedTrip);
+      const { result } = setup();
+
+      await act(() => result.current.onCandidatesReordered(["c2", "c1"]));
+
+      const written = mockSetQueryData.mock.calls[0];
+      expect(written[0]).toEqual(["trips", "t1"]);
+      expect(written[1].candidates.map((c: { id: string }) => c.id)).toEqual(["c2", "c1"]);
+    });
+
+    it("broadcasts the change to other clients", async () => {
+      mockGetQueryData.mockReturnValue(cachedTrip);
+      const { result } = setup();
+
+      await act(() => result.current.onCandidatesReordered(["c2", "c1"]));
+
+      expect(broadcastChange).toHaveBeenCalledTimes(1);
+    });
+
+    it("falls back to a refetch when the cache has no trip", async () => {
+      mockGetQueryData.mockReturnValue(undefined);
+      const { result } = setup();
+
+      await act(() => result.current.onCandidatesReordered(["c2", "c1"]));
+
+      expect(invalidateTrip).toHaveBeenCalledTimes(1);
+      expect(mockSetQueryData).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/web/lib/hooks/use-trip-mutation-callbacks.ts
+++ b/apps/web/lib/hooks/use-trip-mutation-callbacks.ts
@@ -1,8 +1,14 @@
 "use client";
 
+import type { TripResponse } from "@sugara/shared";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 import { queryKeys } from "@/lib/query-keys";
+import {
+  reorderCandidates,
+  reorderSchedulesInPattern,
+  type ScheduleAnchorUpdate,
+} from "@/lib/trip-cache";
 
 /**
  * Shared post-mutation callbacks for the trip detail pages (desktop / SP).
@@ -16,6 +22,13 @@ import { queryKeys } from "@/lib/query-keys";
  * IndexedDB snapshots) that clobbers the just-added schedule (#123), so this
  * variant skips the trip-detail invalidation and only broadcasts + refreshes
  * the activity logs.
+ *
+ * `onSchedulesReordered` / `onCandidatesReordered` apply the same principle
+ * to the reorder endpoints (#166): the client already knows the confirmed
+ * order, so it is written into the cache directly instead of refetched —
+ * an immediate GET after the PATCH can return a stale read that visually
+ * reverts the reorder. Reordering writes no activity log, so unlike
+ * `onScheduleAdded` there is nothing else to refresh.
  */
 export function useTripMutationCallbacks({
   tripId,
@@ -41,5 +54,51 @@ export function useTripMutationCallbacks({
     await queryClient.invalidateQueries({ queryKey: queryKeys.trips.activityLogs(tripId) });
   }, [broadcastChange, queryClient, tripId]);
 
-  return { onMutate, onScheduleAdded };
+  const onSchedulesReordered = useCallback(
+    async (args: {
+      dayId: string;
+      patternId: string;
+      scheduleIds: string[];
+      anchors: ScheduleAnchorUpdate[];
+    }) => {
+      const cacheKey = queryKeys.trips.detail(tripId);
+      // Stop any in-flight trip GET: it could resolve after setQueryData with
+      // a stale snapshot and overwrite the just-confirmed order (#123 / #166).
+      await queryClient.cancelQueries({ queryKey: cacheKey });
+      const prev = queryClient.getQueryData<TripResponse>(cacheKey);
+      if (prev) {
+        queryClient.setQueryData(
+          cacheKey,
+          reorderSchedulesInPattern(
+            prev,
+            args.dayId,
+            args.patternId,
+            args.scheduleIds,
+            args.anchors,
+          ),
+        );
+      } else {
+        await invalidateTrip();
+      }
+      broadcastChange();
+    },
+    [queryClient, tripId, invalidateTrip, broadcastChange],
+  );
+
+  const onCandidatesReordered = useCallback(
+    async (scheduleIds: string[]) => {
+      const cacheKey = queryKeys.trips.detail(tripId);
+      await queryClient.cancelQueries({ queryKey: cacheKey });
+      const prev = queryClient.getQueryData<TripResponse>(cacheKey);
+      if (prev) {
+        queryClient.setQueryData(cacheKey, reorderCandidates(prev, scheduleIds));
+      } else {
+        await invalidateTrip();
+      }
+      broadcastChange();
+    },
+    [queryClient, tripId, invalidateTrip, broadcastChange],
+  );
+
+  return { onMutate, onScheduleAdded, onSchedulesReordered, onCandidatesReordered };
 }

--- a/apps/web/lib/trip-cache.ts
+++ b/apps/web/lib/trip-cache.ts
@@ -138,6 +138,81 @@ export function removeScheduleFromPattern(
   };
 }
 
+export type ScheduleAnchorUpdate = {
+  scheduleId: string;
+  anchor: "before" | "after" | null;
+  anchorSourceId: string | null;
+};
+
+/**
+ * Apply a confirmed reorder (PATCH .../schedules/reorder) to the cached trip.
+ *
+ * Mirrors the server: schedules listed in `scheduleIds` get sortOrder = list
+ * index and `anchors` entries overwrite the targeted schedules' anchor
+ * fields; the pattern is then sorted by sortOrder like the trip GET. Cached
+ * schedules missing from `scheduleIds` (e.g. added concurrently by another
+ * member) keep their sortOrder and survive in that ordering.
+ *
+ * Written into the cache directly (instead of refetching) because a GET
+ * right after the mutation can return a stale read (#123); the reorder
+ * endpoint touches only sortOrder/anchor — not updatedAt — so the cached
+ * rows stay consistent for optimistic-concurrency checks.
+ */
+export function reorderSchedulesInPattern(
+  trip: TripResponse,
+  dayId: string,
+  patternId: string,
+  scheduleIds: string[],
+  anchors?: ScheduleAnchorUpdate[],
+): TripResponse {
+  const day = trip.days.find((d) => d.id === dayId);
+  if (!day) return trip;
+  const pattern = day.patterns.find((p) => p.id === patternId);
+  if (!pattern) return trip;
+
+  const indexById = new Map(scheduleIds.map((id, i) => [id, i]));
+  const anchorById = new Map((anchors ?? []).map((a) => [a.scheduleId, a]));
+
+  const reordered = pattern.schedules.map((s) => {
+    const index = indexById.get(s.id);
+    const anchor = anchorById.get(s.id);
+    if (index === undefined && anchor === undefined) return s;
+    return {
+      ...s,
+      sortOrder: index ?? s.sortOrder,
+      ...(anchor
+        ? { crossDayAnchor: anchor.anchor, crossDayAnchorSourceId: anchor.anchorSourceId }
+        : {}),
+    };
+  });
+  reordered.sort((a, b) => a.sortOrder - b.sortOrder);
+
+  return {
+    ...trip,
+    days: trip.days.map((d) =>
+      d.id !== dayId
+        ? d
+        : {
+            ...d,
+            patterns: d.patterns.map((p) =>
+              p.id !== patternId ? p : { ...p, schedules: reordered },
+            ),
+          },
+    ),
+  };
+}
+
+/** Apply a confirmed candidates reorder to the cached trip (see reorderSchedulesInPattern). */
+export function reorderCandidates(trip: TripResponse, scheduleIds: string[]): TripResponse {
+  const indexById = new Map(scheduleIds.map((id, i) => [id, i]));
+  const reordered = trip.candidates.map((c) => {
+    const index = indexById.get(c.id);
+    return index === undefined ? c : { ...c, sortOrder: index };
+  });
+  reordered.sort((a, b) => a.sortOrder - b.sortOrder);
+  return { ...trip, candidates: reordered };
+}
+
 // --- Candidate operations (trip.candidates) ---
 
 export function addCandidate(trip: TripResponse, candidate: CandidateResponse): TripResponse {


### PR DESCRIPTION
## Summary
- 滞在中(宿泊継続)カードにアンカーされた予定同士をドラッグで並び替えても動かない/遅れて反映されるバグを修正
- 楽観的更新が anchored クラスタで視覚的 no-op になる決定的バグと、直後の stale refetch が反映を巻き戻す確率的バグの 2 層を解消
- 副産物として、上下ボタンの並び替えがクラスタ内で anchor を消す非対称も修正

## Why
- 表示側 `buildMergedTimeline` は anchored クラスタを**配列順でなく `sortOrder` フィールド**でソートするが、楽観的更新は `arrayMove` で配列順しか変えていなかった。実モジュールでの再現スクリプトで「配列は入れ替わるが表示順は不変」を確認(#166)
- PATCH 自体は成功するのに反映されない残りの要因は、`invalidateTrip` の即時 refetch が Supavisor read-after-write lag で stale を返す既知の機構(#123)。reorder はクライアントが確定後の順序を完全に知っているため、refetch せず cache へ直接書く #154 のパターンを踏襲した
- reorder ハンドラは `updatedAt` を更新しない(スキーマに `$onUpdate` なし・ハンドラも未設定)ため、cache 直接書き込みでも optimistic-concurrency 用の `updatedAt` 整合は崩れない

## Changes
- `applyOptimisticReorder`(drop-position.ts): 並び替え後の配列に `sortOrder = index` を振り直し、移動アイテムの anchor をローカル反映。ドラッグ・候補→タイムライン挿入・上下ボタンの全楽観的更新パスに適用
- `reorderSchedulesInPattern` / `reorderCandidates`(trip-cache.ts): 確定済み順序を cache に書くヘルパー。`scheduleIds` 外の予定(並行追加)は保持
- `onSchedulesReordered` / `onCandidatesReordered`(use-trip-mutation-callbacks.ts): `cancelQueries` → `setQueryData` → broadcast。成功パスはこちら、エラーパスは従来の `onDone`(refetch 再同期)
- `handleDragStart` のスナップショットを `localSchedules ?? schedules` に変更(refetch 未完了中の再ドラッグが古い順序を基点にしない)
- 上下ボタンの並び替えで、アンカー済み予定とのスワップ時にクラスタ anchor を継承(ドラッグ経路の `extractAnchor` と対称化)

## Test plan
- [x] 再現テスト: anchored クラスタ内のスワップが `buildMergedTimeline` の表示順に即反映されること(drop-position.test.ts、修正前は fail を確認)
- [x] cache ヘルパー 9 件(並行追加の保持・anchor 適用/クリア・他パターン不干渉)
- [x] コールバック 8 件(cache 書き込み・refetch 抑止・cancelQueries・cache 不在フォールバック)
- [x] フックルーティング 5 件(成功→cache 書き込み / 失敗→onDone 再同期、ドラッグ・キーボード・候補)
- [x] 全パッケージ green: web 827 / api 858 / shared 248 / mcp 95、`bun run check` / `check-types` pass
- [ ] E2E は追加しない: dnd の Playwright 再現はポインタ座標依存で flake 源になるため、純粋関数 + フック単体で固定した

## Notes for reviewer
- code-reviewer の事前レビュー済み(blocking 0)。指摘 W-1(キーボード並び替えの anchor 消失)・W-2(ルーティングテスト欠落)・N-3(テスト前提コメント)は反映済み
- **cache 不在時のフォールバックは旧挙動(invalidate refetch)のまま**で、その経路では #123 系の lag が残る(レビュー W-3)。発生条件が稀(trip 詳細表示中は cache が常在)なため許容した
- 候補⇔タイムラインの移動(assign/unassign)の成功パスは `onDone`(refetch)のまま。新規エンティティの確定データが応答に必要で、#155(stale refetch の汎用対策)の範疇として残す
- FAQ / News は更新なし(機能仕様の変更ではなく既存機能の信頼性修正のため)

## Related
- Closes #166
- 関連: #123 / #154(stale refetch の先行対策)、#155(汎用対策・未対応)

🤖 Generated with [Claude Code](https://claude.com/claude-code)