### PR TITLE
ci: ドキュメントのみの変更で重い CI ジョブを自動スキップ + README/ドキュメント鮮度修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,12 @@ permissions:
 jobs:
   check:
     runs-on: ubuntu-latest
+    needs: changes
+    # Docs-only PRs (Markdown only) skip this job. A skipped required check still
+    # reports success to Branch Protection, so the PR stays mergeable without
+    # [skip ci] (which would suppress the check run entirely and deadlock the
+    # merge). Pushes to main always run the full suite.
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
@@ -57,6 +63,9 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    needs: changes
+    # Required check; skipped on docs-only PRs (see `check` for rationale).
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
@@ -77,6 +86,9 @@ jobs:
 
   test-integration:
     runs-on: ubuntu-latest
+    needs: changes
+    # Not a required check, but skipped on docs-only PRs to save CI minutes.
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
     services:
       postgres:
         image: postgres:17
@@ -157,6 +169,7 @@ jobs:
       pull-requests: read
     outputs:
       web: ${{ steps.filter.outputs.web }}
+      code: ${{ steps.codefilter.outputs.code }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
@@ -172,6 +185,21 @@ jobs:
               - 'package.json'
               - 'turbo.json'
               - '.github/workflows/ci.yml'
+      # `code` is true for any change that is NOT purely Markdown, so docs-only PRs
+      # skip check/test/test-integration. Kept in its own step with
+      # predicate-quantifier: 'every' because the default 'some' (OR) mode makes a
+      # lone '!**/*.md' match nearly every file, which would break the negation. A
+      # single positive '**' avoids the 'every' + multi-positive AND pitfall — so
+      # the multi-positive 'web' filter above must stay on its own default-quantifier
+      # step. Negation defaults to true (run CI) for any new non-Markdown path.
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: codefilter
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            code:
+              - '**'
+              - '!**/*.md'
 
   # Playwright suite against a production build backed by the same local Supabase
   # stack developers use (Postgres 55322 / Realtime / Storage), so CI mirrors

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,13 +97,14 @@ bun run --filter @sugara/shared check-types
 - `main` は Branch Protection で保護 → 直 push 不可、PR + CI green で squash merge
 - feature branch: `<type>/<topic>` (例: `fix/cover-upload`, `feat/expense-category`)
 - PR merge → Vercel が自動デプロイ（Vercel native skipping で web 非依存の変更はスキップ）
-- DB migration は独立した `.github/workflows/db-migrate.yml` で実行（`[skip deploy]` でも migration は走る）
+- DB migration は Vercel の本番ビルド (`apps/web/vercel.json` の `buildCommand` が `next build` の前に `bun run db:migrate` を実行) の一部として走る。独立した migration 用 workflow はない。そのため `[skip deploy]` で Vercel をスキップすると migration も走らない
 
 コミットメッセージでのスキップ:
 
-- `[skip ci]`: Vercel **と** GitHub Actions の両方をスキップ（ドキュメントのみの変更に使う）
+- `[skip ci]`: Vercel **と** GitHub Actions の両方をスキップ。**PR では使わない** — 必須チェック (`check` / `test`) のワークフロー自体が起動せず、チェックが永久に「待ち」のままマージ不能になる。`main` は直 push 不可なので実質使い道がない
 - `[skip deploy]`: Vercel のみスキップ、GitHub Actions は動く（デスクトップリリース時に使う）
-- 例: `docs: CLAUDE.mdを更新 [skip ci]`
+- ドキュメント (Markdown) のみの変更は、CI が重いジョブ (`check` / `test` / `test-integration`) を path フィルタで自動スキップする (`.github/workflows/ci.yml` の `changes` ジョブ)。スキップされた必須チェックは Branch Protection 上「成功」扱いになるためタグ不要
+- 例: `docs: CLAUDE.mdを更新`（タグ不要。CI が自動で軽量スキップ）
 - 例: `chore: デスクトップアプリ v0.2.0 にバージョンアップ [skip deploy]`
 
 ## デスクトップアプリのリリース

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@
 | 共有 | トークンベースの旅行共有 (未登録ユーザーにも閲覧可) |
 | デスクトップアプリ | Tauri 製ネイティブアプリ (macOS / Windows)、自動更新対応 |
 | モバイル対応 | SP 専用レイアウトによるモバイルフレンドリーな UI |
+| 外部 API (v1) | API キー (Bearer トークン) + スコープ認証の REST API。旅行・費用・候補・お土産・ブックマーク・記事の取得/作成/更新 |
+| MCP サーバー | 外部 API v1 を stdio でラップする Model Context Protocol サーバー。Claude Desktop / Claude Code から旅行データを操作 |
 
 ## アーキテクチャ
 
@@ -43,8 +45,9 @@
 sugara/
 ├── apps/
 │   ├── web/          # Next.js フロントエンド + API Route Handler
-│   ├── api/          # Hono API ルート・DB スキーマ・認証
-│   └── desktop/      # Tauri デスクトップアプリ (macOS / Windows)
+│   ├── api/          # Hono API ルート・DB スキーマ・認証 (外部 API v1 を含む)
+│   ├── desktop/      # Tauri デスクトップアプリ (macOS / Windows)
+│   └── mcp/          # MCP (Model Context Protocol) サーバー (外部 API v1 を stdio でラップ)
 ├── packages/
 │   └── shared/       # 共有 Zod スキーマ・型定義
 ├── supabase/         # Supabase CLI 設定・マイグレーション
@@ -74,7 +77,7 @@ sugara/
 
 ### 前提条件
 
-- [bun](https://bun.sh/) >= 1.0
+- [bun](https://bun.sh/) >= 1.3.2 (`packageManager` で固定)
 - [Supabase CLI](https://supabase.com/docs/guides/cli)
 - [Docker](https://www.docker.com/) (Supabase CLI が内部で使用)
 
@@ -137,6 +140,9 @@ bun run db:seed
 | `bun run db:migrate` | マイグレーション実行 |
 | `bun run db:studio` | Drizzle Studio 起動 |
 | `bun run db:seed` | 開発用シードデータ投入 |
+| `bun run db:seed-faqs` | FAQ データ投入 |
+| `bun run test:coverage` | カバレッジ付きテスト実行 |
+| `bun run test:e2e` | E2E テスト実行 (Playwright) |
 
 パッケージ単位の実行:
 
@@ -165,7 +171,7 @@ bun run --filter @sugara/shared check-types
 
 | フック | 内容 | 目的 |
 |--------|------|------|
-| pre-commit | `bun run check` (Biome) + `check-i18n` (messages 変更時のみ) | 1 秒以内に終わる軽いチェック |
+| pre-commit | `branch-guard` (main/master への直接コミット禁止) + `bun run check` (Biome) + `check-i18n` (messages 変更時のみ) | 1 秒以内に終わる軽いチェック |
 | commit-msg | Conventional Commits 形式を強制 | 履歴の一貫性 |
 | pre-push | `bun run check-types` + `bun audit` | push 前に型エラーを検出 |
 
@@ -189,14 +195,17 @@ bun run --filter @sugara/shared check-types
 
 ### CI / デプロイのスキップ
 
-コミットメッセージにタグを付けることでスキップできる。
+ドキュメント (Markdown) のみの変更では、CI の重いジョブ (`check` / `test` / `test-integration`) が path フィルタで自動スキップされる。スキップされた必須チェックは Branch Protection 上「成功」扱いになるため、PR はそのままマージできる。**タグを付ける必要はない**。
+
+コミットメッセージのタグでスキップを制御することもできる。
 
 | タグ | 効果 | 用途 |
 |------|------|------|
-| `[skip ci]` | Vercel + GitHub Actions 両方スキップ | ドキュメントのみの変更 |
-| `[skip deploy]` | Vercel のみスキップ (GitHub Actions は動く) | デスクトップリリース時 |
+| `[skip deploy]` | Vercel デプロイをスキップ (GitHub Actions は動く) | デスクトップのみのリリース時 |
+| `[skip ci]` | Vercel + GitHub Actions を**両方**スキップ | PR では使わない (下記) |
 
-ただし **DB migration は `[skip deploy]` でも走る** (`.github/workflows/db-migrate.yml` が `apps/api/drizzle/**` などの変更を検知して独立実行)。
+- `[skip ci]` を PR コミットに付けると、必須チェック (`check` / `test`) のワークフロー自体が起動せず、チェックが永久に「待ち」のままマージ不能になる。`main` は Branch Protection で直 push 不可なので `[skip ci]` は実質使い道がない。ドキュメントのみの変更は上記の自動スキップに任せる。
+- DB migration は Vercel の本番ビルド (`apps/web/vercel.json` の `buildCommand` が `next build` の前に `bun run db:migrate` を実行) の一部として走る。独立した migration 用 workflow はない。そのため `[skip deploy]` で Vercel をスキップすると migration も走らない (デスクトップのみのリリースは DB に影響しないため問題ない)。
 
 ## リンク
 

--- a/docs/development/release-flow.md
+++ b/docs/development/release-flow.md
@@ -11,8 +11,7 @@ feature branch ── push ──▶ PR 作成
                              │
                              └── CI green ─ 手動 squash merge ─▶ main
                                                                    │
-                                                                   ├── Vercel 自動デプロイ (web)
-                                                                   ├── db-migrate.yml (migration 変更時のみ)
+                                                                   ├── Vercel 自動デプロイ (web。buildCommand 内で db:migrate も実行)
                                                                    ├── desktop-tag.yml (tauri.conf.json 変更時)
                                                                    └── smoke-test.yml (deploy 成功後)
 ```
@@ -149,7 +148,7 @@ Vercel `Settings → Environment Variables` で設定、**全て "Sensitive" フ
 
 `Settings → Environments → production` で:
 
-- `MIGRATION_URL` — db-migrate.yml が使用
+- `MIGRATION_URL` — Vercel の本番ビルド (`buildCommand` 内の `db:migrate`) が使用 (Vercel env に設定。独立した GitHub Actions の migration workflow はない)
 - 本番環境の secret rotation は Vercel 側の env と同じタイミングで更新
 
 ### ローテーション方針


### PR DESCRIPTION
## 概要

ドキュメント (Markdown) のみの PR で CI の重いジョブが毎回フル実行されていた問題を解消し、合わせて長期間更新されていなかった README 等のドキュメント乖離を修正する。

## 変更内容

### 1. CI: docs-only で重いジョブを自動スキップ (`.github/workflows/ci.yml`)

- `changes` ジョブに `code` フィルタ (`** 除く !**/*.md`) を追加し、`check` / `test` / `test-integration` をゲート
- Markdown のみの PR ではこの3ジョブをスキップ。**スキップされた必須チェック (`check` / `test`) は Branch Protection 上「成功」扱い**になるため、PR はそのままマージできる
- これにより `[skip ci]` が不要になる ( `[skip ci]` は必須チェックの起動自体を止めてしまい、PR では永久 pending → マージ不能のデッドロックを起こす)
- 負パターン `!**/*.md` は default の `some` (OR) モードだとほぼ全ファイルにマッチして破綻するため、**専用の paths-filter ステップに `predicate-quantifier: 'every'` で隔離**。既存の multi-positive な `web` フィルタ (default quantifier) は別ステップのまま温存
- `main` への push は従来どおり全ジョブ実行 (`github.event_name != 'pull_request'` 条件)

### 2. ドキュメント乖離の修正

- **db-migrate.yml 誤記**: README / CLAUDE.md / release-flow.md が参照していた `.github/workflows/db-migrate.yml` は実在しない。実態は Vercel の `buildCommand` 内で `db:migrate` を実行するため、記述を実態に修正。`[skip deploy]` では Vercel ごと止まり migration も走らない旨を明記
- **ルート README に MCP / 外部 API を追記**: architecture ツリーに `apps/mcp/`、機能表に「外部 API (v1)」「MCP サーバー」を追加 (直近の #187 で追加された機能が未反映だった)
- **CI スキップ節を全面改訂**: 新挙動 (docs-only 自動スキップ) と `[skip ci]` のデッドロック注意を追記
- **軽微な鮮度修正**: bun 前提 `>= 1.3.2`、lefthook の `branch-guard`、不足スクリプト (`test:e2e` 等) を追記

## 設計根拠 (negation pattern)

dorny/paths-filter は default `predicate-quantifier: 'some'` だと負パターンが OR 評価され `!**/*.md` が「.md 以外の全ファイル」にマッチして意図と逆になる既知挙動がある。`'every'` (AND) + 単一 positive `'**'` の組み合わせが公式に確実に動く書き方のため、これを採用。

## Test plan

- [x] `ci.yml` を pyyaml でパース、`check`/`test`/`test-integration` に `needs: changes` + `if` が付与され `changes.outputs` に `code` が追加されたことを確認
- [x] lefthook pre-commit (`turbo check` 全5パッケージ) green
- [x] 3ドキュメントから `db-migrate.yml` 参照が消えたことを grep で確認
- [ ] **docs-only スキップの実挙動**: 本 PR は `ci.yml` を変更するため `code=true` となりフル実行される (= コード変更時に従来どおり走ることの確認になる)。Markdown のみをスキップする経路は、マージ後に docs-only の後続 PR で確認するのが確実

## 補足

CodeQL (`codeql.yml`) は必須チェックではないが docs-only でも実行される。セキュリティ解析のため本 PR では gate していない。必要なら別途 `paths-ignore` を検討可能。

🤖 Generated with [Claude Code](https://claude.com/claude-code)