### PR TITLE
refactor(web): テスト共通モックを__mocks__/test-utilsに集約 (#152)

### DIFF
--- a/apps/web/__mocks__/sonner.ts
+++ b/apps/web/__mocks__/sonner.ts
@@ -1,0 +1,18 @@
+// Manual mock for sonner, shared across component tests. A test opts in with
+// a bare `vi.mock("sonner")` (no factory); the toast spies live here so the
+// shape stays defined in one place instead of being copy-pasted per file.
+// vi.clearAllMocks() in each test's afterEach resets the call history.
+import { vi } from "vitest";
+
+export const toast = Object.assign(vi.fn(), {
+  success: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  warning: vi.fn(),
+  loading: vi.fn(),
+  message: vi.fn(),
+  dismiss: vi.fn(),
+  promise: vi.fn(),
+});
+
+export const Toaster = () => null;

--- a/apps/web/app/(authenticated)/trips/[id]/print/__tests__/print-page.test.tsx
+++ b/apps/web/app/(authenticated)/trips/[id]/print/__tests__/print-page.test.tsx
@@ -1,9 +1,8 @@
 import type { TripResponse } from "@sugara/shared";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, render, screen } from "@testing-library/react";
-import { NextIntlClientProvider } from "next-intl";
+import { cleanup, screen } from "@testing-library/react";
 import type { ReactElement } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { renderWithIntlAndQuery } from "@/lib/test-utils";
 import messages from "@/messages/ja.json";
 
 const mockPush = vi.fn();
