### PR TITLE
feat: v1 APIの残りの上限・競合409にreason/detailsを展開 (#159)

### DIFF
--- a/apps/api/src/__tests__/v1-write-routes.test.ts
+++ b/apps/api/src/__tests__/v1-write-routes.test.ts
@@ -10,6 +10,13 @@
 //   - PATCH /articles/:id: 404 when article owned by different user
 //   - POST /bookmark-lists/:listId/bookmarks: 404 when list owned by different user
 
+import {
+  MAX_ARTICLES_PER_USER,
+  MAX_BOOKMARK_LISTS_PER_USER,
+  MAX_BOOKMARKS_PER_LIST,
+  MAX_EXPENSES_PER_TRIP,
+  MAX_SCHEDULES_PER_TRIP,
+} from "@sugara/shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
@@ -415,6 +422,31 @@ describe("POST /trips/:tripId/days/:dayNumber/schedules", () => {
     // Assert
     expect(res.status).toBe(409);
     expect(body.error.code).toBe("conflict");
+    expect(body.error.reason).toBe("trip_has_no_days");
+  });
+
+  it("includes schedule_limit_reached reason and details.max when the schedule limit is hit", async () => {
+    // Arrange — trip has a day with a default pattern, but the schedule count is
+    // already at the per-trip ceiling so the transaction returns null.
+    mockVerifyApiKey.mockResolvedValue(WRITE_KEY);
+    mockCheckTripAccess.mockResolvedValue("editor");
+    mockDbQuery.tripDays.findMany.mockResolvedValue([
+      { id: "day-1", dayNumber: 1, patterns: [{ id: "pattern-1" }] },
+    ]);
+    mockGetScheduleCount.mockResolvedValue(MAX_SCHEDULES_PER_TRIP);
+
+    // Act
+    const res = await jsonPost(`/trips/${TRIP_ID}/days/1/schedules`, {
+      name: "Tokyo Tower",
+      category: "sightseeing",
+    });
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(409);
+    expect(body.error.code).toBe("conflict");
+    expect(body.error.reason).toBe("schedule_limit_reached");
+    expect(body.error.details).toEqual({ max: MAX_SCHEDULES_PER_TRIP });
   });
 });
 
