### PR TITLE
fix(web): edit-schedule-dialogをreconcile+skip-refetchに移行 (#155 partial)

### DIFF
--- a/apps/web/components/day-timeline.tsx
+++ b/apps/web/components/day-timeline.tsx
@@ -252,6 +252,7 @@ export function DayTimeline({
             isFirst={isFirst}
             isLast={isLast}
             onDelete={() => handleDelete(s.id, sourceDayId, sourcePatternId)}
+            onSaved={onScheduleAdded}
             onUpdate={onRefresh}
             onUnassign={!disabled && !opts?.selectable ? () => handleUnassign(s.id) : undefined}
             disabled={disabled}
@@ -284,6 +285,7 @@ export function DayTimeline({
           isFirst={isFirst}
           isLast={isLast}
           onDelete={() => handleDelete(schedule.id)}
+          onSaved={onScheduleAdded}
           onUpdate={onRefresh}
           onUnassign={
             !disabled && !opts?.selectable ? () => handleUnassign(schedule.id) : undefined

--- a/apps/web/components/edit-schedule-dialog.test.tsx
+++ b/apps/web/components/edit-schedule-dialog.test.tsx
@@ -1,0 +1,203 @@
+/**
+ * Regression tests for the stale-refetch clobber fix (#155): a successful
+ * schedule edit must reconcile the cache with the server-confirmed row and call
+ * onSaved() (skip refetch) — never onConflict(). A 409/404 or an evicted cache
+ * must fall back to onConflict() so the parent refetches.
+ */
+import type {
+  DayPatternResponse,
+  DayResponse,
+  ScheduleResponse,
+  TripResponse,
+} from "@sugara/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { queryKeys } from "@/lib/query-keys";
+import messages from "@/messages/ja.json";
+
+const mockApi = vi.fn();
+vi.mock("@/lib/api", () => ({
+  api: (...args: unknown[]) => mockApi(...args),
+  ApiError: class ApiError extends Error {
+    status: number;
+    constructor(message: string, status: number) {
+      super(message);
+      this.status = status;
+    }
+  },
+}));
+
+vi.mock("sonner");
+
+// Keep the form render free of the Google Maps loader and OGP fetches; the name
+// input still renders from defaultValues so the submitted FormData is valid.
+vi.mock("@/components/places-autocomplete-input", () => ({
+  PlacesAutocompleteInput: ({ id, name, defaultValue }: Record<string, string>) => (
+    <input id={id} name={name} defaultValue={defaultValue} />
+  ),
+}));
+vi.mock("@/lib/hooks/use-ogp-autofill", () => ({
+  useOgpAutofill: () => ({ onUrlsChange: vi.fn(), titleSuggestion: null }),
+}));
+
+import { ApiError } from "@/lib/api";
+import { EditScheduleDialog } from "./edit-schedule-dialog";
+
+const TRIP_ID = "trip-1";
+const DAY_ID = "d1";
+const PATTERN_ID = "p1";
+const SCHEDULE_ID = "s1";
+
+function makeSchedule(overrides: Partial<ScheduleResponse> = {}): ScheduleResponse {
+  return {
+    id: SCHEDULE_ID,
+    name: "Old name",
+    category: "sightseeing",
+    address: null,
+    departurePlace: null,
+    arrivalPlace: null,
+    transportMethod: null,
+    startTime: null,
+    endTime: null,
+    endDayOffset: null,
+    memo: null,
+    cost: null,
+    urls: [],
+    color: "blue",
+    latitude: null,
+    longitude: null,
+    placeId: null,
+    sortOrder: 0,
+    crossDayAnchor: null,
+    crossDayAnchorSourceId: null,
+    updatedAt: "2026-06-13T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function makePattern(schedules: ScheduleResponse[]): DayPatternResponse {
+  return { id: PATTERN_ID, label: "Default", isDefault: true, sortOrder: 0, schedules };
+}
+
+function makeDay(schedules: ScheduleResponse[]): DayResponse {
+  return { id: DAY_ID, dayNumber: 1, date: "2026-06-13", patterns: [makePattern(schedules)] };
+}
+
+function seedTrip(schedule: ScheduleResponse): TripResponse {
+  return {
+    id: TRIP_ID,
+    title: "Test Trip",
+    destination: "Tokyo",
+    startDate: "2026-06-13",
+    endDate: "2026-06-15",
+    status: "planned",
+    coverImageUrl: null,
+    coverImagePosition: 50,
+    shareToken: null,
+    currency: "JPY",
+    role: "owner",
+    days: [makeDay([schedule])],
+    candidates: [],
+    scheduleCount: 1,
+    expenseCount: 0,
+    memberCount: 1,
+    poll: null,
+    mapsEnabled: false,
+  };
+}
+
+function renderDialog(schedule: ScheduleResponse) {
+  const onSaved = vi.fn();
+  const onConflict = vi.fn();
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  queryClient.setQueryData(queryKeys.trips.detail(TRIP_ID), seedTrip(schedule));
+  render(
+    <NextIntlClientProvider locale="ja" messages={messages}>
+      <QueryClientProvider client={queryClient}>
+        <EditScheduleDialog
+          tripId={TRIP_ID}
+          dayId={DAY_ID}
+          patternId={PATTERN_ID}
+          schedule={schedule}
+          open
+          onOpenChange={vi.fn()}
+          onSaved={onSaved}
+          onConflict={onConflict}
+        />
+      </QueryClientProvider>
+    </NextIntlClientProvider>,
+  );
+  return { onSaved, onConflict, queryClient };
+}
+
+function submit() {
+  // Clicking the type="submit" button fires the form's onSubmit handler.
+  fireEvent.click(screen.getByRole("button", { name: messages.schedule.updateSchedule }));
+}
+
+function readSchedule(queryClient: QueryClient): ScheduleResponse {
+  const trip = queryClient.getQueryData<TripResponse>(queryKeys.trips.detail(TRIP_ID));
+  if (!trip) throw new Error("trip cache missing");
+  return trip.days[0].patterns[0].schedules[0];
+}
+
+describe("EditScheduleDialog stale-refetch fix (#155)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("reconciles cache with the server row and calls onSaved (not onConflict) on success", async () => {
+    const schedule = makeSchedule();
+    mockApi.mockResolvedValue({
+      ...schedule,
+      name: "Server name",
+      updatedAt: "2026-06-13T01:00:00.000Z",
+    });
+    const { onSaved, onConflict, queryClient } = renderDialog(schedule);
+
+    submit();
+
+    await waitFor(() => expect(onSaved).toHaveBeenCalledTimes(1));
+    expect(onConflict).not.toHaveBeenCalled();
+    expect(mockApi).toHaveBeenCalledTimes(1);
+    // Cache now holds the server-confirmed row (fresh name + updatedAt).
+    const cached = readSchedule(queryClient);
+    expect(cached.name).toBe("Server name");
+    expect(cached.updatedAt).toBe("2026-06-13T01:00:00.000Z");
+  });
+
+  it("falls back to onConflict and rolls back the cache on a 409 conflict", async () => {
+    const schedule = makeSchedule();
+    mockApi.mockRejectedValue(new ApiError("conflict", 409));
+    const { onSaved, onConflict, queryClient } = renderDialog(schedule);
+
+    submit();
+
+    await waitFor(() => expect(onConflict).toHaveBeenCalledTimes(1));
+    expect(onSaved).not.toHaveBeenCalled();
+    // Optimistic write was rolled back to the original row.
+    expect(readSchedule(queryClient).name).toBe("Old name");
+  });
+
+  it("falls back to onConflict when the cache was evicted during the round-trip", async () => {
+    const schedule = makeSchedule();
+    const { onSaved, onConflict, queryClient } = renderDialog(schedule);
+    mockApi.mockImplementation(async () => {
+      // Simulate the trip cache being evicted before the response resolves.
+      queryClient.removeQueries({ queryKey: queryKeys.trips.detail(TRIP_ID) });
+      return { ...schedule, name: "Server name" };
+    });
+
+    submit();
+
+    await waitFor(() => expect(onConflict).toHaveBeenCalledTimes(1));
+    expect(onSaved).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/components/edit-schedule-dialog.tsx
+++ b/apps/web/components/edit-schedule-dialog.tsx
@@ -37,7 +37,12 @@ type EditScheduleDialogProps = {
   schedule: ScheduleResponse;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onUpdate: () => void;
+  // Called after the server-confirmed row is written back into the cache; the
+  // parent must then skip its refetch so a stale GET cannot clobber it (#155).
+  onSaved: () => void;
+  // Called when the cache is unavailable (evicted) or the write conflicts, so
+  // the parent should refetch to recover a consistent state.
+  onConflict: () => void;
   maxEndDayOffset?: number;
   onShiftProposal?: (timeDelta: TimeDelta) => void;
   mapsEnabled?: boolean;
@@ -50,7 +55,8 @@ export function EditScheduleDialog({
   schedule,
   open,
   onOpenChange,
-  onUpdate,
+  onSaved,
+  onConflict,
   maxEndDayOffset = 0,
   onShiftProposal,
   mapsEnabled = false,
@@ -168,14 +174,35 @@ export function EditScheduleDialog({
     toast.success(tm("scheduleUpdated"));
 
     try {
-      await api(
+      // Reconcile the cache with the server-confirmed row (fresh updatedAt for
+      // the next optimistic-lock check) and skip the refetch (#155). The
+      // optimistic write above gives instant feedback; this corrects it.
+      const updated = await api<Record<string, unknown>>(
         `/api/trips/${tripId}/days/${dayId}/patterns/${patternId}/schedules/${schedule.id}`,
         {
           method: "PATCH",
           body: JSON.stringify(data),
         },
       );
-      onUpdate();
+      const fresh = queryClient.getQueryData<TripResponse>(cacheKey);
+      if (fresh) {
+        queryClient.setQueryData(
+          cacheKey,
+          updateScheduleInPattern(
+            fresh,
+            dayId,
+            patternId,
+            schedule.id,
+            toScheduleResponse(updated),
+          ),
+        );
+        onSaved();
+      } else {
+        // The cache was evicted during the round-trip, so the server's fresh
+        // updatedAt isn't stored. Refetch to recover it; otherwise the next
+        // edit would send a stale expectedUpdatedAt and hit a spurious 409.
+        onConflict();
+      }
 
       const timeDelta = computeTimeDelta(schedule, {
         startTime: startTime || undefined,
@@ -189,7 +216,7 @@ export function EditScheduleDialog({
       if (prev) queryClient.setQueryData(cacheKey, prev);
       if (err instanceof ApiError && (err.status === 409 || err.status === 404)) {
         toast.error(err.status === 409 ? tm("conflict") : tm("conflictDeleted"));
-        onUpdate();
+        onConflict();
       } else {
         toast.error(tm("scheduleUpdateFailed"));
       }

--- a/apps/web/components/schedule-items/place-item.tsx
+++ b/apps/web/components/schedule-items/place-item.tsx
@@ -43,6 +43,7 @@ export const PlaceItem = memo(function PlaceItem({
   dayId,
   patternId,
   onDelete,
+  onSaved,
   onUpdate,
   onUnassign,
   disabled,
@@ -213,6 +214,7 @@ export const PlaceItem = memo(function PlaceItem({
         }}
         editOpen={editOpen}
         onEditOpenChange={setEditOpen}
+        onSaved={onSaved}
         onUpdate={onUpdate}
         maxEndDayOffset={maxEndDayOffset}
         shift={shift}

--- a/apps/web/components/schedule-items/primitives.tsx
+++ b/apps/web/components/schedule-items/primitives.tsx
@@ -69,6 +69,9 @@ export type ScheduleItemProps = {
   dayId: string;
   patternId: string;
   onDelete: () => void;
+  // Skip-refetch success path after an edit (cache reconciled in-place, #155).
+  onSaved: () => void;
+  // Refetch path: conflict/cache-evict recovery and post-batch-shift sync.
   onUpdate: () => void;
   onUnassign?: () => void;
   disabled?: boolean;
@@ -332,6 +335,7 @@ export function ScheduleItemDialogs({
   schedule,
   editOpen,
   onEditOpenChange,
+  onSaved,
   onUpdate,
   maxEndDayOffset,
   shift,
@@ -359,6 +363,9 @@ export function ScheduleItemDialogs({
   };
   editOpen: boolean;
   onEditOpenChange: (open: boolean) => void;
+  // Skip-refetch success path (cache already reconciled); see EditScheduleDialog.
+  onSaved: () => void;
+  // Refetch path: conflict/cache-evict recovery and post-batch-shift sync.
   onUpdate: () => void;
   maxEndDayOffset?: number;
   shift: ReturnType<typeof useShiftProposal>;
@@ -378,7 +385,8 @@ export function ScheduleItemDialogs({
         }}
         open={editOpen}
         onOpenChange={onEditOpenChange}
-        onUpdate={onUpdate}
+        onSaved={onSaved}
+        onConflict={onUpdate}
         maxEndDayOffset={maxEndDayOffset}
         onShiftProposal={shift.onShiftProposal}
         mapsEnabled={mapsEnabled}

--- a/apps/web/components/schedule-items/transport-item.tsx
+++ b/apps/web/components/schedule-items/transport-item.tsx
@@ -47,6 +47,7 @@ export const TransportItem = memo(function TransportItem({
   dayId,
   patternId,
   onDelete,
+  onSaved,
   onUpdate,
   onUnassign,
   disabled,
@@ -271,6 +272,7 @@ export const TransportItem = memo(function TransportItem({
         }}
         editOpen={editOpen}
         onEditOpenChange={setEditOpen}
+        onSaved={onSaved}
         onUpdate={onUpdate}
         maxEndDayOffset={maxEndDayOffset}
         shift={shift}


### PR DESCRIPTION
## Summary

楽観更新で `setQueryData` した直後に `onUpdate → invalidateTrip` の refetch が走り、**stale な GET が楽観更新を巻き戻す窓**があった(#123 / #155)。edit-candidate-dialog は PR #168 で「server 確定行を cache に reconcile してから refetch を skip」する方式に移行済み。本 PR は同じパターンを **edit-schedule-dialog** に適用する。

- `edit-schedule-dialog.tsx`: props `onUpdate` を `onSaved`(skip-refetch)+ `onConflict`(refetch)に分割。PATCH 成功時に server 応答を `updateScheduleInPattern` で cache に書き戻して `onSaved()`、cache-evict 時 `onConflict()`、409/404 時 rollback + `onConflict()`
- `schedule-items/{primitives,place-item,transport-item}.tsx`: `onSaved` を貫通。`ScheduleItemDialogs` は EditScheduleDialog に `onSaved` / `onConflict={onUpdate}` を渡す。BatchShiftDialog の `onDone` は cache を自前で書かないため `onUpdate`(refetch)のまま
- `day-timeline.tsx`: 2つの ScheduleItem(通常 + cross-day)に `onSaved={onScheduleAdded}`(skip-refetch コールバック)を配線

## 残課題(Issue #155 継続)

本 PR は #155 の残存経路のうち **edit-schedule-dialog** のみを対応。以下は引き続き Issue に残す:
- candidate assign / add-candidate(server 採番の sortOrder に依存するため refetch が必要)
- class-2(broadcast / visibilitychange / online 由来の refetch、option 1 reconciliation が適切)

このため `Closes` ではなく `Refs #155`。

## Test plan

- `apps/web/components/edit-schedule-dialog.test.tsx` を追加:成功時 reconcile + onSaved、409 時 rollback + onConflict、cache-evict 時 onConflict の3ケースを cache の実値で検証
- `bun run --filter @sugara/web test` green(840 tests)
- `bun run --filter @sugara/web check` / `check-types` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)