### PR TITLE
feat: 204エンドポイントへのapi()誤用をCIで静的検出 (#151)

### DIFF
--- a/apps/web/lib/__tests__/no-content-endpoints.test.ts
+++ b/apps/web/lib/__tests__/no-content-endpoints.test.ts
@@ -1,0 +1,184 @@
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  matchesNoContentEndpoint,
+  NO_CONTENT_ENDPOINTS,
+  normalizeApiPath,
+} from "../no-content-endpoints";
+
+const WEB_ROOT = path.resolve(__dirname, "../..");
+const SCAN_DIRS = ["app", "components", "lib"];
+
+function listSourceFiles(dir: string): string[] {
+  const entries = readdirSync(dir, { withFileTypes: true, recursive: true });
+  return entries
+    .filter((e) => e.isFile())
+    .map((e) => path.join(e.parentPath, e.name))
+    .filter((p) => /\.(ts|tsx)$/.test(p))
+    .filter((p) => !/\.test\.(ts|tsx)$/.test(p))
+    .filter((p) => !p.includes(`${path.sep}__tests__${path.sep}`));
+}
+
+// Extract the substring inside the parentheses of a call starting at `openIdx`
+// (the index of the `(`), honoring string/template literals and nested brackets
+// so parens inside strings or nested calls do not end the scan early.
+function extractCallArgs(src: string, openIdx: number): string | null {
+  let depth = 0;
+  // A template literal is treated as an opaque quoted span: `${...}` inside the
+  // call paths in this codebase never nests further backticks, so collapsing the
+  // whole literal to a string is enough to keep paren counting accurate.
+  let quote: string | null = null;
+  for (let i = openIdx; i < src.length; i++) {
+    const ch = src[i];
+    const prev = src[i - 1];
+    if (quote) {
+      if (ch === quote && prev !== "\\") quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      quote = ch;
+      continue;
+    }
+    if (ch === "(" || ch === "[" || ch === "{") depth++;
+    else if (ch === ")" || ch === "]" || ch === "}") {
+      depth--;
+      if (depth === 0) return src.slice(openIdx + 1, i);
+    }
+  }
+  return null;
+}
+
+// Pull the leading string/template literal (the path argument) out of a call's
+// argument list. Returns null when the first argument is not a literal — those
+// dynamic call sites cannot be analyzed statically and are skipped.
+function extractPathLiteral(args: string): string | null {
+  const trimmed = args.trimStart();
+  const first = trimmed[0];
+  if (first !== '"' && first !== "'" && first !== "`") return null;
+  for (let i = 1; i < trimmed.length; i++) {
+    if (trimmed[i] === first && trimmed[i - 1] !== "\\") {
+      return trimmed.slice(1, i);
+    }
+  }
+  return null;
+}
+
+function extractMethod(args: string): string {
+  const m = args.match(/method\s*:\s*["'`]([A-Za-z]+)["'`]/);
+  return m ? m[1] : "GET";
+}
+
+type CallSite = { file: string; method: string; rawPath: string; normalized: string };
+
+// Match `api(` and `api<T>(` calls but not `apiVoid(`, member access (`.api(`),
+// or identifiers that merely end in `api`.
+const API_CALL_RE = /(?<![\w$.])api\s*(?:<[^(]*>)?\s*\(/g;
+
+function scanApiCalls(src: string, file: string): CallSite[] {
+  const calls: CallSite[] = [];
+  for (const match of src.matchAll(API_CALL_RE)) {
+    const openIdx = src.indexOf("(", match.index + "api".length);
+    if (openIdx === -1) continue;
+    const args = extractCallArgs(src, openIdx);
+    if (args === null) continue;
+    const rawPath = extractPathLiteral(args);
+    if (rawPath === null) continue;
+    calls.push({
+      file,
+      method: extractMethod(args),
+      rawPath,
+      normalized: normalizeApiPath(rawPath),
+    });
+  }
+  return calls;
+}
+
+function collectAllApiCalls(): CallSite[] {
+  const calls: CallSite[] = [];
+  for (const dir of SCAN_DIRS) {
+    for (const file of listSourceFiles(path.join(WEB_ROOT, dir))) {
+      calls.push(...scanApiCalls(readFileSync(file, "utf8"), path.relative(WEB_ROOT, file)));
+    }
+  }
+  return calls;
+}
+
+// Build the literal text "${name}" without writing the placeholder inline,
+// which would otherwise trip biome's noTemplateCurlyInString on these
+// intentional `${...}`-in-a-string fixtures.
+const ph = (name: string) => `$${"{"}${name}}`;
+
+describe("no-content endpoint guard", () => {
+  it("the scanner is wired correctly (finds api() calls and parses them)", () => {
+    const calls = collectAllApiCalls();
+    // A silent zero would make the guard below vacuously pass.
+    expect(calls.length).toBeGreaterThan(10);
+
+    const sample = scanApiCalls(
+      `api(\`/api/quick-polls/${ph("id")}\`, { method: "DELETE" });`,
+      "synthetic.ts",
+    );
+    expect(sample).toEqual([
+      {
+        file: "synthetic.ts",
+        method: "DELETE",
+        rawPath: `/api/quick-polls/${ph("id")}`,
+        normalized: "/api/quick-polls/:param",
+      },
+    ]);
+
+    // apiVoid() must not be picked up as an api() call.
+    expect(scanApiCalls('apiVoid("/api/account", { method: "DELETE" })', "s.ts")).toEqual([]);
+  });
+
+  it("normalizes template and :id path segments to :param", () => {
+    expect(normalizeApiPath(`/api/trips/${ph("tripId")}/expenses/${ph("expenseId")}`)).toBe(
+      "/api/trips/:param/expenses/:param",
+    );
+    expect(normalizeApiPath("/api/quick-polls/:id")).toBe("/api/quick-polls/:param");
+    expect(normalizeApiPath(`/api/expenses?tripId=${ph("id")}`)).toBe("/api/expenses");
+  });
+
+  it("flags a known 204 DELETE but not the same path under GET", () => {
+    expect(matchesNoContentEndpoint("DELETE", "/api/quick-polls/:param")).toBe(true);
+    expect(matchesNoContentEndpoint("GET", "/api/quick-polls/:param")).toBe(false);
+    expect(matchesNoContentEndpoint("DELETE", "/api/quick-polls")).toBe(false);
+  });
+
+  it("no api<T>() call targets a 204 No Content endpoint (use apiVoid instead)", () => {
+    const violations = collectAllApiCalls().filter((c) =>
+      matchesNoContentEndpoint(c.method, c.normalized),
+    );
+    const detail = violations
+      .map((v) => `  ${v.file}: api(${v.method} ${v.rawPath}) — should be apiVoid()`)
+      .join("\n");
+    expect(violations, `api() used against 204 endpoints:\n${detail}`).toEqual([]);
+  });
+
+  it("every registered 204 endpoint is exercised by an apiVoid() call site", () => {
+    // Guards against the list drifting stale: if an endpoint stops being called
+    // via apiVoid (renamed/removed), the entry should be updated or dropped.
+    const apiVoidPaths = new Set<string>();
+    for (const dir of SCAN_DIRS) {
+      for (const file of listSourceFiles(path.join(WEB_ROOT, dir))) {
+        const src = readFileSync(file, "utf8");
+        for (const match of src.matchAll(/apiVoid\s*\(/g)) {
+          const openIdx = src.indexOf("(", match.index + "apiVoid".length);
+          const args = extractCallArgs(src, openIdx);
+          if (!args) continue;
+          const rawPath = extractPathLiteral(args);
+          if (rawPath === null) continue;
+          apiVoidPaths.add(`${extractMethod(args)} ${normalizeApiPath(rawPath)}`);
+        }
+      }
+    }
+    const uncovered = NO_CONTENT_ENDPOINTS.filter(
+      (e) =>
+        ![...apiVoidPaths].some(
+          (p) => p.startsWith(`${e.method} `) && e.pattern.test(p.slice(e.method.length + 1)),
+        ),
+    );
+    expect(uncovered.map((e) => `${e.method} ${e.pattern}`)).toEqual([]);
+  });
+});

--- a/apps/web/lib/no-content-endpoints.ts
+++ b/apps/web/lib/no-content-endpoints.ts
@@ -1,0 +1,48 @@
+// Single source of truth for API endpoints that respond `204 No Content`.
+//
+// Client calls to these MUST use `apiVoid()`, never `api<T>()`. `api<T>()`
+// expects a JSON body, so calling it against a 204 endpoint trips the runtime
+// guard in `lib/api.ts` and surfaces a developer-facing error to the user
+// (this regressed in PR #88 / fixed in PR #148). `api<void>()` also type-checks
+// fine, so the type system cannot catch the mistake.
+//
+// `no-content-endpoints.test.ts` statically scans every `api()` call site in
+// the web app and fails CI if any of them targets one of these (method, path)
+// pairs — turning a runtime-only error into a build-time failure (#151).
+//
+// Keep this list in sync with the server routes that return 204
+// (`apps/api/src/routes/*`). Each `pattern` matches a *normalized* request path
+// where dynamic segments (`${id}`) are written as `:param`.
+
+export type NoContentEndpoint = {
+  method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+  pattern: RegExp;
+};
+
+export const NO_CONTENT_ENDPOINTS: readonly NoContentEndpoint[] = [
+  // DELETE /api/account — apps/api/src/routes/account.ts
+  { method: "DELETE", pattern: /^\/api\/account$/ },
+  // DELETE /api/quick-polls/:id — apps/api/src/routes/quick-polls.ts
+  { method: "DELETE", pattern: /^\/api\/quick-polls\/:param$/ },
+  // DELETE /api/trips/:tripId/souvenirs/:itemId — apps/api/src/routes/souvenirs.ts
+  { method: "DELETE", pattern: /^\/api\/trips\/:param\/souvenirs\/:param$/ },
+  // DELETE /api/trips/:tripId/settlement-payments/:paymentId — apps/api/src/routes/settlement-payments.ts
+  { method: "DELETE", pattern: /^\/api\/trips\/:param\/settlement-payments\/:param$/ },
+  // DELETE /api/trips/:tripId/expenses/:expenseId — apps/api/src/routes/expenses.ts
+  { method: "DELETE", pattern: /^\/api\/trips\/:param\/expenses\/:param$/ },
+];
+
+// Normalize a path extracted from source into the `:param` form the patterns
+// match: template substitutions (`${...}`) and `:id`-style segments collapse to
+// `:param`, and any trailing query string is dropped.
+export function normalizeApiPath(rawPath: string): string {
+  return rawPath
+    .replace(/\?.*$/, "")
+    .replace(/\$\{[^}]*\}/g, ":param")
+    .replace(/\/:[A-Za-z_][\w]*/g, "/:param");
+}
+
+export function matchesNoContentEndpoint(method: string, normalizedPath: string): boolean {
+  const upper = method.toUpperCase();
+  return NO_CONTENT_ENDPOINTS.some((e) => e.method === upper && e.pattern.test(normalizedPath));
+}


### PR DESCRIPTION
## Summary

204 No Content を返すエンドポイントは `apiVoid()` を使う必要があるが、`api<void>()` も型は通るため**型では守れない**。過去 PR #88 で souvenir DELETE の移行漏れが本番でユーザーに開発者向けエラーを露出させた(PR #148 で修正したが事後検知のみで本番到達は防げない)。

本 PR は誤用を **CI(test)で静的検出** する仕組みを導入する(Issue #151 の軽量案)。

- `apps/web/lib/no-content-endpoints.ts`: 204 を返す 5 エンドポイント(`method` + 正規化 `path` パターン)の**単一ソース定数** + `normalizeApiPath` / `matchesNoContentEndpoint` ヘルパー。サーバルート(`apps/api/src/routes/{account,quick-polls,souvenirs,settlement-payments,expenses}` の DELETE)と対応。
- `apps/web/lib/__tests__/no-content-endpoints.test.ts`: `app/` `components/` `lib/` 配下の全ソースを走査し、`api()` 呼び出し(`apiVoid()` は除外)の path/method を抽出。204 エンドポイントに一致したら fail。
  - `GET /api/quick-polls/:id`(JSON)と `DELETE /api/quick-polls/:id`(204)のように method で挙動が分かれるため method も照合する。
  - 逆方向(各 204 エンドポイントが `apiVoid()` で呼ばれているか)も検証し、リストの陳腐化を検出。
  - スキャナが silent no-op にならないよう、合成入力での自己検証と最低件数アサーションを含む。

## 受け入れ条件

- [x] 204 エンドポイントに対する `api()` 呼び出しが CI で検出される(test 失敗)
  - 一時的に `api(\`/api/quick-polls/\${id}\`, { method: "DELETE" })` を置いて red を確認済み

## Test plan

- `bun run --filter @sugara/web test -- lib/__tests__/no-content-endpoints.test.ts` green(5 tests)
- `bun run --filter @sugara/web check` / `check-types` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)