@@ -472,6 +504,62 @@ describe("POST /trips/:tripId/expenses", () => {
     expect(json).not.toContain('"userId"');
     expect(json).not.toContain('"paidByUserId"');
     expect(json).not.toContain('"ownerId"');
+  });
+
+  it("includes trip_has_no_days reason when the trip is in scheduling mode", async () => {
+    // Arrange — day count is zero (scheduling/poll mode)
+    mockVerifyApiKey.mockResolvedValue(WRITE_KEY);
+    mockCheckTripAccess.mockResolvedValue("editor");
+    mockDbSelect.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([{ dayCount: 0 }]),
+      }),
+    });
+
+    // Act
+    const res = await jsonPost(`/trips/${TRIP_ID}/expenses`, {
+      title: "Dinner",
+      amount: 1000,
+      paidByMemberNo: 1,
+      splitType: "equal",
+      splits: [{ memberNo: 1 }],
+    });
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(409);
+    expect(body.error.code).toBe("conflict");
+    expect(body.error.reason).toBe("trip_has_no_days");
+  });
+
+  it("includes expense_limit_reached reason and details.max when the expense limit is hit", async () => {
+    // Arrange — service reports the per-trip expense ceiling
+    mockVerifyApiKey.mockResolvedValue(WRITE_KEY);
+    mockCheckTripAccess.mockResolvedValue("editor");
+    mockDbSelect.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([{ dayCount: 1 }]),
+      }),
+    });
+    mockDbQuery.tripMembers.findMany.mockResolvedValue(MEMBER_ROWS);
+    mockDbQuery.users.findFirst.mockResolvedValue({ name: "Alice" });
+    mockCreateExpenseCore.mockResolvedValue({ ok: false, error: "limit_reached" });
+
+    // Act
+    const res = await jsonPost(`/trips/${TRIP_ID}/expenses`, {
+      title: "Dinner",
+      amount: 1000,
+      paidByMemberNo: 1,
+      splitType: "equal",
+      splits: [{ memberNo: 1 }, { memberNo: 2 }],
+    });
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(409);
+    expect(body.error.code).toBe("conflict");
+    expect(body.error.reason).toBe("expense_limit_reached");
+    expect(body.error.details).toEqual({ max: MAX_EXPENSES_PER_TRIP });
   });
 
   it("returns 400 when paidByMemberNo does not match any trip member", async () => {
@@ -573,6 +661,82 @@ describe("POST /bookmark-lists/:listId/bookmarks", () => {
     // Assert
     expect(res.status).toBe(404);
     expect(body.error.code).toBe("not_found");
+  });
+
+  it("includes bookmark_limit_reached reason and details.max when the per-list limit is hit", async () => {
+    // Arrange — list is owned, but bookmark count is already at the ceiling
+    mockVerifyApiKey.mockResolvedValue({ ...WRITE_KEY, scopes: ["bookmarks:write"] });
+    mockVerifyListOwnership.mockResolvedValue({ id: LIST_ID, userId: USER_ID_1 });
+    mockDbSelect.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([{ bCount: MAX_BOOKMARKS_PER_LIST }]),
+      }),
+    });
+
+    // Act
+    const res = await jsonPost(`/bookmark-lists/${LIST_ID}/bookmarks`, {
+      name: "My Place",
+      urls: [],
+    });
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(409);
+    expect(body.error.code).toBe("conflict");
+    expect(body.error.reason).toBe("bookmark_limit_reached");
+    expect(body.error.details).toEqual({ max: MAX_BOOKMARKS_PER_LIST });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /bookmark-lists — limit
+// ---------------------------------------------------------------------------
+
+describe("POST /bookmark-lists", () => {
+  it("includes bookmark_list_limit_reached reason and details.max when the account limit is hit", async () => {
+    // Arrange — list count is already at the per-account ceiling
+    mockVerifyApiKey.mockResolvedValue({ ...WRITE_KEY, scopes: ["bookmarks:write"] });
+    mockDbSelect.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([{ listCount: MAX_BOOKMARK_LISTS_PER_USER }]),
+      }),
+    });
+
+    // Act
+    const res = await jsonPost("/bookmark-lists", { name: "Trips", visibility: "private" });
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(409);
+    expect(body.error.code).toBe("conflict");
+    expect(body.error.reason).toBe("bookmark_list_limit_reached");
+    expect(body.error.details).toEqual({ max: MAX_BOOKMARK_LISTS_PER_USER });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /articles — limit
+// ---------------------------------------------------------------------------
+
+describe("POST /articles", () => {
+  it("includes article_limit_reached reason and details.max when the account limit is hit", async () => {
+    // Arrange — article count is already at the per-account ceiling
+    mockVerifyApiKey.mockResolvedValue({ ...WRITE_KEY, scopes: ["articles:write"] });
+    mockDbSelect.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([{ articleCount: MAX_ARTICLES_PER_USER }]),
+      }),
+    });
+
+    // Act
+    const res = await jsonPost("/articles", { title: "My Article" });
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(409);
+    expect(body.error.code).toBe("conflict");
+    expect(body.error.reason).toBe("article_limit_reached");
+    expect(body.error.details).toEqual({ max: MAX_ARTICLES_PER_USER });
   });
 });
 

--- a/apps/api/src/lib/external-api/errors.ts
+++ b/apps/api/src/lib/external-api/errors.ts
@@ -36,8 +36,16 @@ export type ApiV1ErrorCode =
 // Fine-grained machine-readable reason carried alongside the coarse `code`.
 // The top-level `code` set is frozen for backward compatibility (consumers
 // branch on it), so new distinctions are expressed as an additive `reason`
