### PR TITLE
docs: MCP README の例 URL を実ドメインに修正

### DIFF
--- a/apps/mcp/README.md
+++ b/apps/mcp/README.md
@@ -62,7 +62,7 @@ sugara の設定画面からAPIキーを発行してください。
       "args": ["run", "/絶対パス/sugara/apps/mcp/src/index.ts"],
       "env": {
         "SUGARA_API_KEY": "sk_...",
-        "SUGARA_API_URL": "https://sugara.app"
+        "SUGARA_API_URL": "https://sugara.vercel.app"
       }
     }
   }
@@ -79,7 +79,7 @@ sugara の設定画面からAPIキーを発行してください。
       "args": ["run", "/絶対パス/sugara/apps/mcp/src/index.ts"],
       "env": {
         "SUGARA_API_KEY": "sk_...",
-        "SUGARA_API_URL": "https://sugara.app"
+        "SUGARA_API_URL": "https://sugara.vercel.app"
       }
     }
   }
@@ -91,7 +91,7 @@ sugara の設定画面からAPIキーを発行してください。
 | 変数名 | 必須 | 説明 |
 |---|---|---|
 | `SUGARA_API_KEY` | ✓ | sugara の設定画面で発行した API キー (`sk_...`) |
-| `SUGARA_API_URL` | ✓ | API の URL。`https://` 推奨。`http://` は `localhost` / `127.0.0.1` のみ許可 (例: `https://sugara.app`、ローカルは `http://localhost:3000`) |
+| `SUGARA_API_URL` | ✓ | API の URL。`https://` 推奨。`http://` は `localhost` / `127.0.0.1` のみ許可 (例: `https://sugara.vercel.app`、ローカルは `http://localhost:3000`) |
 
 ## 注意事項
 


### PR DESCRIPTION
## 概要

`apps/mcp/README.md` の `SUGARA_API_URL` 設定例が実在しないドメイン `https://sugara.app` を使っており、README の手順通りに設定すると **DNS 名前解決に失敗して MCP から API に接続できない**。本番ドメイン `https://sugara.vercel.app` に修正する。

## 変更内容

`https://sugara.app` → `https://sugara.vercel.app` (3 箇所)

- Claude Desktop 設定例
- Claude Code 設定例
- 環境変数表の例示

## 背景

この例 URL のまま Claude Desktop に設定すると、ツール読込は成功するが `list_trips` 呼び出し時に「SUGARA_API_URL に接続できません」エラーになる。`https://sugara.vercel.app` の実キーで `GET /api/v1/trips` が 200 を返すことを確認済み。

## Test plan

- [x] README 内に `sugara.app` の残存なしを確認 (grep)
- [x] 修正不要な箇所 (sentry テスト fixture, VAPID の admin@sugara.app) は変更していない
- [x] ドキュメントのみの変更のため `[skip ci]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)