### PR TITLE
fix: sortOrder採番をadvisory lockで直列化し同時INSERT重複を防ぐ (#146)

### DIFF
--- a/apps/api/src/__tests__/articles.test.ts
+++ b/apps/api/src/__tests__/articles.test.ts
@@ -23,6 +23,7 @@ vi.mock("../lib/auth", () => ({
 vi.mock("../db/index", () => {
   const tx = {
     query: mockDbQuery,
+    execute: async () => undefined,
     insert: (...args: unknown[]) => mockDbInsert(...args),
     delete: (...args: unknown[]) => mockDbDelete(...args),
     update: (...args: unknown[]) => mockDbUpdate(...args),

--- a/apps/api/src/__tests__/bookmark-lists.test.ts
+++ b/apps/api/src/__tests__/bookmark-lists.test.ts
@@ -27,6 +27,7 @@ vi.mock("../lib/auth", () => ({
 vi.mock("../db/index", () => {
   const tx = {
     query: mockDbQuery,
+    execute: async () => undefined,
     insert: (...args: unknown[]) => mockDbInsert(...args),
     delete: (...args: unknown[]) => mockDbDelete(...args),
     update: (...args: unknown[]) => mockDbUpdate(...args),

--- a/apps/api/src/__tests__/bookmarks.test.ts
+++ b/apps/api/src/__tests__/bookmarks.test.ts
@@ -23,6 +23,7 @@ vi.mock("../lib/auth", () => ({
 vi.mock("../db/index", () => {
   const tx = {
     query: mockDbQuery,
+    execute: async () => undefined,
     insert: (...args: unknown[]) => mockDbInsert(...args),
     delete: (...args: unknown[]) => mockDbDelete(...args),
     update: (...args: unknown[]) => mockDbUpdate(...args),

--- a/apps/api/src/__tests__/candidates.test.ts
+++ b/apps/api/src/__tests__/candidates.test.ts
@@ -35,6 +35,7 @@ vi.mock("../lib/auth", () => ({
 vi.mock("../db/index", () => {
   const tx = {
     query: mockDbQuery,
+    execute: async () => undefined,
     insert: (...args: unknown[]) => mockDbInsert(...args),
     delete: (...args: unknown[]) => mockDbDelete(...args),
     update: (...args: unknown[]) => mockDbUpdate(...args),

--- a/apps/api/src/__tests__/patterns.test.ts
+++ b/apps/api/src/__tests__/patterns.test.ts
@@ -33,6 +33,7 @@ vi.mock("../lib/auth", () => ({
 vi.mock("../db/index", () => {
   const tx = {
     query: mockDbQuery,
+    execute: async () => undefined,
     insert: (...args: unknown[]) => mockDbInsert(...args),
     delete: (...args: unknown[]) => mockDbDelete(...args),
     update: (...args: unknown[]) => mockDbUpdate(...args),

--- a/apps/api/src/__tests__/polls.test.ts
+++ b/apps/api/src/__tests__/polls.test.ts
@@ -41,6 +41,9 @@ vi.mock("../db/index", () => ({
     select: (...args: unknown[]) => mockDbSelect(...args),
     insert: (...args: unknown[]) => mockDbInsert(...args),
     update: (...args: unknown[]) => mockDbUpdate(...args),
+    // No-op advisory-lock executor. polls.ts derives sort order via tx, so the
+    // tx proxy below is what actually runs it; kept here defensively.
+    execute: async () => undefined,
     // transaction delegates to the callback with a tx proxy so tests can
     // control every query/mutation inside the transaction boundary.
     transaction: (fn: (t: unknown) => unknown) =>
@@ -49,6 +52,7 @@ vi.mock("../db/index", () => ({
         insert: (...args: unknown[]) => mockDbInsert(...args),
         update: (...args: unknown[]) => mockDbUpdate(...args),
         select: (...args: unknown[]) => mockDbSelect(...args),
+        execute: async () => undefined,
       }),
   },
 }));

--- a/apps/api/src/__tests__/schedules.test.ts
+++ b/apps/api/src/__tests__/schedules.test.ts
@@ -50,6 +50,7 @@ vi.mock("../lib/auth", () => ({
 vi.mock("../db/index", () => {
   const tx = {
     query: mockDbQuery,
+    execute: async () => undefined,
     insert: (...args: unknown[]) => mockDbInsert(...args),
     delete: (...args: unknown[]) => mockDbDelete(...args),
     update: (...args: unknown[]) => mockDbUpdate(...args),

--- a/apps/api/src/lib/sort-order.ts
+++ b/apps/api/src/lib/sort-order.ts
@@ -7,12 +7,22 @@ import type { db } from "../db/index";
 type Transaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
 type QueryExecutor = typeof db | Transaction;
 
+// Serializes concurrent sort-order assignment within one parent scope. Two
+// transactions inserting into the same scope could otherwise read the same
+// COALESCE(MAX)+1 under READ COMMITTED and assign a duplicate sortOrder (#146).
+// A transaction-scoped advisory lock (released at COMMIT) makes the
+// read-then-insert atomic per scope without a UNIQUE constraint — which would
+// conflict with the dense-renumber reorder path. The lock only spans the
+// caller's write when dbOrTx is a transaction, so EVERY insert/update call site
+// that derives its value here must run inside db.transaction.
 export async function getNextSortOrder(
   dbOrTx: QueryExecutor,
   column: PgColumn,
   table: PgTable,
   condition: SQL | undefined,
+  lockScope: string,
 ): Promise<number> {
+  await dbOrTx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${lockScope}))`);
   const [result] = await dbOrTx
     .select({ max: sql<number>`COALESCE(MAX(${column}), -1)` })
     .from(table)

--- a/apps/api/src/routes/articles.ts
+++ b/apps/api/src/routes/articles.ts
@@ -180,6 +180,7 @@ articleRoutes.post("/", requireNonGuest, async (c) => {
       articles.sortOrder,
       articles,
       eq(articles.ownerId, user.id),
+      `article:user:${user.id}`,
     );
 
     const [result] = await tx

--- a/apps/api/src/routes/bookmark-lists.ts
+++ b/apps/api/src/routes/bookmark-lists.ts
@@ -71,6 +71,7 @@ bookmarkListRoutes.post("/", async (c) => {
       bookmarkLists.sortOrder,
       bookmarkLists,
       eq(bookmarkLists.userId, user.id),
+      `bookmark_list:user:${user.id}`,
     );
 
     const [result] = await tx
@@ -186,6 +187,7 @@ bookmarkListRoutes.post("/:listId/duplicate", async (c) => {
       bookmarkLists.sortOrder,
       bookmarkLists,
       eq(bookmarkLists.userId, user.id),
+      `bookmark_list:user:${user.id}`,
     );
 
     const [newList] = await tx
@@ -277,6 +279,7 @@ bookmarkListRoutes.post("/batch-duplicate", async (c) => {
       bookmarkLists.sortOrder,
       bookmarkLists,
       eq(bookmarkLists.userId, user.id),
+      `bookmark_list:user:${user.id}`,
     );
 
     for (let i = 0; i < sources.length; i++) {

--- a/apps/api/src/routes/bookmarks.ts
+++ b/apps/api/src/routes/bookmarks.ts
@@ -72,6 +72,7 @@ bookmarkRoutes.post("/:listId/bookmarks", async (c) => {
       bookmarks.sortOrder,
       bookmarks,
       eq(bookmarks.listId, listId),
+      `bookmark:list:${listId}`,
     );
 
     const [result] = await tx

--- a/apps/api/src/routes/candidates.ts
+++ b/apps/api/src/routes/candidates.ts
@@ -59,6 +59,7 @@ candidateRoutes.post("/:tripId/candidates", requireTripAccess("editor"), async (
       schedules.sortOrder,
       schedules,
       and(eq(schedules.tripId, tripId), isNull(schedules.dayPatternId)),
+      `schedule:candidates:${tripId}`,
     );
 
     // Anchors cannot be set on candidates (they have no dayPatternId and
@@ -136,6 +137,7 @@ candidateRoutes.post("/:tripId/candidates/batch-assign", requireTripAccess("edit
       schedules.sortOrder,
       schedules,
       eq(schedules.dayPatternId, parsed.data.dayPatternId),
+      `schedule:pattern:${parsed.data.dayPatternId}`,
     );
 
     const ids = parsed.data.scheduleIds;
@@ -235,13 +237,6 @@ candidateRoutes.post(
       return c.json({ error: ERROR_MSG.CANDIDATE_NOT_FOUND }, 404);
     }
 
-    let nextOrder = await getNextSortOrder(
-      db,
-      schedules.sortOrder,
-      schedules,
-      and(eq(schedules.tripId, tripId), isNull(schedules.dayPatternId)),
-    );
-
     // Preserve the order of scheduleIds in the request
     const scheduleById = new Map(candidates.map((s) => [s.id, s]));
     const ordered = parsed.data.scheduleIds.reduce<typeof candidates>((acc, id) => {
@@ -250,15 +245,25 @@ candidateRoutes.post(
       return acc;
     }, []);
 
-    const duplicated = await db
-      .insert(schedules)
-      .values(
-        ordered.map((schedule) => ({
-          tripId,
-          ...buildScheduleCloneValues(schedule, { sortOrder: nextOrder++ }),
-        })),
-      )
-      .returning();
+    const duplicated = await db.transaction(async (tx) => {
+      let nextOrder = await getNextSortOrder(
+        tx,
+        schedules.sortOrder,
+        schedules,
+        and(eq(schedules.tripId, tripId), isNull(schedules.dayPatternId)),
+        `schedule:candidates:${tripId}`,
+      );
+
+      return tx
+        .insert(schedules)
+        .values(
+          ordered.map((schedule) => ({
+            tripId,
+            ...buildScheduleCloneValues(schedule, { sortOrder: nextOrder++ }),
+          })),
+        )
+        .returning();
+    });
 
     logActivity({
       tripId,
@@ -305,28 +310,31 @@ candidateRoutes.post(
       return c.json({ error: ERROR_MSG.LIMIT_SCHEDULES }, 409);
     }
 
-    let nextOrder = await getNextSortOrder(
-      db,
-      schedules.sortOrder,
-      schedules,
-      and(eq(schedules.tripId, tripId), isNull(schedules.dayPatternId)),
-    );
+    const created = await db.transaction(async (tx) => {
+      let nextOrder = await getNextSortOrder(
+        tx,
+        schedules.sortOrder,
+        schedules,
+        and(eq(schedules.tripId, tripId), isNull(schedules.dayPatternId)),
+        `schedule:candidates:${tripId}`,
+      );
 
-    const created = await db
-      .insert(schedules)
-      .values(
-        owned.map((bm) => ({
-          tripId,
-          dayPatternId: null,
-          name: bm.name,
-          memo: bm.memo,
-          urls: bm.urls,
-          category: "sightseeing" as const,
-          color: "blue" as const,
-          sortOrder: nextOrder++,
-        })),
-      )
-      .returning();
+      return tx
+        .insert(schedules)
+        .values(
+          owned.map((bm) => ({
+            tripId,
+            dayPatternId: null,
+            name: bm.name,
+            memo: bm.memo,
+            urls: bm.urls,
+            category: "sightseeing" as const,
+            color: "blue" as const,
+            sortOrder: nextOrder++,
+          })),
+        )
+        .returning();
+    });
 
     logActivity({
       tripId,
@@ -513,22 +521,27 @@ candidateRoutes.post(
       return c.json({ error: ERROR_MSG.PATTERN_NOT_FOUND }, 404);
     }
 
-    const nextOrder = await getNextSortOrder(
-      db,
-      schedules.sortOrder,
-      schedules,
-      eq(schedules.dayPatternId, parsed.data.dayPatternId),
-    );
+    const updated = await db.transaction(async (tx) => {
+      const nextOrder = await getNextSortOrder(
+        tx,
+        schedules.sortOrder,
+        schedules,
+        eq(schedules.dayPatternId, parsed.data.dayPatternId),
+        `schedule:pattern:${parsed.data.dayPatternId}`,
+      );
 
-    const [updated] = await db
-      .update(schedules)
-      .set({
-        dayPatternId: parsed.data.dayPatternId,
-        sortOrder: nextOrder,
-        updatedAt: new Date(),
-      })
-      .where(eq(schedules.id, scheduleId))
-      .returning();
+      const [row] = await tx
+        .update(schedules)
+        .set({
+          dayPatternId: parsed.data.dayPatternId,
+          sortOrder: nextOrder,
+          updatedAt: new Date(),
+        })
+        .where(eq(schedules.id, scheduleId))
+        .returning();
+
+      return row;
+    });
 
     logActivity({
       tripId,

--- a/apps/api/src/routes/patterns.ts
+++ b/apps/api/src/routes/patterns.ts
@@ -71,22 +71,27 @@ patternRoutes.post("/:tripId/days/:dayId/patterns", async (c) => {
     return c.json({ error: ERROR_MSG.LIMIT_PATTERNS }, 409);
   }
 
-  const nextOrder = await getNextSortOrder(
-    db,
-    dayPatterns.sortOrder,
-    dayPatterns,
-    eq(dayPatterns.tripDayId, dayId),
-  );
+  const pattern = await db.transaction(async (tx) => {
+    const nextOrder = await getNextSortOrder(
+      tx,
+      dayPatterns.sortOrder,
+      dayPatterns,
+      eq(dayPatterns.tripDayId, dayId),
+      `pattern:day:${dayId}`,
+    );
 
-  const [pattern] = await db
-    .insert(dayPatterns)
-    .values({
-      tripDayId: dayId,
-      label: parsed.data.label,
-      isDefault: false,
-      sortOrder: nextOrder,
-    })
-    .returning();
+    const [result] = await tx
+      .insert(dayPatterns)
+      .values({
+        tripDayId: dayId,
+        label: parsed.data.label,
+        isDefault: false,
+        sortOrder: nextOrder,
+      })
+      .returning();
+
+    return result;
+  });
 
   logActivity({
     tripId,
@@ -192,13 +197,12 @@ patternRoutes.post("/:tripId/days/:dayId/patterns/:patternId/duplicate", async (
     return c.json({ error: ERROR_MSG.TRIP_NOT_FOUND }, 404);
   }
 
-  const [source, [patternCount], nextOrder] = await Promise.all([
+  const [source, [patternCount]] = await Promise.all([
     db.query.dayPatterns.findFirst({
       where: and(eq(dayPatterns.id, patternId), eq(dayPatterns.tripDayId, dayId)),
       with: { schedules: true },
     }),
     db.select({ count: count() }).from(dayPatterns).where(eq(dayPatterns.tripDayId, dayId)),
-    getNextSortOrder(db, dayPatterns.sortOrder, dayPatterns, eq(dayPatterns.tripDayId, dayId)),
   ]);
   if (!source) {
     return c.json({ error: ERROR_MSG.PATTERN_NOT_FOUND }, 404);
@@ -208,6 +212,16 @@ patternRoutes.post("/:tripId/days/:dayId/patterns/:patternId/duplicate", async (
   }
 
   const result = await db.transaction(async (tx) => {
+    // Moved out of Promise.all so the advisory lock spans the same transaction
+    // as the insert, making the read-then-insert atomic per scope (#146).
+    const nextOrder = await getNextSortOrder(
+      tx,
+      dayPatterns.sortOrder,
+      dayPatterns,
+      eq(dayPatterns.tripDayId, dayId),
+      `pattern:day:${dayId}`,
+    );
+
     const [newPattern] = await tx
       .insert(dayPatterns)
       .values({

--- a/apps/api/src/routes/polls.ts
+++ b/apps/api/src/routes/polls.ts
@@ -307,6 +307,7 @@ pollRoutes.post("/:pollId/options", async (c) => {
       schedulePollOptions.sortOrder,
       schedulePollOptions,
       eq(schedulePollOptions.pollId, pollId),
+      `poll_option:poll:${pollId}`,
     );
 
     const [option] = await tx

--- a/apps/api/src/routes/schedules.ts
+++ b/apps/api/src/routes/schedules.ts
@@ -82,6 +82,7 @@ scheduleRoutes.post("/:tripId/days/:dayId/patterns/:patternId/schedules", async 
       schedules.sortOrder,
       schedules,
       eq(schedules.dayPatternId, patternId),
+      `schedule:pattern:${patternId}`,
     );
 
     // Anchors are never set on create — they can only be set via the reorder
@@ -316,15 +317,6 @@ scheduleRoutes.post(
       return c.json({ error: ERROR_MSG.SCHEDULE_NOT_FOUND }, 404);
     }
 
-    const nextOrder = await getNextSortOrder(
-      db,
-      schedules.sortOrder,
-      schedules,
-      eq(schedules.dayPatternId, patternId),
-    );
-
-    let currentOrder = nextOrder;
-
     const scheduleById = new Map(targetSchedules.map((s) => [s.id, s]));
     const ordered = parsed.data.scheduleIds.reduce<typeof targetSchedules>((acc, id) => {
       const schedule = scheduleById.get(id);
@@ -332,16 +324,26 @@ scheduleRoutes.post(
       return acc;
     }, []);
 
-    const duplicated = await db
-      .insert(schedules)
-      .values(
-        ordered.map((schedule) => ({
-          tripId,
-          dayPatternId: patternId,
-          ...buildScheduleCloneValues(schedule, { sortOrder: currentOrder++ }),
-        })),
-      )
-      .returning();
+    const duplicated = await db.transaction(async (tx) => {
+      let currentOrder = await getNextSortOrder(
+        tx,
+        schedules.sortOrder,
+        schedules,
+        eq(schedules.dayPatternId, patternId),
+        `schedule:pattern:${patternId}`,
+      );
+
+      return tx
+        .insert(schedules)
+        .values(
+          ordered.map((schedule) => ({
+            tripId,
+            dayPatternId: patternId,
+            ...buildScheduleCloneValues(schedule, { sortOrder: currentOrder++ }),
+          })),
+        )
+        .returning();
+    });
 
     logActivity({
       tripId,
@@ -620,6 +622,7 @@ scheduleRoutes.post("/:tripId/schedules/batch-unassign", requireTripAccess("edit
       schedules.sortOrder,
       schedules,
       and(eq(schedules.tripId, tripId), isNull(schedules.dayPatternId)),
+      `schedule:candidates:${tripId}`,
     );
 
     const ids = parsed.data.scheduleIds;
@@ -667,25 +670,30 @@ scheduleRoutes.post(
       return c.json({ error: ERROR_MSG.SCHEDULE_NOT_FOUND }, 404);
     }
 
-    const nextOrder = await getNextSortOrder(
-      db,
-      schedules.sortOrder,
-      schedules,
-      and(eq(schedules.tripId, tripId), isNull(schedules.dayPatternId)),
-    );
-
     // Candidates cannot have anchors (no dayPatternId → no cross-day context).
-    const [updated] = await db
-      .update(schedules)
-      .set({
-        dayPatternId: null,
-        sortOrder: nextOrder,
-        crossDayAnchor: null,
-        crossDayAnchorSourceId: null,
-        updatedAt: new Date(),
-      })
-      .where(eq(schedules.id, scheduleId))
-      .returning();
+    const updated = await db.transaction(async (tx) => {
+      const nextOrder = await getNextSortOrder(
+        tx,
+        schedules.sortOrder,
+        schedules,
+        and(eq(schedules.tripId, tripId), isNull(schedules.dayPatternId)),
+        `schedule:candidates:${tripId}`,
+      );
+
+      const [row] = await tx
+        .update(schedules)
+        .set({
+          dayPatternId: null,
+          sortOrder: nextOrder,
+          crossDayAnchor: null,
+          crossDayAnchorSourceId: null,
+          updatedAt: new Date(),
+        })
+        .where(eq(schedules.id, scheduleId))
+        .returning();
+
+      return row;
+    });
 
     logActivity({
       tripId,

--- a/apps/api/src/routes/v1/articles-write.ts
+++ b/apps/api/src/routes/v1/articles-write.ts
@@ -97,6 +97,7 @@ articlesWriteApp.post(
         articles.sortOrder,
         articles,
         eq(articles.ownerId, userId),
+        `article:user:${userId}`,
       );
 
       const [created] = await tx

--- a/apps/api/src/routes/v1/bookmarks-write.ts
+++ b/apps/api/src/routes/v1/bookmarks-write.ts
@@ -101,6 +101,7 @@ bookmarksWriteApp.post(
         bookmarkLists.sortOrder,
         bookmarkLists,
         eq(bookmarkLists.userId, userId),
+        `bookmark_list:user:${userId}`,
       );
 
       const [created] = await tx
@@ -311,6 +312,7 @@ bookmarksWriteApp.post(
         bookmarks.sortOrder,
         bookmarks,
         eq(bookmarks.listId, listId),
+        `bookmark:list:${listId}`,
       );
 
       const [created] = await tx

--- a/apps/api/src/routes/v1/trips-write.ts
+++ b/apps/api/src/routes/v1/trips-write.ts
@@ -383,6 +383,7 @@ tripsWriteApp.post(
           schedules.sortOrder,
           schedules,
           eq(schedules.dayPatternId, patternId),
+          `schedule:pattern:${patternId}`,
         );
 
         const [result] = await tx


### PR DESCRIPTION
## Summary

`getNextSortOrder`(`COALESCE(MAX, -1)+1`)は PostgreSQL の READ COMMITTED 下で、同一スコープへの同時 INSERT が同じ MAX を読み、**重複した sortOrder を割り当てうる**(対象テーブルに `(親ID, sort_order)` の複合 UNIQUE 制約がないため DB でも検出されない)。

複合 UNIQUE 制約は dense-renumber する reorder 経路と衝突するため採らず、**transaction-scoped advisory lock**(`pg_advisory_xact_lock`、COMMIT で自動解放・Supabase transaction pooler 安全)で同一スコープの read-then-insert を直列化する。**マイグレーション不要**で reorder にも非干渉。

Closes #146

## 変更

- `apps/api/src/lib/sort-order.ts`: `getNextSortOrder` に必須引数 `lockScope` を追加し、MAX 読み取り前に `pg_advisory_xact_lock(hashtext(lockScope))` を取得
- 全21呼び出しサイトに論理スコープ単位の `lockScope` を付与(`schedule:pattern:${patternId}` / `schedule:candidates:${tripId}` / `bookmark_list:user:${userId}` / `bookmark:list:${listId}` / `article:user:${userId}` / `poll_option:poll:${pollId}` / `pattern:day:${dayId}`)
- `db` 直だった7サイト(schedules/candidates/patterns の clone/batch/assign 系)を `db.transaction` で囲み、lock が後続 write までスパンするよう変更。副作用(`logActivity` 等)はトランザクション外に維持
- 単体テストの db/tx モックに `execute` no-op を追加

## Test plan

- `bun run --filter @sugara/api test` green(858 tests)
- `bun run --filter @sugara/api test:integration` green(131 tests、実 Postgres で advisory lock SQL を検証)
- `bun run --filter @sugara/api check` / `check-types` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)