@@ -33,14 +32,7 @@ vi.mock("@/lib/api", () => ({
 import TripPrintPage from "../page";
 
 function renderWithQuery(ui: ReactElement) {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  });
-  return render(
-    <NextIntlClientProvider locale="ja" messages={messages}>
-      <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
-    </NextIntlClientProvider>,
-  );
+  return renderWithIntlAndQuery(ui);
 }
 
 const tripFixture: TripResponse = {

--- a/apps/web/app/auth/reset-password/page.test.tsx
+++ b/apps/web/app/auth/reset-password/page.test.tsx
@@ -15,9 +15,7 @@ vi.mock("@/lib/auth-client", () => ({
   },
 }));
 
-vi.mock("sonner", () => ({
-  toast: { success: vi.fn(), error: vi.fn() },
-}));
+vi.mock("sonner");
 
 describe("ResetPasswordPage", () => {
   afterEach(() => {

--- a/apps/web/components/article-detail-view.test.tsx
+++ b/apps/web/components/article-detail-view.test.tsx
@@ -41,7 +41,7 @@ vi.mock("@/lib/markdown", () => ({
   MarkdownRenderer: ({ content }: { content: string }) => <p>{content}</p>,
 }));
 
-vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("sonner");
 
 vi.mock("@/lib/hooks/use-article-like", () => ({
   useArticleLike: () => ({ toggleLike: mockToggleLike }),
@@ -64,30 +64,8 @@ vi.mock("@/components/article-editor-dialog", () => ({
 }));
 
 // Suppress Radix responsive-alert-dialog (not needed in this test).
-vi.mock("@/components/ui/responsive-alert-dialog", () => ({
-  ResponsiveAlertDialog: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  ResponsiveAlertDialogContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  ResponsiveAlertDialogHeader: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  ResponsiveAlertDialogTitle: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  ResponsiveAlertDialogDescription: ({ children }: { children: React.ReactNode }) => (
-    <>{children}</>
-  ),
-  ResponsiveAlertDialogFooter: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  ResponsiveAlertDialogCancel: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  ResponsiveAlertDialogDestructiveAction: ({
-    children,
-    onClick,
-    disabled,
-  }: {
-    children: React.ReactNode;
-    onClick: () => void;
-    disabled: boolean;
-  }) => (
-    <button type="button" onClick={onClick} disabled={disabled}>
-      {children}
-    </button>
-  ),
-}));
+// The passthrough mock lives in components/ui/__mocks__/responsive-alert-dialog.tsx.
+vi.mock("@/components/ui/responsive-alert-dialog");
 
 import { ArticleDetailView } from "./article-detail-view";
 

--- a/apps/web/components/article-editor-dialog.test.tsx
+++ b/apps/web/components/article-editor-dialog.test.tsx
@@ -21,7 +21,7 @@ vi.mock("@/lib/api", () => ({
   getApiErrorMessage: vi.fn((_e: unknown, fallback: string) => fallback),
 }));
 
-vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("sonner");
 
 vi.mock("@/lib/markdown", () => ({
   MarkdownRenderer: ({ content }: { content: string }) => <p>{content}</p>,

--- a/apps/web/components/day-timeline.test.tsx
+++ b/apps/web/components/day-timeline.test.tsx
@@ -1,11 +1,10 @@
 import type { CrossDayEntry, ScheduleResponse } from "@sugara/shared";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, fireEvent, screen } from "@testing-library/react";
 import type { ComponentProps } from "react";
 import { afterEach, describe, expect, it } from "vitest";
 import { SelectionProvider } from "@/lib/hooks/selection-context";
 import { MobileContext } from "@/lib/hooks/use-is-mobile";
-import { renderWithIntl } from "@/lib/test-utils";
+import { renderWithIntlAndQuery } from "@/lib/test-utils";
 import { DayTimeline } from "./day-timeline";
 
 // useSortable/useDroppable need no real DndContext here; dnd-kit returns no-op refs.
@@ -86,26 +85,23 @@ function renderTimeline({
   crossDayEntries?: CrossDayEntry[];
   selection?: ComponentProps<typeof SelectionProvider>["value"];
 }) {
-  const queryClient = new QueryClient();
-  return renderWithIntl(
-    <QueryClientProvider client={queryClient}>
-      <MobileContext.Provider value={true}>
-        <SelectionProvider value={selection}>
-          <DayTimeline
-            tripId="t1"
-            dayId="d1"
-            patternId="p1"
-            date="2026-06-11"
-            schedules={schedules}
-            crossDayEntries={crossDayEntries}
-            onRefresh={noop}
-            onScheduleAdded={noop}
-            onReorderSchedule={noop}
-            scheduleLimitReached
-          />
-        </SelectionProvider>
-      </MobileContext.Provider>
-    </QueryClientProvider>,
+  return renderWithIntlAndQuery(
+    <MobileContext.Provider value={true}>
+      <SelectionProvider value={selection}>
+        <DayTimeline
+          tripId="t1"
+          dayId="d1"
+          patternId="p1"
+          date="2026-06-11"
+          schedules={schedules}
+          crossDayEntries={crossDayEntries}
+          onRefresh={noop}
+          onScheduleAdded={noop}
+          onReorderSchedule={noop}
+          scheduleLimitReached
+        />
+      </SelectionProvider>
+    </MobileContext.Provider>,
   );
 }
 

--- a/apps/web/components/souvenir-dialog.test.tsx
+++ b/apps/web/components/souvenir-dialog.test.tsx
@@ -18,7 +18,7 @@ vi.mock("@/lib/api", async (importOriginal) => {
   return { ...actual, api: mockApi };
 });
 
-vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("sonner");
 
 // Suppress the Radix responsive-dialog; only the form matters here.
 vi.mock("@/components/ui/responsive-dialog", () => ({

--- a/apps/web/components/souvenir-panel.test.tsx
+++ b/apps/web/components/souvenir-panel.test.tsx
@@ -6,12 +6,11 @@
  * production on 2026-06-12).
  */
 import type { SouvenirItem } from "@sugara/shared";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
 import { toast } from "sonner";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MobileContext } from "@/lib/hooks/use-is-mobile";
-import { renderWithIntl } from "@/lib/test-utils";
+import { renderWithIntlAndQuery } from "@/lib/test-utils";
 
 // --- module mocks ------------------------------------------------------------
 
@@ -19,7 +18,7 @@ vi.mock("@/lib/auth-client", () => ({
   useSession: () => ({ data: { user: { id: "u1" } } }),
 }));
 
-vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("sonner");
 
 // SouvenirDialog is loaded via next/dynamic; not needed in these tests.
 vi.mock("next/dynamic", () => ({ default: () => () => null }));
@@ -43,30 +42,8 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
 }));
 
 // Suppress the Radix responsive-alert-dialog; only the confirm action matters.
-vi.mock("@/components/ui/responsive-alert-dialog", () => ({
-  ResponsiveAlertDialog: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  ResponsiveAlertDialogContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  ResponsiveAlertDialogHeader: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  ResponsiveAlertDialogTitle: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  ResponsiveAlertDialogDescription: ({ children }: { children: React.ReactNode }) => (
-    <>{children}</>
-  ),
-  ResponsiveAlertDialogFooter: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  ResponsiveAlertDialogCancel: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  ResponsiveAlertDialogDestructiveAction: ({
-    children,
-    onClick,
-    disabled,
-  }: {
-    children: React.ReactNode;
-    onClick: () => void;
-    disabled: boolean;
-  }) => (
-    <button type="button" onClick={onClick} disabled={disabled}>
-      {children}
-    </button>
-  ),
-}));
+// The passthrough mock lives in components/ui/__mocks__/responsive-alert-dialog.tsx.
+vi.mock("@/components/ui/responsive-alert-dialog");
 
 import { SouvenirPanel } from "./souvenir-panel";
 
@@ -142,15 +119,10 @@ afterEach(() => {
 // --- helpers -------------------------------------------------------------------
 
 function renderPanel() {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
-  });
-  return renderWithIntl(
-    <QueryClientProvider client={queryClient}>
-      <MobileContext.Provider value={false}>
-        <SouvenirPanel tripId="t1" />
-      </MobileContext.Provider>
-    </QueryClientProvider>,
+  return renderWithIntlAndQuery(
+    <MobileContext.Provider value={false}>
+      <SouvenirPanel tripId="t1" />
+    </MobileContext.Provider>,
   );
 }
 

--- a/apps/web/components/ui/__mocks__/responsive-alert-dialog.tsx
+++ b/apps/web/components/ui/__mocks__/responsive-alert-dialog.tsx
@@ -1,0 +1,36 @@
+// Manual mock for the Radix-backed responsive-alert-dialog, shared across
+// component tests. A test opts in with a bare
+// `vi.mock("@/components/ui/responsive-alert-dialog")` (no factory). All parts
+// render their children inline; the destructive action becomes a plain button
+// so tests can click "confirm" without driving the real Radix portal/overlay.
+import type { ReactNode } from "react";
+
+const Passthrough = ({ children }: { children: ReactNode }) => <>{children}</>;
+
+export const ResponsiveAlertDialog = Passthrough;
+export const ResponsiveAlertDialogTrigger = Passthrough;
+export const ResponsiveAlertDialogContent = Passthrough;
+export const ResponsiveAlertDialogHeader = Passthrough;
+export const ResponsiveAlertDialogTitle = Passthrough;
+export const ResponsiveAlertDialogDescription = Passthrough;
+export const ResponsiveAlertDialogFooter = Passthrough;
+export const ResponsiveAlertDialogCancel = Passthrough;
+
+// Confirm-style actions render as plain buttons so a test can click them
+// without the real Radix portal; onClick/disabled pass straight through.
+const ActionButton = ({
+  children,
+  onClick,
+  disabled,
+}: {
+  children: ReactNode;
+  onClick: () => void;
+  disabled?: boolean;
+}) => (
+  <button type="button" onClick={onClick} disabled={disabled}>
+    {children}
+  </button>
+);
+
+export const ResponsiveAlertDialogAction = ActionButton;
+export const ResponsiveAlertDialogDestructiveAction = ActionButton;

--- a/apps/web/lib/test-utils.tsx
+++ b/apps/web/lib/test-utils.tsx
@@ -1,9 +1,10 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { type RenderOptions, type RenderResult, render } from "@testing-library/react";
 import { NextIntlClientProvider } from "next-intl";
-import type { ReactElement } from "react";
+import type { ReactElement, ReactNode } from "react";
 import messages from "../messages/ja.json";
 
-function IntlWrapper({ children }: { children: React.ReactNode }) {
+function IntlWrapper({ children }: { children: ReactNode }) {
   return (
     <NextIntlClientProvider locale="ja" messages={messages}>
       {children}
@@ -16,4 +17,28 @@ export function renderWithIntl(
   options?: Omit<RenderOptions, "wrapper">,
 ): RenderResult {
   return render(ui, { wrapper: IntlWrapper, ...options });
+}
+
+// Renders under both the intl provider and a fresh, retry-disabled QueryClient.
+// Retries are off so a mutation/query that rejects surfaces immediately instead
+// of stalling the test behind TanStack Query's default backoff. A new client per
+// call keeps each test's cache isolated.
+export function renderWithIntlAndQuery(
+  ui: ReactElement,
+  options?: Omit<RenderOptions, "wrapper">,
+): RenderResult {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <IntlWrapper>
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      </IntlWrapper>
+    );
+  }
+  return render(ui, { wrapper: Wrapper, ...options });
 }


### PR DESCRIPTION
## Summary

テストファイル間でモック定義が重複し、コンポーネントの props 変更時に**片方のモックだけ stale になって green を維持する**リスクがあった(PR #148 のレビュー指摘)。

- `apps/web/__mocks__/sonner.ts`: `toast` スパイの単一定義。各テストは bare `vi.mock("sonner")` で opt-in
- `apps/web/components/ui/__mocks__/responsive-alert-dialog.tsx`: Radix パススルーモックの単一定義(24行の逐語コピーが 2 ファイルに存在していた)。bare `vi.mock("@/components/ui/responsive-alert-dialog")` で opt-in。実モジュールの全 export(`Action`/`Trigger` 含む)を網羅
- `apps/web/lib/test-utils.tsx`: `renderWithIntlAndQuery`(retry 無効の QueryClient + intl ラッパー)を追加。souvenir-panel / day-timeline / print-page の微妙に異なる QueryClient セットアップを統一

既存7テストを移行(souvenir-panel, article-detail-view, article-editor-dialog, souvenir-dialog, reset-password, day-timeline, print-page)。

## 受け入れ条件

- [x] 新規テストが共通ヘルパー(`renderWithIntlAndQuery` + manual mock)だけで delete/dialog 系のテストを書ける
- [x] responsive-alert-dialog / sonner のモック定義が単一箇所になる

## Test plan

- `bun run --filter @sugara/web test` green(830 tests)
- `bun run --filter @sugara/web check` / `check-types` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)