### PR TITLE
fix: adminページのstats応答をfail-closedに統一 (#165)

### DIFF
--- a/apps/web/app/admin/__tests__/page.test.tsx
+++ b/apps/web/app/admin/__tests__/page.test.tsx
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const NOT_FOUND = "NEXT_NOT_FOUND";
+
+vi.mock("next/headers", () => ({
+  cookies: () => Promise.resolve({ toString: () => "session=abc" }),
+}));
+
+vi.mock("next/navigation", () => ({
+  notFound: () => {
+    throw new Error(NOT_FOUND);
+  },
+}));
+
+vi.mock("../_components/admin-client", () => ({
+  default: () => null,
+}));
+
+import AdminPage from "../page";
+
+function mockFetchStatus(status: number) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(() => Promise.resolve(new Response(null, { status }))),
+  );
+}
+
+describe("AdminPage server-side authorization", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("renders the client shell when stats returns 200", async () => {
+    mockFetchStatus(200);
+    await expect(AdminPage()).resolves.toBeDefined();
+  });
+
+  it.each([
+    401, 403, 429, 500, 503,
+  ])("calls notFound() when stats returns %i (fail-closed)", async (status) => {
+    mockFetchStatus(status);
+    await expect(AdminPage()).rejects.toThrow(NOT_FOUND);
+  });
+
+  it("calls notFound() when the stats fetch throws", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.reject(new Error("network down"))),
+    );
+    await expect(AdminPage()).rejects.toThrow(NOT_FOUND);
+  });
+});

--- a/apps/web/app/admin/page.tsx
+++ b/apps/web/app/admin/page.tsx
@@ -7,18 +7,20 @@ export default async function AdminPage() {
   const cookieHeader = cookieStore.toString();
   const baseUrl = process.env.BETTER_AUTH_BASE_URL ?? "http://localhost:3000";
 
-  // Server-side admin authorization: non-admin users never receive client code
-  try {
-    const res = await fetch(`${baseUrl}/api/admin/stats`, {
-      headers: { cookie: cookieHeader },
-      cache: "no-store",
-      signal: AbortSignal.timeout(5000),
-    });
+  // Server-side admin authorization: non-admin users never receive client code.
+  // Scope the try to the fetch only, so a network failure resolves to a null
+  // response — otherwise notFound()'s internal throw would be swallowed by the
+  // catch and re-fired, blurring "request failed" and "intentional not-found".
+  const res = await fetch(`${baseUrl}/api/admin/stats`, {
+    headers: { cookie: cookieHeader },
+    cache: "no-store",
+    signal: AbortSignal.timeout(5000),
+  }).catch(() => null);
 
-    if (res.status === 401 || res.status === 403) {
-      notFound();
-    }
-  } catch {
+  // Fail closed: only a 200 proves the caller is an authorized admin. 429 (rate
+  // limit), 5xx, and network failures say nothing about authorization, so treat
+  // any non-OK response as not-found rather than rendering the admin shell.
+  if (!res?.ok) {
     notFound();
   }
 


### PR DESCRIPTION
## Summary

admin ページの Server Component (`apps/web/app/admin/page.tsx`) は `/api/admin/stats` の応答が **401/403 のときのみ** `notFound()` していた。429(レート制限)や 5xx の場合は `notFound()` されず `<AdminClient />`(データ非埋め込みの空シェル)を描画していた。

機微データの SSR 埋め込みはないため実害はない (Low / informational) が、admin ガードとしての一貫性に欠ける。`!res.ok` で 200 以外を一律 not-found 扱いにし、**fail-closed** に統一する。

あわせて `try` のスコープを fetch のみに絞り、ネットワーク失敗は `null` 応答に解決させる。従来は `notFound()` の内部 throw を `catch` が握りつぶして再発火する構造で、「リクエスト失敗」と「意図的 notFound」が区別できなかった。

Closes #165

## Test plan

- `apps/web/app/admin/__tests__/page.test.tsx` を追加
  - 200 → admin shell を描画
  - 401 / 403 / 429 / 500 / 503 → `notFound()` (fail-closed)
  - fetch が throw(ネットワーク障害) → `notFound()`
- `bun run --filter @sugara/web test -- app/admin` green
- `bun run --filter @sugara/web check` / `check-types` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)