### PR TITLE
fix(e2e): delete-account 再ログイン失敗 alert をフォームにスコープしフレーキー解消

### DIFF
--- a/apps/web/e2e/delete-account.spec.ts
+++ b/apps/web/e2e/delete-account.spec.ts
@@ -54,9 +54,12 @@ test.describe("Delete Account", () => {
     await assignUniqueClientIp(page, userCredentials.username);
     await deleteAccount(page);
 
-    // Re-login with same credentials should fail
+    // Re-login with same credentials should fail. Scope to the form so the
+    // assertion targets the login error alert specifically — an async
+    // announcement banner (also role="alert", rendered outside the form) can
+    // otherwise race in and make a bare getByRole("alert") match 2 elements.
     await loginUser(page, userCredentials.username);
-    await expect(page.getByRole("alert")).toBeVisible({ timeout: 5000 });
+    await expect(page.locator("form").getByRole("alert")).toBeVisible({ timeout: 5000 });
     await expect(page).toHaveURL(/\/auth\/login/);
   });
 


### PR DESCRIPTION
## Summary

`delete-account.spec.ts` の「cannot log in after account deletion」テストが、再ログイン失敗時のエラー表示を `page.getByRole("alert")` で待っていた。これは **`AnnouncementBanner`**(同じく `role="alert"`、フォーム外に描画)ともマッチしうる。

`AnnouncementBanner` は `/api/announcement` を**非同期 fetch してから描画**するため、有効なお知らせがある環境ではタイミング次第でログインエラー alert とお知らせバナーの2要素が同時に存在し、Playwright の strict mode violation(`resolved to 2 elements`)でテストが落ちる。直近の他 PR が green だったのにこの PR で再現したのはこの**タイミング依存のフレーキー**が原因。

ロケータを `page.locator("form").getByRole("alert")` に絞り、ログインフォーム内のエラー alert のみを対象にする(同ファイル L28 は既に `dialog.getByRole("alert")` とスコープ済みで、本 PR は L59 を揃える)。

## 背景

PR #174(#155 対応)の e2e でこのテストが落ちたことで発見。#174 の変更(edit-schedule-dialog)とは無関係な既存のテスト脆弱性。

## Test plan

- 変更は e2e ロケータのスコープ限定のみ。`bun run --filter @sugara/web check` green
- CI の test-e2e で当該テストが安定して通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)