-// instead of new top-level codes.
-export type ApiV1ErrorReason = "trip_limit_reached";
+// instead of new top-level codes. Every `*_limit_reached` reason ships a
+// `details: { max }` payload; `trip_has_no_days` carries no details.
+export type ApiV1ErrorReason =
+  | "trip_limit_reached"
+  | "schedule_limit_reached"
+  | "expense_limit_reached"
+  | "bookmark_list_limit_reached"
+  | "bookmark_limit_reached"
+  | "article_limit_reached"
+  | "trip_has_no_days";
 
 export type ApiV1ErrorOptions = {
   reason?: ApiV1ErrorReason;

--- a/apps/api/src/routes/v1/articles-write.ts
+++ b/apps/api/src/routes/v1/articles-write.ts
@@ -64,7 +64,8 @@ articlesWriteApp.post(
         content: { "application/json": { schema: resolver(errorResponseSchema) } },
       },
       409: {
-        description: "Article limit reached",
+        description:
+          'Article limit reached (error.reason: "article_limit_reached", error.details.max)',
         content: { "application/json": { schema: resolver(errorResponseSchema) } },
       },
     },
@@ -115,7 +116,10 @@ articlesWriteApp.post(
     });
 
     if (!article) {
-      throw new ApiV1Error(409, "conflict", "Article limit reached for this account");
+      throw new ApiV1Error(409, "conflict", "Article limit reached for this account", {
+        reason: "article_limit_reached",
+        details: { max: MAX_ARTICLES_PER_USER },
+      });
     }
 
     return c.json(serializeArticleDto(article, []), 201);

--- a/apps/api/src/routes/v1/bookmarks-write.ts
+++ b/apps/api/src/routes/v1/bookmarks-write.ts
@@ -70,7 +70,8 @@ bookmarksWriteApp.post(
         content: { "application/json": { schema: resolver(errorResponseSchema) } },
       },
       409: {
-        description: "Bookmark list limit reached",
+        description:
+          'Bookmark list limit reached (error.reason: "bookmark_list_limit_reached", error.details.max)',
         content: { "application/json": { schema: resolver(errorResponseSchema) } },
       },
     },
@@ -117,7 +118,10 @@ bookmarksWriteApp.post(
     });
 
     if (!list) {
-      throw new ApiV1Error(409, "conflict", "Bookmark list limit reached for this account");
+      throw new ApiV1Error(409, "conflict", "Bookmark list limit reached for this account", {
+        reason: "bookmark_list_limit_reached",
+        details: { max: MAX_BOOKMARK_LISTS_PER_USER },
+      });
     }
 
     return c.json(serializeListDto(list, 0), 201);
@@ -269,7 +273,8 @@ bookmarksWriteApp.post(
         content: { "application/json": { schema: resolver(errorResponseSchema) } },
       },
       409: {
-        description: "Bookmark limit reached for this list",
+        description:
+          'Bookmark limit reached for this list (error.reason: "bookmark_limit_reached", error.details.max)',
         content: { "application/json": { schema: resolver(errorResponseSchema) } },
       },
     },
@@ -328,7 +333,10 @@ bookmarksWriteApp.post(
     });
 
     if (!bookmark) {
-      throw new ApiV1Error(409, "conflict", "Bookmark limit reached for this list");
+      throw new ApiV1Error(409, "conflict", "Bookmark limit reached for this list", {
+        reason: "bookmark_limit_reached",
+        details: { max: MAX_BOOKMARKS_PER_LIST },
+      });
     }
 
     return c.json(serializeBookmarkDto(bookmark), 201);

--- a/apps/api/src/routes/v1/expenses-write.ts
+++ b/apps/api/src/routes/v1/expenses-write.ts
@@ -9,6 +9,7 @@
 //   request body  memberNo → userId  (before calling the service)
 //   response body userId  → memberNo (when serializing the result)
 
