### PR TITLE
fix: 候補スポット操作とステータス変更の stale refetch クロバー窓を塞ぐ (#155 partial)

### DIFF
--- a/apps/web/app/(authenticated)/trips/[id]/_components/right-panel.tsx
+++ b/apps/web/app/(authenticated)/trips/[id]/_components/right-panel.tsx
@@ -21,6 +21,7 @@ export function RightPanel({
   currentDayId,
   currentPatternId,
   onRefresh,
+  onCacheWritten,
   disabled,
   canEdit,
   online,
@@ -46,6 +47,7 @@ export function RightPanel({
   currentDayId: string | null;
   currentPatternId: string | null;
   onRefresh: () => Promise<void>;
+  onCacheWritten: () => void;
   disabled: boolean;
   canEdit: boolean;
   online: boolean;
@@ -95,6 +97,7 @@ export function RightPanel({
             currentDayId={currentDayId ?? undefined}
             currentPatternId={currentPatternId ?? undefined}
             onRefresh={onRefresh}
+            onCacheWritten={onCacheWritten}
             disabled={disabled}
             draggable={canEdit && online && !!currentDayId}
             addDialogOpen={addCandidateOpen}

--- a/apps/web/app/(authenticated)/trips/[id]/_components/trip-header.tsx
+++ b/apps/web/app/(authenticated)/trips/[id]/_components/trip-header.tsx
@@ -18,7 +18,7 @@ export function TripHeader({
   isConnected,
   online,
   canEdit,
-  onMutate,
+  onCacheWritten,
   onEditOpen,
   onOpenBookmarks,
   onOpenActivity,
@@ -33,7 +33,7 @@ export function TripHeader({
   isConnected: boolean;
   online: boolean;
   canEdit: boolean;
-  onMutate: () => Promise<void>;
+  onCacheWritten: () => void;
   onEditOpen: () => void;
   onOpenBookmarks?: () => void;
   onOpenActivity?: () => void;
@@ -48,7 +48,9 @@ export function TripHeader({
     status: trip.status,
     role: trip.role,
     pollId: trip.poll?.id,
-    onStatusChange: onMutate,
+    // Status change writes the complete new status into the cache itself, so
+    // skip the refetch (#155).
+    onStatusChange: onCacheWritten,
     onEdit: canEdit ? onEditOpen : undefined,
     disabled: !online,
     memberLimitReached: trip.memberCount >= MAX_MEMBERS_PER_TRIP,

--- a/apps/web/app/(authenticated)/trips/[id]/page.tsx
+++ b/apps/web/app/(authenticated)/trips/[id]/page.tsx
@@ -532,7 +532,7 @@ export default function TripDetailPage() {
 
   // Mutation callbacks: refetch + broadcast to other clients (see hook for
   // why schedule adds and reorders skip the refetch, #123 / #166)
-  const { onMutate, onScheduleAdded, onSchedulesReordered, onCandidatesReordered } =
+  const { onMutate, onCacheWritten, onSchedulesReordered, onCandidatesReordered } =
     useTripMutationCallbacks({
       tripId,
       invalidateTrip,
@@ -742,7 +742,7 @@ export default function TripDetailPage() {
                   date={currentDay.date}
                   schedules={dnd.localSchedules}
                   onRefresh={onMutate}
-                  onScheduleAdded={onScheduleAdded}
+                  onScheduleAdded={onCacheWritten}
                   disabled={!online || !canEdit}
                   addScheduleOpen={!isLg ? addScheduleOpen : false}
                   onAddScheduleOpenChange={!isLg ? setAddScheduleOpen : undefined}
@@ -791,6 +791,7 @@ export default function TripDetailPage() {
               currentDayId={currentDay.id}
               currentPatternId={currentPattern.id}
               onRefresh={onMutate}
+              onCacheWritten={onCacheWritten}
               disabled={!online || !canEdit}
               draggable={false}
               addDialogOpen={!isLg ? addCandidateOpen : false}
@@ -870,7 +871,7 @@ export default function TripDetailPage() {
                 isConnected={isConnected}
                 online={online}
                 canEdit={canEdit}
-                onMutate={onMutate}
+                onCacheWritten={onCacheWritten}
                 onEditOpen={() => setEditOpen(true)}
                 onOpenBookmarks={
                   isGuest
@@ -978,7 +979,7 @@ export default function TripDetailPage() {
                           date={currentDay.date}
                           schedules={dnd.localSchedules}
                           onRefresh={onMutate}
-                          onScheduleAdded={onScheduleAdded}
+                          onScheduleAdded={onCacheWritten}
                           disabled={!online || !canEdit}
                           addScheduleOpen={isLg ? addScheduleOpen : false}
                           onAddScheduleOpenChange={isLg ? setAddScheduleOpen : undefined}
@@ -1028,6 +1029,7 @@ export default function TripDetailPage() {
                     currentDayId={currentDay?.id ?? null}
                     currentPatternId={currentPattern?.id ?? null}
                     onRefresh={onMutate}
+                    onCacheWritten={onCacheWritten}
                     disabled={!online || !canEdit}
                     canEdit={canEdit}
                     online={online}

--- a/apps/web/app/(sp)/sp/trips/[id]/page.tsx
+++ b/apps/web/app/(sp)/sp/trips/[id]/page.tsx
@@ -163,7 +163,7 @@ export default function SpTripDetailPage() {
 
   // Mutation callbacks: refetch + broadcast to other clients (see hook for
   // why schedule adds and reorders skip the refetch, #123 / #166)
-  const { onMutate, onScheduleAdded, onSchedulesReordered, onCandidatesReordered } =
+  const { onMutate, onCacheWritten, onSchedulesReordered, onCandidatesReordered } =
     useTripMutationCallbacks({
       tripId: tripId ?? "",
       invalidateTrip,
@@ -370,7 +370,7 @@ export default function SpTripDetailPage() {
                   date={currentDay.date}
                   schedules={dnd.localSchedules}
                   onRefresh={onMutate}
-                  onScheduleAdded={onScheduleAdded}
+                  onScheduleAdded={onCacheWritten}
                   disabled={!online || !canEdit}
                   addScheduleOpen={addScheduleOpen}
                   onAddScheduleOpenChange={setAddScheduleOpen}
@@ -419,6 +419,7 @@ export default function SpTripDetailPage() {
               currentDayId={currentDay?.id}
               currentPatternId={currentPattern?.id}
               onRefresh={onMutate}
+              onCacheWritten={onCacheWritten}
               disabled={!online || !canEdit}
               draggable={false}
               addDialogOpen={addCandidateOpen}
@@ -558,7 +559,7 @@ export default function SpTripDetailPage() {
                   isConnected={isConnected}
                   online={online}
                   canEdit={canEdit}
-                  onMutate={onMutate}
+                  onCacheWritten={onCacheWritten}
                   onEditOpen={() => setEditOpen(true)}
                   onOpenBookmarks={
                     isGuest

--- a/apps/web/components/candidate-panel.tsx
+++ b/apps/web/components/candidate-panel.tsx
@@ -36,7 +36,7 @@ import { api } from "@/lib/api";
 import { useSelection } from "@/lib/hooks/selection-context";
 import { useMobile } from "@/lib/hooks/use-is-mobile";
 import { queryKeys } from "@/lib/query-keys";
-import { moveCandidateToSchedule, removeCandidate } from "@/lib/trip-cache";
+import { moveCandidateToSchedule, removeCandidate, setCandidateReaction } from "@/lib/trip-cache";
 import { CandidateList } from "./candidate-list";
 
 const AddCandidateDialog = dynamic(() =>
@@ -56,7 +56,13 @@ type CandidatePanelProps = {
   candidates: CandidateResponse[];
   currentDayId?: string;
   currentPatternId?: string;
+  // Refetches the trip. Used by assign, which needs the server-assigned
+  // sortOrder that the optimistic update can't know.
   onRefresh: () => void;
+  // For mutations that write the server-confirmed result into the cache
+  // themselves (delete, react): skips the refetch so a stale read can't
+  // clobber the just-written entry (#155). Broadcasts + refreshes logs only.
+  onCacheWritten: () => void;
   disabled?: boolean;
   draggable?: boolean;
   scheduleLimitReached?: boolean;
@@ -78,6 +84,7 @@ export function CandidatePanel({
   currentDayId,
   currentPatternId,
   onRefresh,
+  onCacheWritten,
   disabled,
   draggable,
   scheduleLimitReached,
@@ -165,7 +172,9 @@ export function CandidatePanel({
       await api(`/api/trips/${tripId}/candidates/${spotId}`, {
         method: "DELETE",
       });
-      onRefresh();
+      // removeCandidate produced the complete post-delete state, so skip the
+      // refetch (#155): a stale GET could otherwise resurrect the candidate.
+      onCacheWritten();
     } catch {
       if (prev) queryClient.setQueryData(cacheKey, prev);
       toast.error(tm("candidateDeleteFailed"));
@@ -192,11 +201,17 @@ export function CandidatePanel({
       };
     });
     try {
-      await api(`/api/trips/${tripId}/candidates/${scheduleId}/reaction`, {
-        method: "PUT",
-        body: JSON.stringify({ type }),
-      });
-      onRefresh();
+      // The server returns authoritative counts (other users may have reacted
+      // concurrently). Write them in so the optimistic delta is reconciled
+      // without a refetch that could clobber it with a stale read (#155).
+      const counts = await api<{ likeCount: number; hmmCount: number }>(
+        `/api/trips/${tripId}/candidates/${scheduleId}/reaction`,
+        { method: "PUT", body: JSON.stringify({ type }) },
+      );
+      queryClient.setQueryData(cacheKey, (old: TripResponse | undefined) =>
+        old ? setCandidateReaction(old, scheduleId, type, counts) : old,
+      );
+      onCacheWritten();
     } catch {
       if (prev) queryClient.setQueryData(cacheKey, prev);
       toast.error(tm("reactionFailed"));
@@ -222,10 +237,14 @@ export function CandidatePanel({
       };
     });
     try {
-      await api(`/api/trips/${tripId}/candidates/${scheduleId}/reaction`, {
-        method: "DELETE",
-      });
-      onRefresh();
+      const counts = await api<{ likeCount: number; hmmCount: number }>(
+        `/api/trips/${tripId}/candidates/${scheduleId}/reaction`,
+        { method: "DELETE" },
+      );
+      queryClient.setQueryData(cacheKey, (old: TripResponse | undefined) =>
+        old ? setCandidateReaction(old, scheduleId, null, counts) : old,
+      );
+      onCacheWritten();
     } catch {
       if (prev) queryClient.setQueryData(cacheKey, prev);
       toast.error(tm("reactionRemoveFailed"));
@@ -429,7 +448,8 @@ export function CandidatePanel({
           onOpenChange={(open) => {
             if (!open) setEditSchedule(null);
           }}
-          onUpdate={onRefresh}
+          onSaved={onCacheWritten}
+          onConflict={onRefresh}
           maxEndDayOffset={maxEndDayOffset}
         />
       )}

--- a/apps/web/components/candidate-panel.tsx
+++ b/apps/web/components/candidate-panel.tsx
@@ -56,8 +56,10 @@ type CandidatePanelProps = {
   candidates: CandidateResponse[];
   currentDayId?: string;
   currentPatternId?: string;
-  // Refetches the trip. Used by assign, which needs the server-assigned
-  // sortOrder that the optimistic update can't know.
+  // Refetches the trip. Used where the optimistic write can't know the final
+  // server state: assign (server-assigned sortOrder), add-candidate, and
+  // edit-candidate conflict recovery. delete / react write complete state
+  // and use onCacheWritten instead.
   onRefresh: () => void;
   // For mutations that write the server-confirmed result into the cache
   // themselves (delete, react): skips the refetch so a stale read can't

--- a/apps/web/components/edit-candidate-dialog.tsx
+++ b/apps/web/components/edit-candidate-dialog.tsx
@@ -118,7 +118,7 @@ export function EditCandidateDialog({
 
     const { expectedUpdatedAt: _, ...updateFields } = data;
 
-    queryClient.cancelQueries({ queryKey: cacheKey });
+    await queryClient.cancelQueries({ queryKey: cacheKey });
     const prev = queryClient.getQueryData<TripResponse>(cacheKey);
     if (prev) {
       queryClient.setQueryData(
@@ -143,8 +143,13 @@ export function EditCandidateDialog({
           cacheKey,
           updateCandidate(fresh, schedule.id, toCandidateResponse(updated)),
         );
+        onSaved();
+      } else {
+        // The cache was evicted during the round-trip, so the server's fresh
+        // updatedAt isn't stored. Refetch to recover it; otherwise the next
+        // edit would send a stale expectedUpdatedAt and hit a spurious 409.
+        onConflict();
       }
-      onSaved();
     } catch (err) {
       if (prev) queryClient.setQueryData(cacheKey, prev);
       if (err instanceof ApiError && (err.status === 409 || err.status === 404)) {

--- a/apps/web/components/edit-candidate-dialog.tsx
+++ b/apps/web/components/edit-candidate-dialog.tsx
@@ -33,7 +33,12 @@ type EditCandidateDialogProps = {
   schedule: ScheduleResponse;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onUpdate: () => void;
+  // Called after the server-confirmed row is written into the cache; skips
+  // the refetch (#155).
+  onSaved: () => void;
+  // Called on an optimistic-lock conflict (409/404), where the cache is stale
+  // and a refetch is required to recover the true state.
+  onConflict: () => void;
   maxEndDayOffset?: number;
 };
 
@@ -42,7 +47,8 @@ export function EditCandidateDialog({
   schedule,
   open,
   onOpenChange,
-  onUpdate,
+  onSaved,
+  onConflict,
   maxEndDayOffset = 0,
 }: EditCandidateDialogProps) {
   const tm = useTranslations("messages");
@@ -124,16 +130,26 @@ export function EditCandidateDialog({
     toast.success(tm("candidateUpdated"));
 
     try {
-      await api(`/api/trips/${tripId}/candidates/${schedule.id}`, {
-        method: "PATCH",
-        body: JSON.stringify(data),
-      });
-      onUpdate();
+      // Reconcile the cache with the server-confirmed row (fresh updatedAt for
+      // the next optimistic-lock check) and skip the refetch (#155). The
+      // optimistic write above gives instant feedback; this corrects it.
+      const updated = await api<Record<string, unknown>>(
+        `/api/trips/${tripId}/candidates/${schedule.id}`,
+        { method: "PATCH", body: JSON.stringify(data) },
+      );
+      const fresh = queryClient.getQueryData<TripResponse>(cacheKey);
+      if (fresh) {
+        queryClient.setQueryData(
+          cacheKey,
+          updateCandidate(fresh, schedule.id, toCandidateResponse(updated)),
+        );
+      }
+      onSaved();
     } catch (err) {
       if (prev) queryClient.setQueryData(cacheKey, prev);
       if (err instanceof ApiError && (err.status === 409 || err.status === 404)) {
         toast.error(err.status === 409 ? tm("conflict") : tm("conflictDeleted"));
-        onUpdate();
+        onConflict();
       } else {
         toast.error(tm("candidateUpdateFailed"));
       }

--- a/apps/web/lib/__tests__/trip-cache.test.ts
+++ b/apps/web/lib/__tests__/trip-cache.test.ts
@@ -15,6 +15,7 @@ import {
   removeScheduleFromPattern,
   reorderCandidates,
   reorderSchedulesInPattern,
+  setCandidateReaction,
   toCandidateResponse,
   toScheduleResponse,
   updateCandidate,
@@ -295,6 +296,49 @@ describe("removeCandidate", () => {
     const result = removeCandidate(trip, "nonexistent");
 
     expect(result).toBe(trip);
+  });
+});
+
+describe("setCandidateReaction", () => {
+  it("writes the server counts and the user's reaction onto the candidate", () => {
+    const trip = makeTrip({
+      candidates: [makeCandidate({ id: "c1", likeCount: 0, hmmCount: 0, myReaction: null })],
+    });
+
+    const result = setCandidateReaction(trip, "c1", "like", { likeCount: 5, hmmCount: 2 });
+
+    expect(result.candidates[0]).toMatchObject({
+      myReaction: "like",
+      likeCount: 5,
+      hmmCount: 2,
+    });
+  });
+
+  it("clears the reaction while still applying the server counts", () => {
+    const trip = makeTrip({
+      candidates: [makeCandidate({ id: "c1", likeCount: 3, hmmCount: 1, myReaction: "like" })],
+    });
+
+    const result = setCandidateReaction(trip, "c1", null, { likeCount: 2, hmmCount: 1 });
+
+    expect(result.candidates[0]).toMatchObject({
+      myReaction: null,
+      likeCount: 2,
+      hmmCount: 1,
+    });
+  });
+
+  it("leaves other candidates untouched", () => {
+    const trip = makeTrip({
+      candidates: [
+        makeCandidate({ id: "c1", likeCount: 0 }),
+        makeCandidate({ id: "c2", likeCount: 9, myReaction: "hmm" }),
+      ],
+    });
+
+    const result = setCandidateReaction(trip, "c1", "like", { likeCount: 1, hmmCount: 0 });
+
+    expect(result.candidates[1]).toMatchObject({ likeCount: 9, myReaction: "hmm" });
   });
 });
 

--- a/apps/web/lib/hooks/use-trip-mutation-callbacks.test.ts
+++ b/apps/web/lib/hooks/use-trip-mutation-callbacks.test.ts
@@ -62,40 +62,40 @@ describe("useTripMutationCallbacks", () => {
     expect(mockInvalidateQueries).not.toHaveBeenCalled();
   });
 
-  // Reproduction for #123: the add-schedule dialog has already written the
-  // server-confirmed schedule into the cache. An immediate trip-detail refetch
-  // can return a stale snapshot and clobber that entry, so the schedule-added
+  // Reproduction for #123 / #155: the caller has already written the
+  // server-confirmed result into the cache. An immediate trip-detail refetch
+  // can return a stale snapshot and clobber that entry, so the cache-written
   // callback must NOT trigger one.
-  it("onScheduleAdded does not refetch the trip detail", async () => {
+  it("onCacheWritten does not refetch the trip detail", async () => {
     const { result } = setup();
 
-    await act(() => result.current.onScheduleAdded());
+    await act(() => result.current.onCacheWritten());
 
     expect(invalidateTrip).not.toHaveBeenCalled();
   });
 
-  it("onScheduleAdded does not invalidate the trip detail query key", async () => {
+  it("onCacheWritten does not invalidate the trip detail query key", async () => {
     const { result } = setup();
 
-    await act(() => result.current.onScheduleAdded());
+    await act(() => result.current.onCacheWritten());
 
     expect(mockInvalidateQueries).not.toHaveBeenCalledWith({
       queryKey: ["trips", "t1"],
     });
   });
 
-  it("onScheduleAdded broadcasts the change to other clients", async () => {
+  it("onCacheWritten broadcasts the change to other clients", async () => {
     const { result } = setup();
 
-    await act(() => result.current.onScheduleAdded());
+    await act(() => result.current.onCacheWritten());
 
     expect(broadcastChange).toHaveBeenCalledTimes(1);
   });
 
-  it("onScheduleAdded invalidates the activity logs", async () => {
+  it("onCacheWritten invalidates the activity logs", async () => {
     const { result } = setup();
 
-    await act(() => result.current.onScheduleAdded());
+    await act(() => result.current.onCacheWritten());
 
     expect(mockInvalidateQueries).toHaveBeenCalledWith({
       queryKey: ["trips", "t1", "activity-logs"],

--- a/apps/web/lib/hooks/use-trip-mutation-callbacks.ts
+++ b/apps/web/lib/hooks/use-trip-mutation-callbacks.ts
@@ -16,19 +16,20 @@ import {
  * `onMutate` is the default: refetch the trip, broadcast to other clients,
  * and refresh the activity logs.
  *
- * `onScheduleAdded` exists because the add-schedule dialog writes the
- * server-confirmed POST response into the cache itself. Refetching the trip
+ * `onCacheWritten` is for mutations that have already written the
+ * server-confirmed result into the trip cache themselves (add / edit /
+ * delete dialogs, candidate panel, status change). Refetching the trip
  * right after can return a stale GET (Supavisor read-after-write lag, SW or
- * IndexedDB snapshots) that clobbers the just-added schedule (#123), so this
- * variant skips the trip-detail invalidation and only broadcasts + refreshes
- * the activity logs.
+ * IndexedDB snapshots) that clobbers the just-written entry (#123 / #155),
+ * so this variant skips the trip-detail invalidation and only broadcasts +
+ * refreshes the activity logs.
  *
  * `onSchedulesReordered` / `onCandidatesReordered` apply the same principle
  * to the reorder endpoints (#166): the client already knows the confirmed
  * order, so it is written into the cache directly instead of refetched —
  * an immediate GET after the PATCH can return a stale read that visually
  * reverts the reorder. Reordering writes no activity log, so unlike
- * `onScheduleAdded` there is nothing else to refresh.
+ * `onCacheWritten` there is nothing else to refresh.
  */
 export function useTripMutationCallbacks({
   tripId,
@@ -49,7 +50,7 @@ export function useTripMutationCallbacks({
     broadcastChange();
   }, [invalidateTrip, broadcastChange]);
 
-  const onScheduleAdded = useCallback(async () => {
+  const onCacheWritten = useCallback(async () => {
     broadcastChange();
     await queryClient.invalidateQueries({ queryKey: queryKeys.trips.activityLogs(tripId) });
   }, [broadcastChange, queryClient, tripId]);
@@ -100,5 +101,5 @@ export function useTripMutationCallbacks({
     [queryClient, tripId, invalidateTrip, broadcastChange],
   );
 
-  return { onMutate, onScheduleAdded, onSchedulesReordered, onCandidatesReordered };
+  return { onMutate, onCacheWritten, onSchedulesReordered, onCandidatesReordered };
 }

--- a/apps/web/lib/trip-cache.ts
+++ b/apps/web/lib/trip-cache.ts
@@ -238,6 +238,29 @@ export function updateCandidate(
   };
 }
 
+/**
+ * Apply a confirmed reaction change to a cached candidate. `counts` are the
+ * server's authoritative like/hmm totals (other users may have reacted
+ * concurrently); `myReaction` is the current user's own state. Written
+ * directly into the cache so the optimistic delta is reconciled without a
+ * refetch that could clobber it with a stale read (#155).
+ */
+export function setCandidateReaction(
+  trip: TripResponse,
+  candidateId: string,
+  myReaction: "like" | "hmm" | null,
+  counts: { likeCount: number; hmmCount: number },
+): TripResponse {
+  return {
+    ...trip,
+    candidates: trip.candidates.map((c) =>
+      c.id === candidateId
+        ? { ...c, myReaction, likeCount: counts.likeCount, hmmCount: counts.hmmCount }
+        : c,
+    ),
+  };
+}
+
 export function removeCandidate(trip: TripResponse, scheduleId: string): TripResponse {
   if (!trip.candidates.some((c) => c.id === scheduleId)) return trip;
 


### PR DESCRIPTION
## Summary
- trip 詳細キャッシュで「cache 書き込み直後の refetch が stale read で書き込みを巻き戻す」transient な窓 (#155) の残存経路のうち、サーバー確定データを cache に書ける操作を refetch なしに切り替えた
- 対象: 候補スポットの delete / react / removeReaction / edit、旅行ステータス変更
- #123/#154/#166 で確立した「cache 直接書き込み + skip refetch」パターンの一般化

## Why
- `setQueryData` 直後に `invalidateTrip` が走ると、Supavisor の read-after-write lag による stale GET が楽観的書き込みを巻き戻しうる(#155 が列挙した残存経路)。発生は一過性・自己修復だが、co-editing 利用時に体感ブレの原因になる
- クライアントが確定状態を完全に知れる操作は、refetch せず cache に直接書けば窓自体が生じない。`onScheduleAdded`(#123)/`onSchedulesReordered`(#166)と同じ考え方を candidate 操作と status に展開した

## Changes
- **`onScheduleAdded` → `onCacheWritten` に一般化**(use-trip-mutation-callbacks.ts): add 専用ではなく cache-written 系の共通コールバックに。broadcast + activity-logs invalidate のみで trip detail は refetch しない
- **`setCandidateReaction` ヘルパー追加**(trip-cache.ts): サーバーの権威的 like/hmm counts と myReaction を cache に反映
- **candidate-panel**: delete は `removeCandidate` で完結するため skip。react/removeReaction はサーバー counts を書いて skip。**assign は server 採番の sortOrder が必要なため refetch を維持**
- **edit-candidate-dialog**: 成功時はサーバー行(fresh updatedAt)を cache に書いて skip、楽観ロック衝突(409/404)時のみ refetch するよう `onSaved`/`onConflict` に分離。cache evict 時も refetch にフォールバック
- **trip-actions のステータス変更**: 楽観値が完全なため skip。trip-header 経由で配線し、未使用化した `onMutate` を除去
- 両 trip 詳細ページ(desktop/SP)・right-panel の prop 配線

## Test plan
- [x] `setCandidateReaction` 3 件(counts+reaction 反映 / クリア / 他候補不変)
- [x] `onCacheWritten` のリネームに伴う mutation-callbacks テスト更新(refetch しない / broadcast / activity-logs invalidate)
- [x] 全パッケージ green: web 830 / api 858 / shared 248 / mcp 95、`bun run check` / `check-types` pass
- [ ] コンポーネントレベルのテストは元々存在せず本 PR でも追加しない(新ロジックの reaction counts 反映は純粋ヘルパー `setCandidateReaction` に切り出して単体テスト済み)

## Notes for reviewer
- code-reviewer の事前レビュー済み(blocking 0、approve)。指摘 Minor 1-3(onRefresh コメント / `await cancelQueries` / cache evict 時の 409 回避フォールバック)は反映済み
- **本 PR は #155 の partial**。意図的に残した残存経路:
  - **edit-schedule-dialog**: `onUpdate` が day-timeline → schedule-items を貫いて配線されており、edit だけを分離するコストが高いため据え置き
  - **candidate assign / add-candidate**: server 採番 sortOrder に依存するため refetch を維持
  - **class-2(broadcast / visibilitychange / online 由来の refetch)**: 協調編集者の更新を遅延させる懸念があるため対象外
- これらは #155 に残課題として残す

## Related
- Refs #155(partial)
- 関連パターン: #123 / #154 / #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)