+import { MAX_EXPENSES_PER_TRIP } from "@sugara/shared";
 import { count, eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { describeRoute, resolver } from "hono-openapi";
@@ -80,7 +81,8 @@ expensesWriteApp.post(
         content: { "application/json": { schema: resolver(errorResponseSchema) } },
       },
       409: {
-        description: "Trip in scheduling mode or expense limit reached",
+        description:
+          'Trip has no days (error.reason: "trip_has_no_days") or expense limit reached (error.reason: "expense_limit_reached", error.details.max)',
         content: { "application/json": { schema: resolver(errorResponseSchema) } },
       },
     },
@@ -101,6 +103,7 @@ expensesWriteApp.post(
           409,
           "conflict",
           "Trip has no days; finalize the trip dates before adding expenses",
+          { reason: "trip_has_no_days" },
         );
       }
 
@@ -183,7 +186,10 @@ expensesWriteApp.post(
               "exchangeRate is required when expense currency differs from trip currency",
             );
           case "limit_reached":
-            throw new ApiV1Error(409, "conflict", "Per-trip expense limit reached");
+            throw new ApiV1Error(409, "conflict", "Per-trip expense limit reached", {
+              reason: "expense_limit_reached",
+              details: { max: MAX_EXPENSES_PER_TRIP },
+            });
           case "payer_not_member":
             throw new ApiV1Error(400, "invalid_request", "paidByMemberNo is not a trip member");
           case "split_user_not_member":

--- a/apps/api/src/routes/v1/trips-write.ts
+++ b/apps/api/src/routes/v1/trips-write.ts
@@ -310,7 +310,8 @@ tripsWriteApp.post(
         content: { "application/json": { schema: resolver(errorResponseSchema) } },
       },
       409: {
-        description: "Trip has no days (scheduling mode) or schedule limit reached",
+        description:
+          'Trip has no days (error.reason: "trip_has_no_days") or schedule limit reached (error.reason: "schedule_limit_reached", error.details.max)',
         content: { "application/json": { schema: resolver(errorResponseSchema) } },
       },
     },
@@ -350,6 +351,7 @@ tripsWriteApp.post(
           409,
           "conflict",
           "Trip has no days; create days before adding schedules",
+          { reason: "trip_has_no_days" },
         );
       }
 
@@ -399,7 +401,10 @@ tripsWriteApp.post(
       });
 
       if (!schedule) {
-        throw new ApiV1Error(409, "conflict", "Per-trip schedule limit reached");
+        throw new ApiV1Error(409, "conflict", "Per-trip schedule limit reached", {
+          reason: "schedule_limit_reached",
+          details: { max: MAX_SCHEDULES_PER_TRIP },
+        });
       }
 
       logActivity({

--- a/apps/mcp/src/__tests__/client.test.ts
+++ b/apps/mcp/src/__tests__/client.test.ts
@@ -212,6 +212,199 @@ describe("ApiClient", () => {
       expect(errorMessage).toContain("10");
     });
 
+    it("includes the schedule limit value when reason is schedule_limit_reached", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(
+        makeResponse(
+          {
+            error: {
+              code: "conflict",
+              reason: "schedule_limit_reached",
+              message: "Per-trip schedule limit reached",
+              details: { max: 300 },
+            },
+          },
+          409,
+        ),
+      );
+
+      // Act
+      let errorMessage = "";
+      try {
+        await client.createSchedule("trip-1", 1, { name: "Tokyo Tower" });
+      } catch (err) {
+        errorMessage = err instanceof Error ? err.message : "";
+      }
+
+      // Assert
+      expect(errorMessage).toContain("300");
+      expect(errorMessage).toContain("予定");
+    });
+
+    it("includes the expense limit value when reason is expense_limit_reached", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(
+        makeResponse(
+          {
+            error: {
+              code: "conflict",
+              reason: "expense_limit_reached",
+              message: "Per-trip expense limit reached",
+              details: { max: 200 },
+            },
+          },
+          409,
+        ),
+      );
+
+      // Act
+      let errorMessage = "";
+      try {
+        await client.createExpense("trip-1", { title: "Dinner", amount: 1000 });
+      } catch (err) {
+        errorMessage = err instanceof Error ? err.message : "";
+      }
+
+      // Assert
+      expect(errorMessage).toContain("200");
+      expect(errorMessage).toContain("費用");
+    });
+
+    it("includes the bookmark-list limit value when reason is bookmark_list_limit_reached", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(
+        makeResponse(
+          {
+            error: {
+              code: "conflict",
+              reason: "bookmark_list_limit_reached",
+              message: "Bookmark list limit reached",
+              details: { max: 5 },
+            },
+          },
+          409,
+        ),
+      );
+
+      // Act
+      let errorMessage = "";
+      try {
+        await client.createBookmarkList({ name: "Trips" });
+      } catch (err) {
+        errorMessage = err instanceof Error ? err.message : "";
+      }
+
+      // Assert
+      expect(errorMessage).toContain("5");
+      expect(errorMessage).toContain("リスト");
+    });
+
+    it("includes the bookmark limit value when reason is bookmark_limit_reached", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(
+        makeResponse(
+          {
+            error: {
+              code: "conflict",
+              reason: "bookmark_limit_reached",
+              message: "Bookmark limit reached",
+              details: { max: 20 },
+            },
+          },
+          409,
+        ),
+      );
+
+      // Act
+      let errorMessage = "";
+      try {
+        await client.createBookmark("list-1", { name: "Place", urls: [] });
+      } catch (err) {
+        errorMessage = err instanceof Error ? err.message : "";
+      }
+
+      // Assert
+      expect(errorMessage).toContain("20");
+      expect(errorMessage).toContain("ブックマーク");
+    });
+
+    it("includes the article limit value when reason is article_limit_reached", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(
+        makeResponse(
+          {
+            error: {
+              code: "conflict",
+              reason: "article_limit_reached",
+              message: "Article limit reached",
+              details: { max: 50 },
+            },
+          },
+          409,
+        ),
+      );
+
+      // Act
+      let errorMessage = "";
+      try {
+        await client.createArticle({ title: "My Article" });
+      } catch (err) {
+        errorMessage = err instanceof Error ? err.message : "";
+      }
+
+      // Assert
+      expect(errorMessage).toContain("50");
+      expect(errorMessage).toContain("記事");
+    });
+
+    it("maps the trip_has_no_days reason to a Japanese message", async () => {
+      // Arrange — non-limit reason, no details
+      mockFetch.mockResolvedValue(
+        makeResponse(
+          {
+            error: {
+              code: "conflict",
+              reason: "trip_has_no_days",
+              message: "Trip has no days",
+            },
+          },
+          409,
+        ),
+      );
+
+      // Act
+      let errorMessage = "";
+      try {
+        await client.createSchedule("trip-1", 1, { name: "Tokyo Tower" });
+      } catch (err) {
+        errorMessage = err instanceof Error ? err.message : "";
+      }
+
+      // Assert
+      expect(errorMessage).toContain("日程");
+    });
+
+    it("falls back to the generic conflict message when an unknown reason is returned", async () => {
+      // Arrange — a reason the client does not recognize maps to the code-level message
+      mockFetch.mockResolvedValue(
+        makeResponse(
+          { error: { code: "conflict", reason: "some_future_reason", message: "x" } },
+          409,
+        ),
+      );
+
+      // Act
+      let errorMessage = "";
+      try {
+        await client.createTrip({ title: "Test", startDate: "2025-01-01", endDate: "2025-01-03" });
+      } catch (err) {
+        errorMessage = err instanceof Error ? err.message : "";
+      }
+
+      // Assert
+      expect(errorMessage).toContain("競合");
+    });
+
     it("falls back to the generic conflict message when details.max is absent", async () => {
       // Arrange
       mockFetch.mockResolvedValue(

--- a/apps/mcp/src/client.ts
+++ b/apps/mcp/src/client.ts
@@ -14,6 +14,22 @@ const v1ErrorBodySchema = z.object({
 
 const limitDetailsSchema = z.object({ max: z.number() });
 
+// Localized messages for the v1 API's fine-grained `error.reason` codes. Limit
+// reasons carry `details: { max }` and use a builder; non-limit reasons map to a
+// static message. Keep in sync with ApiV1ErrorReason (apps/api/src/lib/external-api/errors.ts).
+const LIMIT_REASON_MESSAGES: Record<string, (max: number) => string> = {
+  trip_limit_reached: (max) => `旅行の作成上限（${max}件）に達しました`,
+  schedule_limit_reached: (max) => `予定・候補の上限（1旅行あたり${max}件）に達しました`,
+  expense_limit_reached: (max) => `費用の上限（1旅行あたり${max}件）に達しました`,
+  bookmark_list_limit_reached: (max) => `ブックマークリストの上限（${max}件）に達しました`,
+  bookmark_limit_reached: (max) => `ブックマークの上限（1リストあたり${max}件）に達しました`,
+  article_limit_reached: (max) => `記事の作成上限（${max}件）に達しました`,
+};
+
+const REASON_MESSAGES: Record<string, string> = {
+  trip_has_no_days: "この旅行にはまだ日程がありません。先に日程を作成してください",
+};
+
 type V1ErrorCode =
   | "unauthorized"
   | "insufficient_scope"
@@ -55,10 +71,17 @@ async function buildApiError(response: Response): Promise<Error> {
   const parsed = v1ErrorBodySchema.safeParse(body);
   if (parsed.success) {
     const { code, reason, details } = parsed.data.error;
-    if (reason === "trip_limit_reached") {
-      const limit = limitDetailsSchema.safeParse(details);
-      if (limit.success) {
-        return new Error(`旅行の作成上限（${limit.data.max}件）に達しました`);
+    if (reason !== undefined) {
+      const limitMessage = LIMIT_REASON_MESSAGES[reason];
+      if (limitMessage) {
+        const limit = limitDetailsSchema.safeParse(details);
+        if (limit.success) {
+          return new Error(limitMessage(limit.data.max));
+        }
+      }
+      const reasonMessage = REASON_MESSAGES[reason];
+      if (reasonMessage) {
+        return new Error(reasonMessage);
       }
     }
     const message = isV1ErrorCode(code)


### PR DESCRIPTION
## Summary

#157 / PR #158 で導入した optional な `error.reason`(細分化コード)+ `error.details`(構造化データ)を、trip 作成上限以外の上限・競合分岐にも展開する。

### 付与した reason

| エンドポイント | 分岐 | reason | details |
|---|---|---|---|
| POST `/trips/:id/days/:n/schedules` | scheduling mode | `trip_has_no_days` | — |
| POST `/trips/:id/days/:n/schedules` | 予定上限 | `schedule_limit_reached` | `{ max }` |
| POST `/trips/:id/expenses` | scheduling mode | `trip_has_no_days` | — |
| POST `/trips/:id/expenses` | 費用上限 | `expense_limit_reached` | `{ max }` |
| POST `/bookmark-lists` | リスト上限 | `bookmark_list_limit_reached` | `{ max }` |
| POST `/bookmark-lists/:id/bookmarks` | ブックマーク上限 | `bookmark_limit_reached` | `{ max }` |
| POST `/articles` | 記事上限 | `article_limit_reached` | `{ max }` |

`details` は外部公開されるため `max` のみを含め、内部 id・制約名は含めない。`max` は `@sugara/shared` の `MAX_*` 定数を参照(ルート・サービス層・テストで同一定数)。

### MCP / OpenAPI

- `apps/mcp/src/client.ts`: reason→日本語メッセージ写像を `LIMIT_REASON_MESSAGES`(builder)+ `REASON_MESSAGES`(静的)に一般化し、各 reason のメッセージを追加。
- 各ルートの OpenAPI 409 response description に reason/details を明記。

## Test plan

- `apps/api/src/__tests__/v1-write-routes.test.ts`: 各 reason の 409 body アサーション追加(27 tests green)
- `apps/mcp/src/__tests__/client.test.ts`: 各 reason→メッセージのアサーション追加(102 tests green)
- `bun run --filter @sugara/api check` / `check-types`、`--filter @sugara/mcp` 同 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)