### PR TITLE
feat: 外部API(v1)/MCPに件数メタ・検索・一括作成・削除を追加

### DIFF
--- a/apps/api/src/__tests__/integration/v1-writes.integration.test.ts
+++ b/apps/api/src/__tests__/integration/v1-writes.integration.test.ts
@@ -39,6 +39,7 @@ vi.mock("../../lib/notifications", () => ({
   notifyUsers: vi.fn(),
 }));
 
+import { MAX_SCHEDULES_PER_TRIP, MAX_SOUVENIRS_PER_USER_PER_TRIP } from "@sugara/shared";
 import { eq } from "drizzle-orm";
 import { articles, expenses, tripDays, tripMembers } from "../../db/schema";
 import { v1App } from "../../routes/v1/index";
@@ -360,5 +361,82 @@ describe("v1 write routes integration", () => {
     });
     const sortOrders = rows.map((r) => r.sortOrder);
     expect(new Set(sortOrders).size).toBe(sortOrders.length);
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /trips/:tripId/souvenirs — _meta reflects per-user-per-trip count
+  // -------------------------------------------------------------------------
+
+  it("POST /trips/:tripId/souvenirs returns _meta with count=1 and correct max after first insert", async () => {
+    // Arrange: create trip (owner becomes member automatically)
+    const tripRes = await v1App.request("/trips", {
+      method: "POST",
+      headers: { Authorization: "Bearer sk_test", "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "Souvenir Trip",
+        startDate: "2026-07-01",
+        endDate: "2026-07-01",
+      }),
+    });
+    expect(tripRes.status).toBe(201);
+    const trip = await tripRes.json();
+
+    apiKey = { ...apiKey, scopes: ["souvenirs:write"] };
+    mockVerifyApiKey.mockResolvedValue(apiKey);
+
+    // Act
+    const res = await v1App.request(`/trips/${trip.id}/souvenirs`, {
+      method: "POST",
+      headers: { Authorization: "Bearer sk_test", "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "Matcha KitKat" }),
+    });
+
+    // Assert
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body._meta).toEqual({ count: 1, max: MAX_SOUVENIRS_PER_USER_PER_TRIP });
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /trips/:tripId/candidates — _meta.count includes ALL schedules
+  // (assigned + candidates), not just candidates
+  // -------------------------------------------------------------------------
+
+  it("POST /trips/:tripId/candidates _meta.count includes pre-existing assigned schedules", async () => {
+    // Arrange: create a 1-day trip and add one schedule to day 1 (assigned).
+    // Then POST a candidate. The _meta.count must be 2 (1 assigned + 1 candidate),
+    // confirming getScheduleCount counts ALL schedules, not just candidates.
+    const tripRes = await v1App.request("/trips", {
+      method: "POST",
+      headers: { Authorization: "Bearer sk_test", "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "Candidate Trip",
+        startDate: "2026-07-01",
+        endDate: "2026-07-01",
+      }),
+    });
+    expect(tripRes.status).toBe(201);
+    const trip = await tripRes.json();
+
+    // Add one assigned schedule to day 1 via the existing schedule endpoint
+    const schedRes = await v1App.request(`/trips/${trip.id}/days/1/schedules`, {
+      method: "POST",
+      headers: { Authorization: "Bearer sk_test", "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "Tokyo Tower", category: "sightseeing" }),
+    });
+    expect(schedRes.status).toBe(201);
+
+    // Act: POST candidate (unassigned schedule)
+    const res = await v1App.request(`/trips/${trip.id}/candidates`, {
+      method: "POST",
+      headers: { Authorization: "Bearer sk_test", "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "Akihabara", category: "sightseeing" }),
+    });
+
+    // Assert: _meta.count is 2 — both assigned schedule and new candidate are
+    // counted because MAX_SCHEDULES_PER_TRIP is a trip-wide cap over all schedules.
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body._meta).toEqual({ count: 2, max: MAX_SCHEDULES_PER_TRIP });
   });
 });

--- a/apps/api/src/__tests__/integration/v1-writes.integration.test.ts
+++ b/apps/api/src/__tests__/integration/v1-writes.integration.test.ts
@@ -41,7 +41,7 @@ vi.mock("../../lib/notifications", () => ({
 
 import { MAX_SCHEDULES_PER_TRIP, MAX_SOUVENIRS_PER_USER_PER_TRIP } from "@sugara/shared";
 import { eq } from "drizzle-orm";
-import { articles, expenses, tripDays, tripMembers } from "../../db/schema";
+import { articles, expenses, schedules, tripDays, tripMembers } from "../../db/schema";
 import { v1App } from "../../routes/v1/index";
 import { cleanupTables, createTestUser, getTestDb, teardownTestDb } from "./setup";
 
@@ -684,5 +684,278 @@ describe("v1 write routes integration", () => {
     expect(res.status).toBe(201);
     const body = await res.json();
     expect(body._meta).toEqual({ count: 2, max: MAX_SCHEDULES_PER_TRIP });
+  });
+
+  // -------------------------------------------------------------------------
+  // DELETE /trips/:tripId/candidates/:scheduleId
+  // -------------------------------------------------------------------------
+
+  it("DELETE candidate returns deleted:true and decrements remaining on first delete", async () => {
+    // Arrange: create trip and one candidate
+    const tripRes = await v1App.request("/trips", {
+      method: "POST",
+      headers: { Authorization: "Bearer sk_test", "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "Delete Trip",
+        startDate: "2026-07-01",
+        endDate: "2026-07-01",
+      }),
+    });
+    expect(tripRes.status).toBe(201);
+    const trip = await tripRes.json();
+
+    const candRes = await v1App.request(`/trips/${trip.id}/candidates`, {
+      method: "POST",
+      headers: { Authorization: "Bearer sk_test", "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "Tokyo Tower", category: "sightseeing" }),
+    });
+    expect(candRes.status).toBe(201);
+    const cand = await candRes.json();
+
+    apiKey = { ...apiKey, scopes: ["trips:write"] };
+    mockVerifyApiKey.mockResolvedValue(apiKey);
+
+    // Act
+    const res = await v1App.request(`/trips/${trip.id}/candidates/${cand.id}`, {
+      method: "DELETE",
+      headers: { Authorization: "Bearer sk_test" },
+    });
+
+    // Assert
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.deleted).toBe(true);
+    expect(body.id).toBe(cand.id);
+    // The trip only had the one candidate (no assigned schedules), so after deleting
+    // it the trip-wide schedule count is 0.
+    expect(body.remaining).toEqual({ count: 0, max: MAX_SCHEDULES_PER_TRIP });
+  });
+
+  it("DELETE candidate is idempotent: second call returns deleted:false with same remaining", async () => {
+    // Arrange: create trip, one candidate, delete it once
+    const tripRes = await v1App.request("/trips", {
+      method: "POST",
+      headers: { Authorization: "Bearer sk_test", "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "Idempotent Trip",
+        startDate: "2026-07-01",
+        endDate: "2026-07-01",
+      }),
+    });
+    const trip = await tripRes.json();
+
+    const candRes = await v1App.request(`/trips/${trip.id}/candidates`, {
+      method: "POST",
+      headers: { Authorization: "Bearer sk_test", "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "Akihabara", category: "sightseeing" }),
+    });
+    const cand = await candRes.json();
+
+    apiKey = { ...apiKey, scopes: ["trips:write"] };
+    mockVerifyApiKey.mockResolvedValue(apiKey);
+
+    // First delete
+    const first = await v1App.request(`/trips/${trip.id}/candidates/${cand.id}`, {
+      method: "DELETE",
+      headers: { Authorization: "Bearer sk_test" },
+    });
+    expect((await first.json()).deleted).toBe(true);
+
+    // Act: second delete (idempotent)
+    const second = await v1App.request(`/trips/${trip.id}/candidates/${cand.id}`, {
+      method: "DELETE",
+      headers: { Authorization: "Bearer sk_test" },
+    });
+
+    // Assert
+    expect(second.status).toBe(200);
+    const body = await second.json();
+    expect(body.deleted).toBe(false);
+    expect(body.id).toBe(cand.id);
+  });
+
+  it("DELETE candidate returns deleted:false when schedule is assigned to a day (not a candidate)", async () => {
+    // Arrange: create 1-day trip, add a schedule to day 1 (assigned, not a candidate)
+    const tripRes = await v1App.request("/trips", {
+      method: "POST",
+      headers: { Authorization: "Bearer sk_test", "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "Assigned Trip",
+        startDate: "2026-07-01",
+        endDate: "2026-07-01",
+      }),
+    });
+    const trip = await tripRes.json();
+
+    const schedRes = await v1App.request(`/trips/${trip.id}/days/1/schedules`, {
+      method: "POST",
+      headers: { Authorization: "Bearer sk_test", "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "Tokyo Tower", category: "sightseeing" }),
+    });
+    expect(schedRes.status).toBe(201);
+    const sched = await schedRes.json();
+
+    apiKey = { ...apiKey, scopes: ["trips:write"] };
+    mockVerifyApiKey.mockResolvedValue(apiKey);
+
+    // Act: attempt to DELETE the assigned schedule via the candidates endpoint
+    const res = await v1App.request(`/trips/${trip.id}/candidates/${sched.id}`, {
+      method: "DELETE",
+      headers: { Authorization: "Bearer sk_test" },
+    });
+
+    // Assert: assigned schedules are not candidates → deleted:false, NOT physically removed
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.deleted).toBe(false);
+
+    // Regression guard: confirm the row still exists in DB (atomic WHERE must
+    // have excluded it, not physically removed it).
+    const db = getTestDb();
+    const row = await db.query.schedules.findFirst({ where: eq(schedules.id, sched.id) });
+    expect(row).toBeDefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // DELETE /trips/:tripId/souvenirs/:itemId
+  // -------------------------------------------------------------------------
+
+  it("DELETE souvenir returns deleted:true and decrements remaining on first delete", async () => {
+    // Arrange: create trip and one souvenir
+    const tripRes = await v1App.request("/trips", {
+      method: "POST",
+      headers: { Authorization: "Bearer sk_test", "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "Souvenir Delete Trip",
+        startDate: "2026-07-01",
+        endDate: "2026-07-01",
+      }),
+    });
+    expect(tripRes.status).toBe(201);
+    const trip = await tripRes.json();
+
+    apiKey = { ...apiKey, scopes: ["souvenirs:write"] };
+    mockVerifyApiKey.mockResolvedValue(apiKey);
+
+    const createRes = await v1App.request(`/trips/${trip.id}/souvenirs`, {
+      method: "POST",
+      headers: { Authorization: "Bearer sk_test", "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "Matcha KitKat" }),
+    });
+    expect(createRes.status).toBe(201);
+    const souvenir = await createRes.json();
+
+    // Act
+    const res = await v1App.request(`/trips/${trip.id}/souvenirs/${souvenir.id}`, {
+      method: "DELETE",
+      headers: { Authorization: "Bearer sk_test" },
+    });
+
+    // Assert
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.deleted).toBe(true);
+    expect(body.id).toBe(souvenir.id);
+    expect(body.remaining).toEqual({ count: 0, max: MAX_SOUVENIRS_PER_USER_PER_TRIP });
+  });
+
+  it("DELETE souvenir is idempotent: second call returns deleted:false", async () => {
+    // Arrange: create trip and souvenir, delete once
+    const tripRes = await v1App.request("/trips", {
+      method: "POST",
+      headers: { Authorization: "Bearer sk_test", "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "Souvenir Idempotent Trip",
+        startDate: "2026-07-01",
+        endDate: "2026-07-01",
+      }),
+    });
+    const trip = await tripRes.json();
+
+    apiKey = { ...apiKey, scopes: ["souvenirs:write"] };
+    mockVerifyApiKey.mockResolvedValue(apiKey);
+
+    const createRes = await v1App.request(`/trips/${trip.id}/souvenirs`, {
+      method: "POST",
+      headers: { Authorization: "Bearer sk_test", "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "Pocky" }),
+    });
+    const souvenir = await createRes.json();
+
+    // First delete
+    const first = await v1App.request(`/trips/${trip.id}/souvenirs/${souvenir.id}`, {
+      method: "DELETE",
+      headers: { Authorization: "Bearer sk_test" },
+    });
+    expect((await first.json()).deleted).toBe(true);
+
+    // Act: second delete
+    const second = await v1App.request(`/trips/${trip.id}/souvenirs/${souvenir.id}`, {
+      method: "DELETE",
+      headers: { Authorization: "Bearer sk_test" },
+    });
+
+    // Assert
+    expect(second.status).toBe(200);
+    const body = await second.json();
+    expect(body.deleted).toBe(false);
+    expect(body.id).toBe(souvenir.id);
+  });
+
+  it("DELETE souvenir returns deleted:false for another user's item (no information leak)", async () => {
+    // Arrange: create trip, add Bob as member, create souvenir owned by Alice,
+    // then try to delete it as Bob — must return deleted:false, item stays.
+    const tripRes = await v1App.request("/trips", {
+      method: "POST",
+      headers: { Authorization: "Bearer sk_test", "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "Ownership Trip",
+        startDate: "2026-07-01",
+        endDate: "2026-07-01",
+      }),
+    });
+    const trip = await tripRes.json();
+
+    const db = getTestDb();
+    const bob = await createTestUser({ name: "Bob", email: "bob@souvenir-delete.test" });
+    await db.insert(tripMembers).values({ tripId: trip.id, userId: bob.id, role: "viewer" });
+
+    // Alice creates a souvenir
+    apiKey = { ...apiKey, scopes: ["souvenirs:write"] };
+    mockVerifyApiKey.mockResolvedValue(apiKey);
+    const createRes = await v1App.request(`/trips/${trip.id}/souvenirs`, {
+      method: "POST",
+      headers: { Authorization: "Bearer sk_test", "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "Alice's KitKat" }),
+    });
+    const aliceSouvenir = await createRes.json();
+
+    // Bob tries to delete Alice's souvenir
+    const bobApiKey = {
+      id: "cccccccc-0000-0000-0000-000000000001",
+      userId: bob.id,
+      scopes: ["souvenirs:write"],
+      expiresAt: new Date(Date.now() + 3_600_000),
+    };
+    mockVerifyApiKey.mockResolvedValue(bobApiKey);
+
+    // Act
+    const res = await v1App.request(`/trips/${trip.id}/souvenirs/${aliceSouvenir.id}`, {
+      method: "DELETE",
+      headers: { Authorization: "Bearer sk_test" },
+    });
+
+    // Assert: deleted:false — Bob cannot see or delete Alice's item
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.deleted).toBe(false);
+
+    // Assert: Alice's souvenir still exists in the DB
+    const { souvenirItems } = await import("../../db/schema");
+    const { eq: eqFn } = await import("drizzle-orm");
+    const row = await db.query.souvenirItems.findFirst({
+      where: eqFn(souvenirItems.id, aliceSouvenir.id),
+    });
+    expect(row).toBeDefined();
   });
 });

--- a/apps/api/src/__tests__/integration/v1-writes.integration.test.ts
+++ b/apps/api/src/__tests__/integration/v1-writes.integration.test.ts
@@ -398,6 +398,252 @@ describe("v1 write routes integration", () => {
   });
 
   // -------------------------------------------------------------------------
+  // POST /trips/:tripId/candidates/batch
+  // -------------------------------------------------------------------------
+
+  it("POST /trips/:tripId/candidates/batch creates all items with consecutive sortOrders", async () => {
+    // Arrange: 1-day trip, caller is editor
+    const tripRes = await v1App.request("/trips", {
+      method: "POST",
+      headers: { Authorization: "Bearer sk_test", "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "Batch Trip", startDate: "2026-07-01", endDate: "2026-07-01" }),
+    });
+    expect(tripRes.status).toBe(201);
+    const trip = await tripRes.json();
+
+    // Act
+    const res = await v1App.request(`/trips/${trip.id}/candidates/batch`, {
+      method: "POST",
+      headers: { Authorization: "Bearer sk_test", "Content-Type": "application/json" },
+      body: JSON.stringify({
+        items: [
+          { name: "Tokyo Tower", category: "sightseeing" },
+          { name: "Akihabara", category: "sightseeing" },
+          { name: "Shibuya", category: "sightseeing" },
+        ],
+      }),
+    });
+
+    // Assert
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.created).toHaveLength(3);
+    expect(body.skipped).toHaveLength(0);
+    expect(body._meta.count).toBe(3);
+
+    // sortOrders must be unique and ascending (consecutive allocation in-memory)
+    const sortOrders = body.created
+      .map((c: { sortOrder: number }) => c.sortOrder)
+      .sort((a: number, b: number) => a - b);
+    expect(new Set(sortOrders).size).toBe(3);
+    expect(sortOrders[1] - sortOrders[0]).toBe(1);
+    expect(sortOrders[2] - sortOrders[1]).toBe(1);
+  });
+
+  it("POST /trips/:tripId/candidates/batch with onConflict=skip deduplicates by name (trim+lowercase)", async () => {
+    // Arrange: create trip and a pre-existing candidate
+    const tripRes = await v1App.request("/trips", {
+      method: "POST",
+      headers: { Authorization: "Bearer sk_test", "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "Dedup Trip", startDate: "2026-07-01", endDate: "2026-07-01" }),
+    });
+    const trip = await tripRes.json();
+
+    // Pre-insert one candidate via single create
+    const preRes = await v1App.request(`/trips/${trip.id}/candidates`, {
+      method: "POST",
+      headers: { Authorization: "Bearer sk_test", "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "Tokyo Tower", category: "sightseeing" }),
+    });
+    expect(preRes.status).toBe(201);
+
+    // Act: batch with existing name + case/space variants + in-batch dupe + new name
+    const res = await v1App.request(`/trips/${trip.id}/candidates/batch`, {
+      method: "POST",
+      headers: { Authorization: "Bearer sk_test", "Content-Type": "application/json" },
+      body: JSON.stringify({
+        items: [
+          { name: "tokyo tower", category: "sightseeing" }, // same after lowercase
+          { name: "  Tokyo Tower  ", category: "sightseeing" }, // same after trim
+          { name: "Akihabara", category: "sightseeing" }, // new — should be created
+          { name: "Akihabara", category: "sightseeing" }, // in-batch dupe — skipped
+        ],
+        onConflict: "skip",
+      }),
+    });
+
+    // Assert
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    // Only "Akihabara" (first occurrence) is created; the rest are skipped as duplicates
+    expect(body.created).toHaveLength(1);
+    expect(body.created[0].name).toBe("Akihabara");
+    expect(body.skipped).toHaveLength(3);
+    expect(body.skipped.every((s: { reason: string }) => s.reason === "duplicate")).toBe(true);
+  });
+
+  it("POST /trips/:tripId/candidates/batch with onConflict=create inserts same-name items", async () => {
+    // Arrange
+    const tripRes = await v1App.request("/trips", {
+      method: "POST",
+      headers: { Authorization: "Bearer sk_test", "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "No-dedup Trip",
+        startDate: "2026-07-01",
+        endDate: "2026-07-01",
+      }),
+    });
+    const trip = await tripRes.json();
+
+    // Act: two items with the same name, onConflict defaults to "create"
+    const res = await v1App.request(`/trips/${trip.id}/candidates/batch`, {
+      method: "POST",
+      headers: { Authorization: "Bearer sk_test", "Content-Type": "application/json" },
+      body: JSON.stringify({
+        items: [
+          { name: "Tokyo Tower", category: "sightseeing" },
+          { name: "Tokyo Tower", category: "sightseeing" },
+        ],
+      }),
+    });
+
+    // Assert: both inserted, no skipped
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.created).toHaveLength(2);
+    expect(body.skipped).toHaveLength(0);
+  });
+
+  it("POST /trips/:tripId/candidates/batch returns partial success when limit is reached mid-batch", async () => {
+    // Arrange: create a trip and fill it to MAX-1 using many batch calls, then test overflow
+    const db = getTestDb();
+    const tripRes = await v1App.request("/trips", {
+      method: "POST",
+      headers: { Authorization: "Bearer sk_test", "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "Limit Trip", startDate: "2026-07-01", endDate: "2026-07-01" }),
+    });
+    const trip = await tripRes.json();
+
+    // Fill to MAX_SCHEDULES_PER_TRIP - 1 with individual creates to avoid test complexity
+    // (use db directly for speed)
+    const { schedules } = await import("../../db/schema");
+    const placeholders = Array.from({ length: MAX_SCHEDULES_PER_TRIP - 1 }, (_, i) => ({
+      tripId: trip.id,
+      name: `Place ${i}`,
+      category: "sightseeing" as const,
+      sortOrder: i,
+    }));
+    await db.insert(schedules).values(placeholders);
+
+    // Act: batch with 3 items; only 1 should fit
+    const res = await v1App.request(`/trips/${trip.id}/candidates/batch`, {
+      method: "POST",
+      headers: { Authorization: "Bearer sk_test", "Content-Type": "application/json" },
+      body: JSON.stringify({
+        items: [
+          { name: "Last Slot", category: "sightseeing" },
+          { name: "Overflow 1", category: "sightseeing" },
+          { name: "Overflow 2", category: "sightseeing" },
+        ],
+      }),
+    });
+
+    // Assert: 201 with partial success, _meta.count at the cap
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.created).toHaveLength(1);
+    expect(body.created[0].name).toBe("Last Slot");
+    expect(body.skipped).toHaveLength(2);
+    expect(body.skipped.every((s: { reason: string }) => s.reason === "limit_reached")).toBe(true);
+    expect(body._meta.count).toBe(MAX_SCHEDULES_PER_TRIP);
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /trips/:tripId/souvenirs/batch
+  // -------------------------------------------------------------------------
+
+  it("POST /trips/:tripId/souvenirs/batch creates all items and returns correct _meta.count", async () => {
+    // Arrange: create trip, switch to souvenirs:write scope
+    const tripRes = await v1App.request("/trips", {
+      method: "POST",
+      headers: { Authorization: "Bearer sk_test", "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "Souvenir Batch Trip",
+        startDate: "2026-07-01",
+        endDate: "2026-07-01",
+      }),
+    });
+    expect(tripRes.status).toBe(201);
+    const trip = await tripRes.json();
+
+    apiKey = { ...apiKey, scopes: ["souvenirs:write"] };
+    mockVerifyApiKey.mockResolvedValue(apiKey);
+
+    // Act
+    const res = await v1App.request(`/trips/${trip.id}/souvenirs/batch`, {
+      method: "POST",
+      headers: { Authorization: "Bearer sk_test", "Content-Type": "application/json" },
+      body: JSON.stringify({
+        items: [{ name: "Matcha KitKat" }, { name: "Pocky" }],
+      }),
+    });
+
+    // Assert
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.created).toHaveLength(2);
+    expect(body.skipped).toHaveLength(0);
+    expect(body._meta).toEqual({ count: 2, max: MAX_SOUVENIRS_PER_USER_PER_TRIP });
+  });
+
+  it("POST /trips/:tripId/souvenirs/batch with onConflict=skip deduplicates caller's own items", async () => {
+    // Arrange: create trip and a pre-existing souvenir
+    const tripRes = await v1App.request("/trips", {
+      method: "POST",
+      headers: { Authorization: "Bearer sk_test", "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "Souvenir Dedup Trip",
+        startDate: "2026-07-01",
+        endDate: "2026-07-01",
+      }),
+    });
+    const trip = await tripRes.json();
+
+    apiKey = { ...apiKey, scopes: ["souvenirs:write"] };
+    mockVerifyApiKey.mockResolvedValue(apiKey);
+
+    // Pre-insert one souvenir
+    const preRes = await v1App.request(`/trips/${trip.id}/souvenirs`, {
+      method: "POST",
+      headers: { Authorization: "Bearer sk_test", "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "Matcha KitKat" }),
+    });
+    expect(preRes.status).toBe(201);
+
+    // Act: batch with existing name + case variant + in-batch dupe + new name
+    const res = await v1App.request(`/trips/${trip.id}/souvenirs/batch`, {
+      method: "POST",
+      headers: { Authorization: "Bearer sk_test", "Content-Type": "application/json" },
+      body: JSON.stringify({
+        items: [
+          { name: "MATCHA KITKAT" }, // same after lowercase — skipped
+          { name: "Pocky" }, // new — created
+          { name: "Pocky" }, // in-batch dupe — skipped
+        ],
+        onConflict: "skip",
+      }),
+    });
+
+    // Assert
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.created).toHaveLength(1);
+    expect(body.created[0].name).toBe("Pocky");
+    expect(body.skipped).toHaveLength(2);
+    expect(body.skipped.every((s: { reason: string }) => s.reason === "duplicate")).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
   // POST /trips/:tripId/candidates — _meta.count includes ALL schedules
   // (assigned + candidates), not just candidates
   // -------------------------------------------------------------------------

--- a/apps/api/src/__tests__/v1-routes.test.ts
+++ b/apps/api/src/__tests__/v1-routes.test.ts
@@ -728,6 +728,59 @@ describe("GET /bookmark-lists/:listId/bookmarks", () => {
     const body = await res.json();
     expect(body).toEqual({ error: { code: "invalid_request", message: expect.any(String) } });
   });
+
+  it("accepts q and returns 200 with name-filtered bookmarks", async () => {
+    // Arrange
+    setupValidKey();
+    mockDbQuery.bookmarkLists.findFirst.mockResolvedValue({
+      id: LIST_ID,
+      userId: USER_ID_1,
+      name: "Places",
+    });
+    mockCountQuery(1);
+    mockDbQuery.bookmarks.findMany.mockResolvedValue([
+      {
+        id: "bm-1",
+        name: "Senso-ji",
+        memo: null,
+        urls: [],
+        sortOrder: 0,
+        createdAt: new Date("2026-01-01T00:00:00Z"),
+        updatedAt: new Date("2026-01-01T00:00:00Z"),
+      },
+    ]);
+
+    // Act
+    const res = await v1App.request(`/bookmark-lists/${LIST_ID}/bookmarks?q=Senso`, {
+      headers: AUTH_HEADER,
+    });
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(200);
+    expect(body.data).toHaveLength(1);
+    expect(body.pagination.total).toBe(1);
+  });
+
+  it("treats empty q as no filter and returns all bookmarks", async () => {
+    // Arrange
+    setupValidKey();
+    mockDbQuery.bookmarkLists.findFirst.mockResolvedValue({
+      id: LIST_ID,
+      userId: USER_ID_1,
+      name: "Places",
+    });
+    mockCountQuery(0);
+    mockDbQuery.bookmarks.findMany.mockResolvedValue([]);
+
+    // Act — q= (empty) must not cause 400
+    const res = await v1App.request(`/bookmark-lists/${LIST_ID}/bookmarks?q=`, {
+      headers: AUTH_HEADER,
+    });
+
+    // Assert
+    expect(res.status).toBe(200);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -792,6 +845,35 @@ describe("GET /articles", () => {
     const body = await res.json();
 
     expect(articleListResponseSchema.safeParse(body).success).toBe(true);
+  });
+
+  it("accepts q and returns 200 with title-filtered articles", async () => {
+    // Arrange
+    setupValidKey();
+    mockCountQuery(1);
+    mockDbQuery.articles.findMany.mockResolvedValue([articleSummaryRow]);
+
+    // Act
+    const res = await v1App.request("/articles?q=Kyoto", { headers: AUTH_HEADER });
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(200);
+    expect(body.data).toHaveLength(1);
+    expect(body.pagination.total).toBe(1);
+  });
+
+  it("treats empty q as no filter and returns all articles", async () => {
+    // Arrange
+    setupValidKey();
+    mockCountQuery(0);
+    mockDbQuery.articles.findMany.mockResolvedValue([]);
+
+    // Act — q= (empty) must not cause 400
+    const res = await v1App.request("/articles?q=", { headers: AUTH_HEADER });
+
+    // Assert
+    expect(res.status).toBe(200);
   });
 });
 
@@ -928,6 +1010,62 @@ describe("GET /trips/:tripId/candidates", () => {
     expect(json).not.toContain('"dayPatternId"');
     expect(json).not.toContain('"tripId"');
   });
+
+  it("accepts q and returns 200 with data from the filtered DB result", async () => {
+    // Arrange
+    setupValidKey();
+    mockCheckTripAccess.mockResolvedValue("owner");
+    mockCountQuery(1);
+    mockDbQuery.schedules.findMany.mockResolvedValue([
+      {
+        id: "cand-1",
+        tripId: TRIP_ID,
+        dayPatternId: null,
+        name: "Tokyo Tower",
+        category: "sightseeing",
+        startTime: null,
+        endTime: null,
+        address: null,
+        memo: null,
+        urls: [],
+        departurePlace: null,
+        arrivalPlace: null,
+        transportMethod: null,
+        cost: null,
+        color: "blue",
+        endDayOffset: null,
+        sortOrder: 0,
+        createdAt: new Date("2026-06-01T00:00:00Z"),
+        updatedAt: new Date("2026-06-01T00:00:00Z"),
+      },
+    ]);
+
+    // Act
+    const res = await v1App.request(`/trips/${TRIP_ID}/candidates?q=Tower`, {
+      headers: AUTH_HEADER,
+    });
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(200);
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].name).toBe("Tokyo Tower");
+    expect(body.pagination.total).toBe(1);
+  });
+
+  it("treats empty q as no filter and returns all candidates", async () => {
+    // Arrange
+    setupValidKey();
+    mockCheckTripAccess.mockResolvedValue("owner");
+    mockCountQuery(0);
+    mockDbQuery.schedules.findMany.mockResolvedValue([]);
+
+    // Act — q= (empty string after URL decoding) must not cause 400
+    const res = await v1App.request(`/trips/${TRIP_ID}/candidates?q=`, { headers: AUTH_HEADER });
+
+    // Assert
+    expect(res.status).toBe(200);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -1027,5 +1165,74 @@ describe("GET /trips/:tripId/souvenirs", () => {
     const body = await res.json();
 
     expect(souvenirListResponseSchema.safeParse(body).success).toBe(true);
+  });
+
+  it("accepts q and returns 200 with filtered data", async () => {
+    // Arrange
+    setupValidKey(SOUVENIR_KEY);
+    mockCheckTripAccess.mockResolvedValue("owner");
+    mockDbQuery.tripMembers.findMany.mockResolvedValue([{ userId: USER_ID_1 }]);
+    mockCountQuery(1);
+    mockDbQuery.souvenirItems.findMany.mockResolvedValue([
+      {
+        id: "souv-1",
+        userId: USER_ID_1,
+        name: "Matcha KitKat",
+        recipient: null,
+        urls: [],
+        addresses: [],
+        memo: null,
+        priority: null,
+        isPurchased: false,
+        isShared: false,
+        shareStyle: null,
+        createdAt: new Date("2026-06-01T00:00:00Z"),
+        updatedAt: new Date("2026-06-01T00:00:00Z"),
+        user: { name: "Alice" },
+      },
+    ]);
+
+    // Act
+    const res = await v1App.request(`/trips/${TRIP_ID}/souvenirs?q=Matcha`, {
+      headers: AUTH_HEADER,
+    });
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(200);
+    expect(body.data).toHaveLength(1);
+    expect(body.pagination.total).toBe(1);
+  });
+
+  it("treats empty q as no filter and returns all souvenirs", async () => {
+    // Arrange
+    setupValidKey(SOUVENIR_KEY);
+    mockCheckTripAccess.mockResolvedValue("owner");
+    mockDbQuery.tripMembers.findMany.mockResolvedValue([{ userId: USER_ID_1 }]);
+    mockCountQuery(0);
+    mockDbQuery.souvenirItems.findMany.mockResolvedValue([]);
+
+    // Act
+    const res = await v1App.request(`/trips/${TRIP_ID}/souvenirs?q=`, { headers: AUTH_HEADER });
+
+    // Assert — empty q must not cause 400
+    expect(res.status).toBe(200);
+  });
+
+  it("accepts q with LIKE metacharacters without error", async () => {
+    // Arrange — percent sign must be escaped so it is not treated as a wildcard
+    setupValidKey(SOUVENIR_KEY);
+    mockCheckTripAccess.mockResolvedValue("owner");
+    mockDbQuery.tripMembers.findMany.mockResolvedValue([{ userId: USER_ID_1 }]);
+    mockCountQuery(0);
+    mockDbQuery.souvenirItems.findMany.mockResolvedValue([]);
+
+    // Act
+    const res = await v1App.request(`/trips/${TRIP_ID}/souvenirs?q=100%25`, {
+      headers: AUTH_HEADER,
+    });
+
+    // Assert — route must not crash or return 400
+    expect(res.status).toBe(200);
   });
 });

--- a/apps/api/src/__tests__/v1-write-routes.test.ts
+++ b/apps/api/src/__tests__/v1-write-routes.test.ts
@@ -456,6 +456,33 @@ describe("POST /trips/:tripId/days/:dayNumber/schedules", () => {
     expect(body.error.reason).toBe("schedule_limit_reached");
     expect(body.error.details).toEqual({ max: MAX_SCHEDULES_PER_TRIP });
   });
+
+  it("returns 201 with schedule DTO and no _meta (only candidate write routes carry _meta)", async () => {
+    // This test pins the contract that trips-write schedule routes are not
+    // cap-context aware. _meta belongs only on candidate write responses.
+    mockVerifyApiKey.mockResolvedValue(WRITE_KEY);
+    mockCheckTripAccess.mockResolvedValue("editor");
+    mockDbQuery.tripDays.findMany.mockResolvedValue([
+      { id: "day-1", dayNumber: 1, patterns: [{ id: "pattern-1" }] },
+    ]);
+    mockGetScheduleCount.mockResolvedValueOnce(0);
+    mockGetNextSortOrder.mockResolvedValueOnce(0);
+    mockDbInsert.mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([CANDIDATE_ROW]),
+      }),
+    });
+
+    const res = await jsonPost(`/trips/${TRIP_ID}/days/1/schedules`, {
+      name: "Tokyo Tower",
+      category: "sightseeing",
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(body.id).toBe(CANDIDATE_ROW.id);
+    expect(body._meta).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -930,6 +957,24 @@ describe("POST /trips/:tripId/candidates", () => {
     expect(res.status).toBe(403);
   });
 
+  it("includes _meta with post-insert schedule count and max in the 201 response", async () => {
+    // Arrange: createCandidateCore inserts 1 row; getScheduleCount returns 1.
+    mockVerifyApiKey.mockResolvedValue(WRITE_KEY);
+    mockCheckTripAccess.mockResolvedValue("editor");
+    mockCreateCandidateCore.mockResolvedValue({ ok: true, schedule: CANDIDATE_ROW });
+    mockGetScheduleCount.mockResolvedValueOnce(1);
+
+    // Act
+    const res = await jsonPost(`/trips/${TRIP_ID}/candidates`, {
+      name: "Tokyo Tower",
+      category: "sightseeing",
+    });
+    const body = await res.json();
+
+    // Assert
+    expect(body._meta).toEqual({ count: 1, max: MAX_SCHEDULES_PER_TRIP });
+  });
+
   it("returns 404 when caller has viewer role (editor-gated)", async () => {
     mockVerifyApiKey.mockResolvedValue(WRITE_KEY);
     mockCheckTripAccess.mockResolvedValue("viewer");
@@ -946,10 +991,9 @@ describe("POST /trips/:tripId/candidates", () => {
     mockVerifyApiKey.mockResolvedValue(WRITE_KEY);
     mockCheckTripAccess.mockResolvedValue("editor");
     mockCreateCandidateCore.mockResolvedValue({ ok: true, schedule: CANDIDATE_ROW });
-    // getActorName select (for the notification payload)
-    mockDbSelect.mockReturnValueOnce({
-      from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue([{ name: "Alice" }]) }),
-    });
+    // getActorName uses db.query.users.findFirst (not db.select); no mockDbSelect needed.
+    // getScheduleCount is mocked separately via mockGetScheduleCount.
+    mockGetScheduleCount.mockResolvedValueOnce(3);
 
     const res = await jsonPost(`/trips/${TRIP_ID}/candidates`, {
       name: "Tokyo Tower",
@@ -1024,6 +1068,7 @@ describe("PATCH /trips/:tripId/candidates/:scheduleId", () => {
     mockVerifyApiKey.mockResolvedValue(WRITE_KEY);
     mockCheckTripAccess.mockResolvedValue("editor");
     mockDbQuery.schedules.findFirst.mockResolvedValue(CANDIDATE_ROW);
+    mockGetScheduleCount.mockResolvedValueOnce(3);
     mockDbUpdate.mockReturnValue({
       set: vi.fn().mockReturnValue({
         where: vi.fn().mockReturnValue({
@@ -1039,6 +1084,47 @@ describe("PATCH /trips/:tripId/candidates/:scheduleId", () => {
 
     expect(res.status).toBe(200);
     expect(body.name).toBe("Updated");
+  });
+
+  it("includes _meta with schedule count and max in the 200 response on update", async () => {
+    // Arrange
+    mockVerifyApiKey.mockResolvedValue(WRITE_KEY);
+    mockCheckTripAccess.mockResolvedValue("editor");
+    mockDbQuery.schedules.findFirst.mockResolvedValue(CANDIDATE_ROW);
+    mockGetScheduleCount.mockResolvedValueOnce(3);
+    mockDbUpdate.mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ ...CANDIDATE_ROW, name: "Updated" }]),
+        }),
+      }),
+    });
+
+    // Act
+    const res = await jsonPatch(`/trips/${TRIP_ID}/candidates/${CANDIDATE_ROW.id}`, {
+      name: "Updated",
+    });
+    const body = await res.json();
+
+    // Assert
+    expect(body._meta).toEqual({ count: 3, max: MAX_SCHEDULES_PER_TRIP });
+  });
+
+  it("includes _meta in the 200 response on a no-op update (when no fields change)", async () => {
+    // Arrange: send the same name as the existing candidate → hasChanges returns false.
+    mockVerifyApiKey.mockResolvedValue(WRITE_KEY);
+    mockCheckTripAccess.mockResolvedValue("editor");
+    mockDbQuery.schedules.findFirst.mockResolvedValue(CANDIDATE_ROW);
+    mockGetScheduleCount.mockResolvedValueOnce(2);
+
+    // Act: same name as existing record → no-op path
+    const res = await jsonPatch(`/trips/${TRIP_ID}/candidates/${CANDIDATE_ROW.id}`, {
+      name: CANDIDATE_ROW.name,
+    });
+    const body = await res.json();
+
+    // Assert
+    expect(body._meta).toEqual({ count: 2, max: MAX_SCHEDULES_PER_TRIP });
   });
 });
 
@@ -1098,6 +1184,20 @@ describe("POST /trips/:tripId/souvenirs", () => {
     expect(res.status).toBe(403);
   });
 
+  it("includes _meta with post-insert count and max in the 201 response", async () => {
+    // Arrange: arrangeSouvenirCreate sets itemCount to 0 → post-insert count is 1.
+    mockVerifyApiKey.mockResolvedValue({ ...WRITE_KEY, scopes: ["souvenirs:write"] });
+    mockCheckTripAccess.mockResolvedValue("viewer");
+    arrangeSouvenirCreate(souvenirRow());
+
+    // Act
+    const res = await jsonPost(`/trips/${TRIP_ID}/souvenirs`, { name: "Matcha KitKat" });
+    const body = await res.json();
+
+    // Assert
+    expect(body._meta).toEqual({ count: 1, max: MAX_SOUVENIRS_PER_USER_PER_TRIP });
+  });
+
   it("allows a viewer to create their own souvenir (no editor role required)", async () => {
     mockVerifyApiKey.mockResolvedValue({ ...WRITE_KEY, scopes: ["souvenirs:write"] });
     mockCheckTripAccess.mockResolvedValue("viewer");
@@ -1151,6 +1251,32 @@ describe("POST /trips/:tripId/souvenirs", () => {
 });
 
 describe("PATCH /trips/:tripId/souvenirs/:itemId", () => {
+  it("includes _meta with current count and max in the 200 response", async () => {
+    // Arrange
+    mockVerifyApiKey.mockResolvedValue({ ...WRITE_KEY, scopes: ["souvenirs:write"] });
+    mockCheckTripAccess.mockResolvedValue("editor");
+    mockDbQuery.souvenirItems.findFirst.mockResolvedValue(souvenirRow());
+    mockDbUpdate.mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([souvenirRow()]),
+        }),
+      }),
+    });
+    mockDbQuery.tripMembers.findMany.mockResolvedValue(SOUVENIR_MEMBER_ROWS);
+    // count SELECT executed after the update (same per-user filter as the cap check)
+    mockDbSelect.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue([{ itemCount: 2 }]) }),
+    });
+
+    // Act
+    const res = await jsonPatch(`/trips/${TRIP_ID}/souvenirs/${SOUVENIR_ID}`, { name: "Updated" });
+    const body = await res.json();
+
+    // Assert
+    expect(body._meta).toEqual({ count: 2, max: MAX_SOUVENIRS_PER_USER_PER_TRIP });
+  });
+
   it("returns 404 when the souvenir is owned by another member", async () => {
     // The ownership-scoped query (userId === caller) yields no row for others' items.
     mockVerifyApiKey.mockResolvedValue({ ...WRITE_KEY, scopes: ["souvenirs:write"] });
@@ -1188,8 +1314,9 @@ describe("PATCH /trips/:tripId/souvenirs/:itemId", () => {
     });
     mockDbUpdate.mockReturnValue({ set: setSpy });
     mockDbQuery.tripMembers.findMany.mockResolvedValue(SOUVENIR_MEMBER_ROWS);
+    // count SELECT executed after the update in Promise.all
     mockDbSelect.mockReturnValueOnce({
-      from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue([{ name: "Alice" }]) }),
+      from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue([{ itemCount: 1 }]) }),
     });
 
     const res = await jsonPatch(`/trips/${TRIP_ID}/souvenirs/${SOUVENIR_ID}`, { isShared: false });

--- a/apps/api/src/__tests__/v1-write-routes.test.ts
+++ b/apps/api/src/__tests__/v1-write-routes.test.ts
@@ -38,6 +38,7 @@ const {
   mockCreateCandidateCore,
   mockBatchCreateCandidatesCore,
   mockBatchCreateSouvenirsCore,
+  mockDbDelete,
 } = vi.hoisted(() => ({
   mockVerifyApiKey: vi.fn(),
   mockCheckTripAccess: vi.fn(),
@@ -69,6 +70,7 @@ const {
   mockCreateCandidateCore: vi.fn(),
   mockBatchCreateCandidatesCore: vi.fn(),
   mockBatchCreateSouvenirsCore: vi.fn(),
+  mockDbDelete: vi.fn(),
 }));
 
 vi.mock("../lib/external-api/api-key", () => ({
@@ -87,6 +89,7 @@ vi.mock("../db/index", () => {
     insert: (...args: unknown[]) => mockDbInsert(...args),
     update: (...args: unknown[]) => mockDbUpdate(...args),
     select: (...args: unknown[]) => mockDbSelect(...args),
+    delete: (...args: unknown[]) => mockDbDelete(...args),
   };
   return {
     db: { ...tx, transaction: (fn: (t: typeof tx) => unknown) => fn(tx) },
@@ -202,6 +205,13 @@ function jsonPatch(path: string, body: unknown) {
     method: "PATCH",
     headers: { ...AUTH_HEADER, "Content-Type": "application/json" },
     body: JSON.stringify(body),
+  });
+}
+
+function jsonDelete(path: string) {
+  return v1App.request(path, {
+    method: "DELETE",
+    headers: AUTH_HEADER,
   });
 }
 
@@ -1639,5 +1649,151 @@ describe("POST /trips/:tripId/souvenirs/batch", () => {
     expect(body.created[0]).not.toHaveProperty("_meta");
     expect(body.created[0]).toHaveProperty("owner");
     expect(body).toHaveProperty("_meta");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /trips/:tripId/candidates/:scheduleId
+// ---------------------------------------------------------------------------
+
+describe("DELETE /trips/:tripId/candidates/:scheduleId", () => {
+  const CANDIDATE_ID = "33333333-0000-0000-0000-000000000001";
+
+  beforeEach(() => {
+    mockVerifyApiKey.mockResolvedValue({
+      ...WRITE_KEY,
+      scopes: ["trips:write"],
+    });
+    mockCheckTripAccess.mockResolvedValue("editor");
+  });
+
+  it("returns 403 when key has only trips:read scope", async () => {
+    // Arrange
+    mockVerifyApiKey.mockResolvedValue({ ...WRITE_KEY, scopes: ["trips:read"] });
+
+    // Act
+    const res = await jsonDelete(`/trips/${TRIP_ID}/candidates/${CANDIDATE_ID}`);
+
+    // Assert
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 404 when caller has viewer role (editor-gated)", async () => {
+    // Arrange
+    mockCheckTripAccess.mockResolvedValue("viewer");
+
+    // Act
+    const res = await jsonDelete(`/trips/${TRIP_ID}/candidates/${CANDIDATE_ID}`);
+
+    // Assert
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 200 with deleted:false when candidate not found or already deleted", async () => {
+    // Arrange: atomic delete returns empty rows (id unknown, assigned, or already gone)
+    mockDbDelete.mockReturnValue({
+      where: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([]) }),
+    });
+    mockGetScheduleCount.mockResolvedValue(0);
+
+    // Act
+    const res = await jsonDelete(`/trips/${TRIP_ID}/candidates/${CANDIDATE_ID}`);
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(200);
+    expect(body.deleted).toBe(false);
+    expect(body.id).toBe(CANDIDATE_ID);
+  });
+
+  it("returns 200 with deleted:true and correct remaining when candidate deleted", async () => {
+    // Arrange: atomic delete returns the removed row; getActorName resolves for notification
+    mockDbDelete.mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{ id: CANDIDATE_ID, name: "Tokyo Tower" }]),
+      }),
+    });
+    mockGetScheduleCount.mockResolvedValue(0);
+    mockDbQuery.users.findFirst.mockResolvedValue({ name: "Alice" });
+
+    // Act
+    const res = await jsonDelete(`/trips/${TRIP_ID}/candidates/${CANDIDATE_ID}`);
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(200);
+    expect(body.deleted).toBe(true);
+    expect(body.remaining).toEqual({ count: 0, max: MAX_SCHEDULES_PER_TRIP });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /trips/:tripId/souvenirs/:itemId
+// ---------------------------------------------------------------------------
+
+describe("DELETE /trips/:tripId/souvenirs/:itemId", () => {
+  const SOUVENIR_ID = "44444444-0000-0000-0000-000000000001";
+
+  beforeEach(() => {
+    mockVerifyApiKey.mockResolvedValue({
+      ...WRITE_KEY,
+      scopes: ["souvenirs:write"],
+    });
+    mockCheckTripAccess.mockResolvedValue("viewer");
+  });
+
+  it("returns 403 when key has only souvenirs:read scope", async () => {
+    // Arrange
+    mockVerifyApiKey.mockResolvedValue({ ...WRITE_KEY, scopes: ["souvenirs:read"] });
+
+    // Act
+    const res = await jsonDelete(`/trips/${TRIP_ID}/souvenirs/${SOUVENIR_ID}`);
+
+    // Assert
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 200 with deleted:false when souvenir not found or owned by another user", async () => {
+    // Arrange: atomic delete returns empty rows (not found, another trip, or wrong owner)
+    mockDbDelete.mockReturnValue({
+      where: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([]) }),
+    });
+    mockDbSelect.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([{ itemCount: 3 }]),
+      }),
+    });
+
+    // Act
+    const res = await jsonDelete(`/trips/${TRIP_ID}/souvenirs/${SOUVENIR_ID}`);
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(200);
+    expect(body.deleted).toBe(false);
+    expect(body.remaining.count).toBe(3);
+  });
+
+  it("returns 200 with deleted:true and correct remaining when souvenir deleted", async () => {
+    // Arrange: atomic delete returns the removed row; count query reflects post-delete state
+    mockDbDelete.mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{ id: SOUVENIR_ID }]),
+      }),
+    });
+    mockDbSelect.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([{ itemCount: 2 }]),
+      }),
+    });
+
+    // Act
+    const res = await jsonDelete(`/trips/${TRIP_ID}/souvenirs/${SOUVENIR_ID}`);
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(200);
+    expect(body.deleted).toBe(true);
+    expect(body.remaining).toEqual({ count: 2, max: MAX_SOUVENIRS_PER_USER_PER_TRIP });
   });
 });

--- a/apps/api/src/__tests__/v1-write-routes.test.ts
+++ b/apps/api/src/__tests__/v1-write-routes.test.ts
@@ -36,6 +36,8 @@ const {
   mockGetScheduleCount,
   mockGetNextSortOrder,
   mockCreateCandidateCore,
+  mockBatchCreateCandidatesCore,
+  mockBatchCreateSouvenirsCore,
 } = vi.hoisted(() => ({
   mockVerifyApiKey: vi.fn(),
   mockCheckTripAccess: vi.fn(),
@@ -65,6 +67,8 @@ const {
   mockGetScheduleCount: vi.fn(),
   mockGetNextSortOrder: vi.fn(),
   mockCreateCandidateCore: vi.fn(),
+  mockBatchCreateCandidatesCore: vi.fn(),
+  mockBatchCreateSouvenirsCore: vi.fn(),
 }));
 
 vi.mock("../lib/external-api/api-key", () => ({
@@ -135,6 +139,11 @@ vi.mock("../lib/sort-order", () => ({
 
 vi.mock("../lib/candidate-service", () => ({
   createCandidateCore: (...args: unknown[]) => mockCreateCandidateCore(...args),
+  batchCreateCandidatesCore: (...args: unknown[]) => mockBatchCreateCandidatesCore(...args),
+}));
+
+vi.mock("../lib/souvenir-service", () => ({
+  batchCreateSouvenirsCore: (...args: unknown[]) => mockBatchCreateSouvenirsCore(...args),
 }));
 
 import { v1App } from "../routes/v1/index";
@@ -1323,5 +1332,312 @@ describe("PATCH /trips/:tripId/souvenirs/:itemId", () => {
 
     expect(res.status).toBe(200);
     expect(setSpy).toHaveBeenCalledWith(expect.objectContaining({ shareStyle: null }));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Candidates — batch create
+// ---------------------------------------------------------------------------
+
+function arrangeCandidateBatch(result: {
+  created: unknown[];
+  skipped: { name: string; reason: "duplicate" | "limit_reached" }[];
+}) {
+  mockBatchCreateCandidatesCore.mockResolvedValue(result);
+  // getScheduleCount is called after the batch for _meta
+  mockGetScheduleCount.mockResolvedValue(result.created.length);
+}
+
+describe("POST /trips/:tripId/candidates/batch", () => {
+  it("returns 403 when key has only trips:read", async () => {
+    // Arrange
+    mockVerifyApiKey.mockResolvedValue({ ...WRITE_KEY, scopes: ["trips:read"] });
+
+    // Act
+    const res = await jsonPost(`/trips/${TRIP_ID}/candidates/batch`, {
+      items: [{ name: "Tokyo Tower", category: "sightseeing" }],
+    });
+
+    // Assert
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 404 when caller has viewer role (editor-gated)", async () => {
+    // Arrange
+    mockVerifyApiKey.mockResolvedValue(WRITE_KEY);
+    mockCheckTripAccess.mockResolvedValue("viewer");
+
+    // Act
+    const res = await jsonPost(`/trips/${TRIP_ID}/candidates/batch`, {
+      items: [{ name: "Tokyo Tower", category: "sightseeing" }],
+    });
+
+    // Assert
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 for an empty items array", async () => {
+    // Arrange
+    mockVerifyApiKey.mockResolvedValue(WRITE_KEY);
+    mockCheckTripAccess.mockResolvedValue("editor");
+
+    // Act
+    const res = await jsonPost(`/trips/${TRIP_ID}/candidates/batch`, { items: [] });
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(400);
+    expect(body.error.code).toBe("invalid_request");
+  });
+
+  it("returns 201 with created, skipped, and _meta when all items are created", async () => {
+    // Arrange
+    mockVerifyApiKey.mockResolvedValue(WRITE_KEY);
+    mockCheckTripAccess.mockResolvedValue("editor");
+    arrangeCandidateBatch({
+      created: [
+        CANDIDATE_ROW,
+        {
+          ...CANDIDATE_ROW,
+          id: "33333333-0000-0000-0000-000000000002",
+          name: "Akihabara",
+          sortOrder: 1,
+        },
+      ],
+      skipped: [],
+    });
+
+    // Act
+    const res = await jsonPost(`/trips/${TRIP_ID}/candidates/batch`, {
+      items: [
+        { name: "Tokyo Tower", category: "sightseeing" },
+        { name: "Akihabara", category: "sightseeing" },
+      ],
+    });
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(201);
+    expect(body.created).toHaveLength(2);
+    expect(body.skipped).toHaveLength(0);
+    expect(body._meta).toEqual({ count: 2, max: MAX_SCHEDULES_PER_TRIP });
+  });
+
+  it("returns 201 with partial success when some items are skipped due to limit", async () => {
+    // Arrange
+    mockVerifyApiKey.mockResolvedValue(WRITE_KEY);
+    mockCheckTripAccess.mockResolvedValue("editor");
+    arrangeCandidateBatch({
+      created: [CANDIDATE_ROW],
+      skipped: [{ name: "Akihabara", reason: "limit_reached" }],
+    });
+
+    // Act
+    const res = await jsonPost(`/trips/${TRIP_ID}/candidates/batch`, {
+      items: [
+        { name: "Tokyo Tower", category: "sightseeing" },
+        { name: "Akihabara", category: "sightseeing" },
+      ],
+    });
+    const body = await res.json();
+
+    // Assert — still 201, no global 409
+    expect(res.status).toBe(201);
+    expect(body.created).toHaveLength(1);
+    expect(body.skipped).toEqual([{ name: "Akihabara", reason: "limit_reached" }]);
+  });
+
+  it("returns 201 with duplicate skipped when onConflict is skip", async () => {
+    // Arrange
+    mockVerifyApiKey.mockResolvedValue(WRITE_KEY);
+    mockCheckTripAccess.mockResolvedValue("editor");
+    arrangeCandidateBatch({
+      created: [CANDIDATE_ROW],
+      skipped: [{ name: "Tokyo Tower", reason: "duplicate" }],
+    });
+
+    // Act
+    const res = await jsonPost(`/trips/${TRIP_ID}/candidates/batch`, {
+      items: [
+        { name: "Tokyo Tower", category: "sightseeing" },
+        { name: "Tokyo Tower", category: "sightseeing" },
+      ],
+      onConflict: "skip",
+    });
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(201);
+    expect(body.created).toHaveLength(1);
+    expect(body.skipped[0]).toEqual({ name: "Tokyo Tower", reason: "duplicate" });
+  });
+
+  it("created items have no per-item _meta (only response-level _meta)", async () => {
+    // Arrange
+    mockVerifyApiKey.mockResolvedValue(WRITE_KEY);
+    mockCheckTripAccess.mockResolvedValue("editor");
+    arrangeCandidateBatch({ created: [CANDIDATE_ROW], skipped: [] });
+
+    // Act
+    const res = await jsonPost(`/trips/${TRIP_ID}/candidates/batch`, {
+      items: [{ name: "Tokyo Tower", category: "sightseeing" }],
+    });
+    const body = await res.json();
+
+    // Assert
+    expect(body.created[0]).not.toHaveProperty("_meta");
+    expect(body).toHaveProperty("_meta");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Souvenirs — batch create
+// ---------------------------------------------------------------------------
+
+function arrangeSouvenirBatch(result: {
+  created: unknown[];
+  skipped: { name: string; reason: "duplicate" | "limit_reached" }[];
+}) {
+  mockBatchCreateSouvenirsCore.mockResolvedValue(result);
+  mockDbQuery.tripMembers.findMany.mockResolvedValue(SOUVENIR_MEMBER_ROWS);
+  // getActorName uses db.query.users.findFirst, not db.select
+  mockDbQuery.users.findFirst.mockResolvedValue({ name: "Alice" });
+  // post-batch count SELECT for _meta (the only db.select call in the batch route)
+  mockDbSelect.mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue([{ itemCount: result.created.length }]),
+    }),
+  });
+}
+
+describe("POST /trips/:tripId/souvenirs/batch", () => {
+  it("returns 403 when key has only souvenirs:read", async () => {
+    // Arrange
+    mockVerifyApiKey.mockResolvedValue({ ...WRITE_KEY, scopes: ["souvenirs:read"] });
+
+    // Act
+    const res = await jsonPost(`/trips/${TRIP_ID}/souvenirs/batch`, {
+      items: [{ name: "Matcha KitKat" }],
+    });
+
+    // Assert
+    expect(res.status).toBe(403);
+  });
+
+  it("allows a viewer to batch-create their own souvenirs (no editor role required)", async () => {
+    // Arrange
+    mockVerifyApiKey.mockResolvedValue({ ...WRITE_KEY, scopes: ["souvenirs:write"] });
+    mockCheckTripAccess.mockResolvedValue("viewer");
+    arrangeSouvenirBatch({ created: [souvenirRow()], skipped: [] });
+
+    // Act
+    const res = await jsonPost(`/trips/${TRIP_ID}/souvenirs/batch`, {
+      items: [{ name: "Matcha KitKat" }],
+    });
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(201);
+    expect(body.created).toHaveLength(1);
+  });
+
+  it("returns 400 for an empty items array", async () => {
+    // Arrange
+    mockVerifyApiKey.mockResolvedValue({ ...WRITE_KEY, scopes: ["souvenirs:write"] });
+    mockCheckTripAccess.mockResolvedValue("editor");
+
+    // Act
+    const res = await jsonPost(`/trips/${TRIP_ID}/souvenirs/batch`, { items: [] });
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(400);
+    expect(body.error.code).toBe("invalid_request");
+  });
+
+  it("returns 201 with created, skipped, and _meta when all items are created", async () => {
+    // Arrange
+    mockVerifyApiKey.mockResolvedValue({ ...WRITE_KEY, scopes: ["souvenirs:write"] });
+    mockCheckTripAccess.mockResolvedValue("editor");
+    arrangeSouvenirBatch({
+      created: [
+        souvenirRow(),
+        souvenirRow({ id: "44444444-0000-0000-0000-000000000002", name: "Pocky" }),
+      ],
+      skipped: [],
+    });
+
+    // Act
+    const res = await jsonPost(`/trips/${TRIP_ID}/souvenirs/batch`, {
+      items: [{ name: "Matcha KitKat" }, { name: "Pocky" }],
+    });
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(201);
+    expect(body.created).toHaveLength(2);
+    expect(body.skipped).toHaveLength(0);
+    expect(body._meta).toEqual({ count: 2, max: MAX_SOUVENIRS_PER_USER_PER_TRIP });
+  });
+
+  it("returns 201 with partial success when some items exceed the limit", async () => {
+    // Arrange
+    mockVerifyApiKey.mockResolvedValue({ ...WRITE_KEY, scopes: ["souvenirs:write"] });
+    mockCheckTripAccess.mockResolvedValue("editor");
+    arrangeSouvenirBatch({
+      created: [souvenirRow()],
+      skipped: [{ name: "Pocky", reason: "limit_reached" }],
+    });
+
+    // Act
+    const res = await jsonPost(`/trips/${TRIP_ID}/souvenirs/batch`, {
+      items: [{ name: "Matcha KitKat" }, { name: "Pocky" }],
+    });
+    const body = await res.json();
+
+    // Assert — still 201, no global 409
+    expect(res.status).toBe(201);
+    expect(body.created).toHaveLength(1);
+    expect(body.skipped).toEqual([{ name: "Pocky", reason: "limit_reached" }]);
+  });
+
+  it("returns 201 with duplicate skipped when onConflict is skip", async () => {
+    // Arrange
+    mockVerifyApiKey.mockResolvedValue({ ...WRITE_KEY, scopes: ["souvenirs:write"] });
+    mockCheckTripAccess.mockResolvedValue("editor");
+    arrangeSouvenirBatch({
+      created: [souvenirRow()],
+      skipped: [{ name: "Matcha KitKat", reason: "duplicate" }],
+    });
+
+    // Act
+    const res = await jsonPost(`/trips/${TRIP_ID}/souvenirs/batch`, {
+      items: [{ name: "Matcha KitKat" }, { name: "Matcha KitKat" }],
+      onConflict: "skip",
+    });
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(201);
+    expect(body.created).toHaveLength(1);
+    expect(body.skipped[0]).toEqual({ name: "Matcha KitKat", reason: "duplicate" });
+  });
+
+  it("created items have no per-item _meta (owner is a memberNo ref)", async () => {
+    // Arrange
+    mockVerifyApiKey.mockResolvedValue({ ...WRITE_KEY, scopes: ["souvenirs:write"] });
+    mockCheckTripAccess.mockResolvedValue("editor");
+    arrangeSouvenirBatch({ created: [souvenirRow()], skipped: [] });
+
+    // Act
+    const res = await jsonPost(`/trips/${TRIP_ID}/souvenirs/batch`, {
+      items: [{ name: "Matcha KitKat" }],
+    });
+    const body = await res.json();
+
+    // Assert: items have owner (memberNo ref) but no _meta on each item
+    expect(body.created[0]).not.toHaveProperty("_meta");
+    expect(body.created[0]).toHaveProperty("owner");
+    expect(body).toHaveProperty("_meta");
   });
 });

--- a/apps/api/src/lib/candidate-service.ts
+++ b/apps/api/src/lib/candidate-service.ts
@@ -7,7 +7,7 @@
 // because the actor name is resolved differently per surface.
 
 import { type createScheduleSchema, MAX_SCHEDULES_PER_TRIP } from "@sugara/shared";
-import { and, eq, isNull } from "drizzle-orm";
+import { and, eq, isNull, sql } from "drizzle-orm";
 import type { z } from "zod";
 import { db } from "../db/index";
 import { schedules } from "../db/schema";
@@ -64,4 +64,93 @@ export async function createCandidateCore(
     return { ok: false, error: "limit_reached" };
   }
   return { ok: true, schedule };
+}
+
+export type BatchCreateCandidatesResult = {
+  created: Schedule[];
+  skipped: { name: string; reason: "duplicate" | "limit_reached" }[];
+};
+
+// Inserts multiple candidates in a single transaction.
+//
+// Advisory lock (`schedule:candidates:<tripId>`) is acquired once at transaction
+// start, serializing concurrent single-create and batch-create calls that share
+// the same lock scope. sortOrder values are allocated in-memory from the current
+// MAX so only one MAX query is needed regardless of batch size.
+//
+// When onConflict is "skip", each item is checked against:
+//   - existing schedule names in the trip (trip-wide, trimmed + lowercased)
+//   - names seen earlier in the same batch (in-batch dedup)
+// Items that exceed the per-trip limit are pushed to `skipped` with
+// reason "limit_reached"; items not yet at the limit always succeed.
+export async function batchCreateCandidatesCore(
+  tripId: string,
+  items: CreateCandidateInput[],
+  onConflict: "create" | "skip",
+): Promise<BatchCreateCandidatesResult> {
+  return db.transaction(async (tx) => {
+    const lockScope = `schedule:candidates:${tripId}`;
+    await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${lockScope}))`);
+
+    const scheduleCount = await getScheduleCount(tx, tripId);
+
+    // Collect existing names once for trip-wide dedup (only when needed).
+    const existingNamesLower = new Set<string>();
+    if (onConflict === "skip") {
+      const rows = await tx
+        .select({ name: schedules.name })
+        .from(schedules)
+        .where(eq(schedules.tripId, tripId));
+      for (const row of rows) {
+        existingNamesLower.add(row.name.trim().toLowerCase());
+      }
+    }
+
+    // Get current max sortOrder for candidates (dayPatternId IS NULL) once,
+    // then increment in-memory — avoids N advisory lock acquisitions.
+    const [maxResult] = await tx
+      .select({ maxOrder: sql<number>`COALESCE(MAX(${schedules.sortOrder}), -1)` })
+      .from(schedules)
+      .where(and(eq(schedules.tripId, tripId), isNull(schedules.dayPatternId)));
+    let nextSortOrder = maxResult.maxOrder + 1;
+
+    const created: Schedule[] = [];
+    const skipped: { name: string; reason: "duplicate" | "limit_reached" }[] = [];
+    const seenNamesLower = new Set<string>();
+
+    for (const item of items) {
+      // Limit: count pre-existing schedules + those created in this batch.
+      if (scheduleCount + created.length >= MAX_SCHEDULES_PER_TRIP) {
+        skipped.push({ name: item.name, reason: "limit_reached" });
+        continue;
+      }
+
+      if (onConflict === "skip") {
+        const nameLower = item.name.trim().toLowerCase();
+        if (existingNamesLower.has(nameLower) || seenNamesLower.has(nameLower)) {
+          skipped.push({ name: item.name, reason: "duplicate" });
+          continue;
+        }
+        seenNamesLower.add(nameLower);
+      }
+
+      // Strip anchor fields — candidates have no day-pattern context.
+      const { crossDayAnchor: _a, crossDayAnchorSourceId: _s, ...createData } = item;
+
+      const [row] = await tx
+        .insert(schedules)
+        .values({ tripId, ...createData, sortOrder: nextSortOrder })
+        .returning();
+
+      // A successful INSERT with RETURNING always returns a row; guard is for type safety.
+      if (row === undefined) {
+        throw new Error(`unexpected: insert returned no row for candidate "${item.name}"`);
+      }
+
+      created.push(row);
+      nextSortOrder += 1;
+    }
+
+    return { created, skipped };
+  });
 }

--- a/apps/api/src/lib/like-escape.test.ts
+++ b/apps/api/src/lib/like-escape.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { escapeLike } from "./like-escape";
+
+describe("escapeLike", () => {
+  it("passes through strings with no metacharacters", () => {
+    expect(escapeLike("hello world")).toBe("hello world");
+  });
+
+  it("escapes percent sign so it becomes a literal character in ILIKE", () => {
+    expect(escapeLike("100%")).toBe("100\\%");
+  });
+
+  it("escapes underscore so it becomes a literal character in ILIKE", () => {
+    expect(escapeLike("a_b")).toBe("a\\_b");
+  });
+
+  it("escapes backslash so the escape character itself is treated literally", () => {
+    expect(escapeLike("a\\b")).toBe("a\\\\b");
+  });
+
+  it("escapes all metacharacters in a mixed string", () => {
+    expect(escapeLike("a%_\\b")).toBe("a\\%\\_\\\\b");
+  });
+
+  it("returns empty string unchanged", () => {
+    expect(escapeLike("")).toBe("");
+  });
+
+  it("does not alter alphanumeric and common punctuation", () => {
+    expect(escapeLike("Tokyo 東京!")).toBe("Tokyo 東京!");
+  });
+});

--- a/apps/api/src/lib/like-escape.ts
+++ b/apps/api/src/lib/like-escape.ts
@@ -1,0 +1,14 @@
+/**
+ * Escapes PostgreSQL ILIKE/LIKE pattern metacharacters in a user-supplied string
+ * so that the value is treated as a literal substring, not a pattern.
+ *
+ * PostgreSQL's default LIKE escape character is backslash, so we must escape:
+ *   % → \%  (wildcard for any sequence of characters)
+ *   _ → \_  (wildcard for exactly one character)
+ *   \ → \\  (the escape character itself)
+ *
+ * Usage: ilike(column, `%${escapeLike(userInput)}%`)
+ */
+export function escapeLike(value: string): string {
+  return value.replace(/[\\%_]/g, "\\$&");
+}

--- a/apps/api/src/lib/souvenir-service.ts
+++ b/apps/api/src/lib/souvenir-service.ts
@@ -1,0 +1,114 @@
+// Shared core for batch-creating souvenir items (a souvenirItems row).
+//
+// Extracted from the v1 souvenir write route so the limit check, dedup logic,
+// and insert loop stay single-sourced. Side effects (activity logging, member
+// notification, serialization) remain in the route layer.
+//
+// Unlike candidates, souvenirs have no sortOrder, so no advisory lock is needed.
+// Dedup scope is per-user per-trip (the caller's own items only), matching the
+// internal souvenir route's uniqueness semantics.
+//
+// Limit check is non-locking (READ COMMITTED): like the single-create route's
+// acknowledged benign race, two concurrent batches can both read the same count
+// and exceed the cap — but a batch amplifies the overshoot by up to batch_size
+// items. The cap is a soft per-user constraint, so this is accepted rather than
+// guarded with an advisory lock.
+
+import { type CreateSouvenirInput, MAX_SOUVENIRS_PER_USER_PER_TRIP } from "@sugara/shared";
+import { and, count, eq } from "drizzle-orm";
+import { db } from "../db/index";
+import { souvenirItems } from "../db/schema";
+
+type SouvenirItem = typeof souvenirItems.$inferSelect;
+
+export type BatchCreateSouvenirsResult = {
+  created: SouvenirItem[];
+  skipped: { name: string; reason: "duplicate" | "limit_reached" }[];
+};
+
+// Inserts multiple souvenir items in a single transaction.
+//
+// When onConflict is "skip", each item is checked against:
+//   - existing souvenir names owned by the caller in the trip (trimmed + lowercased)
+//   - names seen earlier in the same batch (in-batch dedup)
+// Items that exceed the per-user per-trip limit are pushed to `skipped` with
+// reason "limit_reached"; items not yet at the limit always succeed.
+//
+// shareStyle is cleared when isShared is not true, mirroring the single-create
+// route's semantics so the batch endpoint behaves consistently.
+export async function batchCreateSouvenirsCore(
+  tripId: string,
+  userId: string,
+  items: CreateSouvenirInput[],
+  onConflict: "create" | "skip",
+): Promise<BatchCreateSouvenirsResult> {
+  return db.transaction(async (tx) => {
+    // Current user's souvenir count for this trip.
+    const [{ itemCount }] = await tx
+      .select({ itemCount: count() })
+      .from(souvenirItems)
+      .where(and(eq(souvenirItems.tripId, tripId), eq(souvenirItems.userId, userId)));
+
+    // Collect existing names once for dedup (caller's items only).
+    const existingNamesLower = new Set<string>();
+    if (onConflict === "skip") {
+      const rows = await tx
+        .select({ name: souvenirItems.name })
+        .from(souvenirItems)
+        .where(and(eq(souvenirItems.tripId, tripId), eq(souvenirItems.userId, userId)));
+      for (const row of rows) {
+        existingNamesLower.add(row.name.trim().toLowerCase());
+      }
+    }
+
+    const created: SouvenirItem[] = [];
+    const skipped: { name: string; reason: "duplicate" | "limit_reached" }[] = [];
+    const seenNamesLower = new Set<string>();
+
+    for (const item of items) {
+      // Limit: count pre-existing items + those created in this batch.
+      if (itemCount + created.length >= MAX_SOUVENIRS_PER_USER_PER_TRIP) {
+        skipped.push({ name: item.name, reason: "limit_reached" });
+        continue;
+      }
+
+      if (onConflict === "skip") {
+        const nameLower = item.name.trim().toLowerCase();
+        if (existingNamesLower.has(nameLower) || seenNamesLower.has(nameLower)) {
+          skipped.push({ name: item.name, reason: "duplicate" });
+          continue;
+        }
+        seenNamesLower.add(nameLower);
+      }
+
+      const { name, recipient, urls, addresses, memo, priority, isShared, shareStyle } = item;
+      const resolvedIsShared = isShared ?? false;
+
+      const [row] = await tx
+        .insert(souvenirItems)
+        .values({
+          tripId,
+          userId,
+          name,
+          recipient,
+          urls,
+          addresses,
+          memo,
+          priority,
+          isShared: resolvedIsShared,
+          // shareStyle is cleared when not shared — mirrors single-create semantics.
+          shareStyle: resolvedIsShared ? (shareStyle ?? null) : null,
+        })
+        .returning();
+
+      // A successful INSERT with RETURNING always returns a row; guard is for type safety.
+      if (row === undefined) {
+        throw new Error(`unexpected: insert returned no row for souvenir "${item.name}"`);
+      }
+
+      created.push(row);
+    }
+
+    return { created, skipped };
+  });
+}

--- a/apps/api/src/routes/v1/candidates-write.ts
+++ b/apps/api/src/routes/v1/candidates-write.ts
@@ -2,6 +2,7 @@
 //
 // File layout:
 //   POST   /trips/:tripId/candidates
+//   POST   /trips/:tripId/candidates/batch
 //   PATCH  /trips/:tripId/candidates/:scheduleId
 //
 // A candidate is a schedule row with dayPatternId = NULL — an unassigned spot in
@@ -21,7 +22,7 @@ import { describeRoute, resolver } from "hono-openapi";
 import { db } from "../../db";
 import { schedules } from "../../db/schema";
 import { logActivity } from "../../lib/activity-logger";
-import { createCandidateCore } from "../../lib/candidate-service";
+import { batchCreateCandidatesCore, createCandidateCore } from "../../lib/candidate-service";
 import { ApiV1Error, getApiKey, type V1Env } from "../../lib/external-api/errors";
 import { hasChanges } from "../../lib/has-changes";
 import { notifyTripMembersExcluding } from "../../lib/notifications";
@@ -31,6 +32,8 @@ import { errorResponseSchema } from "./openapi-schemas";
 import { serializeScheduleDto } from "./serializers";
 import { getActorName, uuidSchema, withTripAccess } from "./shared";
 import {
+  v1BatchCreateCandidateSchema,
+  v1CandidateBatchWriteResponseSchema,
   v1CandidateWriteResponseSchema,
   v1CreateScheduleSchema,
   v1UpdateScheduleSchema,
@@ -135,6 +138,87 @@ candidatesWriteApp.post(
       return c.json(
         {
           ...serializeScheduleDto(schedule),
+          _meta: { count: scheduleCount, max: MAX_SCHEDULES_PER_TRIP },
+        },
+        201,
+      );
+    },
+    { minRole: "editor" },
+  ),
+);
+
+// ---------------------------------------------------------------------------
+// POST /trips/:tripId/candidates/batch
+// ---------------------------------------------------------------------------
+
+candidatesWriteApp.post(
+  "/trips/:tripId/candidates/batch",
+  describeRoute({
+    tags: ["Candidates"],
+    summary: "Batch create candidates",
+    description:
+      'Creates up to 50 candidates in a single transaction. Items that exceed the per-trip schedule limit are returned in `skipped` with `reason: "limit_reached"`. When `onConflict` is `"skip"`, items whose name (trimmed, case-insensitive) matches an existing schedule in the trip or an earlier item in the same batch are returned in `skipped` with `reason: "duplicate"`. Requires `trips:write` scope and editor/owner role on the trip.',
+    security: [{ bearerAuth: [] }],
+    parameters: [
+      {
+        name: "tripId",
+        in: "path",
+        required: true,
+        description: "Trip UUID.",
+        schema: { type: "string", format: "uuid" },
+      },
+    ],
+    requestBody: {
+      required: true,
+      content: { "application/json": { schema: { type: "object" } } },
+    },
+    responses: {
+      201: {
+        description: "Batch processed (partial success is normal — check `skipped`)",
+        content: {
+          "application/json": { schema: resolver(v1CandidateBatchWriteResponseSchema) },
+        },
+      },
+      400: {
+        description: "Invalid request body",
+        content: { "application/json": { schema: resolver(errorResponseSchema) } },
+      },
+      401: {
+        description: "Missing or invalid API key",
+        content: { "application/json": { schema: resolver(errorResponseSchema) } },
+      },
+      403: {
+        description: "Insufficient scope",
+        content: { "application/json": { schema: resolver(errorResponseSchema) } },
+      },
+      404: {
+        description: "Trip not found or access denied",
+        content: { "application/json": { schema: resolver(errorResponseSchema) } },
+      },
+    },
+  }),
+  requireApiKey("trips:write"),
+  withTripAccess(
+    "tripId",
+    async (c, tripId) => {
+      const body = await c.req.json();
+      const parsed = v1BatchCreateCandidateSchema.safeParse(body);
+      if (!parsed.success) {
+        throw new ApiV1Error(400, "invalid_request", "Invalid request body");
+      }
+
+      const { items, onConflict } = parsed.data;
+      const { created, skipped } = await batchCreateCandidatesCore(tripId, items, onConflict);
+
+      // Intentionally no logActivity/notifyTripMembersExcluding here: a batch can
+      // create up to 50 items, and per-item logs/notifications would spam members.
+      // Post-batch trip-wide schedule count for _meta.
+      const scheduleCount = await getScheduleCount(db, tripId);
+
+      return c.json(
+        {
+          created: created.map((s) => serializeScheduleDto(s)),
+          skipped,
           _meta: { count: scheduleCount, max: MAX_SCHEDULES_PER_TRIP },
         },
         201,

--- a/apps/api/src/routes/v1/candidates-write.ts
+++ b/apps/api/src/routes/v1/candidates-write.ts
@@ -4,6 +4,7 @@
 //   POST   /trips/:tripId/candidates
 //   POST   /trips/:tripId/candidates/batch
 //   PATCH  /trips/:tripId/candidates/:scheduleId
+//   DELETE /trips/:tripId/candidates/:scheduleId
 //
 // A candidate is a schedule row with dayPatternId = NULL — an unassigned spot in
 // the trip's planning pool. The create/update payloads reuse the v1 schedule
@@ -36,6 +37,7 @@ import {
   v1CandidateBatchWriteResponseSchema,
   v1CandidateWriteResponseSchema,
   v1CreateScheduleSchema,
+  v1DeleteResponseSchema,
   v1UpdateScheduleSchema,
 } from "./write-schemas";
 
@@ -340,6 +342,133 @@ candidatesWriteApp.patch(
       });
 
       return c.json({ ...serializeScheduleDto(updated), _meta: meta });
+    },
+    { minRole: "editor" },
+  ),
+);
+
+// ---------------------------------------------------------------------------
+// DELETE /trips/:tripId/candidates/:scheduleId
+// ---------------------------------------------------------------------------
+
+candidatesWriteApp.delete(
+  "/trips/:tripId/candidates/:scheduleId",
+  describeRoute({
+    tags: ["Candidates"],
+    summary: "Delete a candidate",
+    description:
+      "Physically deletes an unassigned candidate from the trip's planning pool. " +
+      "Idempotent: returns 200 in all cases. " +
+      "deleted:true when the item was found and removed; deleted:false when the id is unknown, " +
+      "belongs to another trip, or the schedule has already been assigned to a day (not a candidate). " +
+      "remaining reflects the post-operation trip-wide schedule count. " +
+      "Requires `trips:write` scope and editor/owner role on the trip.",
+    security: [{ bearerAuth: [] }],
+    parameters: [
+      {
+        name: "tripId",
+        in: "path",
+        required: true,
+        description: "Trip UUID.",
+        schema: { type: "string", format: "uuid" },
+      },
+      {
+        name: "scheduleId",
+        in: "path",
+        required: true,
+        description: "Candidate (schedule) UUID.",
+        schema: { type: "string", format: "uuid" },
+      },
+    ],
+    responses: {
+      200: {
+        description:
+          "Deletion result (deleted:true when removed, deleted:false when already gone or assigned)",
+        content: { "application/json": { schema: resolver(v1DeleteResponseSchema) } },
+      },
+      400: {
+        description: "Invalid candidate id",
+        content: { "application/json": { schema: resolver(errorResponseSchema) } },
+      },
+      401: {
+        description: "Missing or invalid API key",
+        content: { "application/json": { schema: resolver(errorResponseSchema) } },
+      },
+      403: {
+        description: "Insufficient scope",
+        content: { "application/json": { schema: resolver(errorResponseSchema) } },
+      },
+      404: {
+        description: "Trip not found or access denied",
+        content: { "application/json": { schema: resolver(errorResponseSchema) } },
+      },
+    },
+  }),
+  requireApiKey("trips:write"),
+  withTripAccess(
+    "tripId",
+    async (c, tripId) => {
+      const key = getApiKey(c);
+
+      const rawScheduleId = c.req.param("scheduleId");
+      const parsedId = uuidSchema.safeParse(rawScheduleId);
+      if (!parsedId.success) {
+        throw new ApiV1Error(400, "invalid_request", "Invalid candidate id");
+      }
+      const scheduleId = parsedId.data;
+
+      // Atomic delete: guard conditions (tripId + unassigned) are folded into
+      // the WHERE clause so there is no TOCTOU window between an existence
+      // check and the delete. Without this, a concurrent assign between a
+      // prior findFirst and the delete would physically remove an assigned
+      // schedule from the day — the atomic approach eliminates that window.
+      const deletedRows = await db
+        .delete(schedules)
+        .where(
+          and(
+            eq(schedules.id, scheduleId),
+            eq(schedules.tripId, tripId),
+            isNull(schedules.dayPatternId),
+          ),
+        )
+        .returning({ id: schedules.id, name: schedules.name });
+      const didDelete = deletedRows.length > 0;
+
+      if (didDelete) {
+        // Run in parallel: count needs the post-delete state, actorName is
+        // needed for the candidate_deleted notification payload.
+        const [scheduleCount, actorName] = await Promise.all([
+          getScheduleCount(db, tripId),
+          getActorName(key.userId),
+        ]);
+        logActivity({
+          tripId,
+          userId: key.userId,
+          action: "deleted",
+          entityType: "candidate",
+          entityName: deletedRows[0].name,
+        });
+        notifyTripMembersExcluding({
+          type: "candidate_deleted",
+          tripId,
+          actorId: key.userId,
+          makePayload: (tripName) => ({ actorName, tripName }),
+        });
+        return c.json({
+          id: scheduleId,
+          deleted: true,
+          remaining: { count: scheduleCount, max: MAX_SCHEDULES_PER_TRIP },
+        });
+      }
+
+      // Idempotent: id unknown, belongs to another trip, already deleted,
+      // or is an assigned schedule (no longer a candidate).
+      const scheduleCount = await getScheduleCount(db, tripId);
+      return c.json({
+        id: scheduleId,
+        deleted: false,
+        remaining: { count: scheduleCount, max: MAX_SCHEDULES_PER_TRIP },
+      });
     },
     { minRole: "editor" },
   ),

--- a/apps/api/src/routes/v1/candidates-write.ts
+++ b/apps/api/src/routes/v1/candidates-write.ts
@@ -25,13 +25,14 @@ import { createCandidateCore } from "../../lib/candidate-service";
 import { ApiV1Error, getApiKey, type V1Env } from "../../lib/external-api/errors";
 import { hasChanges } from "../../lib/has-changes";
 import { notifyTripMembersExcluding } from "../../lib/notifications";
+import { getScheduleCount } from "../../lib/schedule-count";
 import { requireApiKey } from "../../middleware/require-api-key";
 import { errorResponseSchema } from "./openapi-schemas";
 import { serializeScheduleDto } from "./serializers";
 import { getActorName, uuidSchema, withTripAccess } from "./shared";
 import {
+  v1CandidateWriteResponseSchema,
   v1CreateScheduleSchema,
-  v1ScheduleWriteResponseSchema,
   v1UpdateScheduleSchema,
 } from "./write-schemas";
 
@@ -65,7 +66,7 @@ candidatesWriteApp.post(
     responses: {
       201: {
         description: "Candidate created",
-        content: { "application/json": { schema: resolver(v1ScheduleWriteResponseSchema) } },
+        content: { "application/json": { schema: resolver(v1CandidateWriteResponseSchema) } },
       },
       400: {
         description: "Invalid request body",
@@ -111,7 +112,12 @@ candidatesWriteApp.post(
       }
       const schedule = result.schedule;
 
-      const actorName = await getActorName(key.userId);
+      // Run in parallel: count is needed for _meta and must reflect the
+      // post-insert state; actorName is needed for the notification payload.
+      const [scheduleCount, actorName] = await Promise.all([
+        getScheduleCount(db, tripId),
+        getActorName(key.userId),
+      ]);
       logActivity({
         tripId,
         userId: key.userId,
@@ -126,7 +132,13 @@ candidatesWriteApp.post(
         makePayload: (tripName) => ({ actorName, tripName, entityName: schedule.name }),
       });
 
-      return c.json(serializeScheduleDto(schedule), 201);
+      return c.json(
+        {
+          ...serializeScheduleDto(schedule),
+          _meta: { count: scheduleCount, max: MAX_SCHEDULES_PER_TRIP },
+        },
+        201,
+      );
     },
     { minRole: "editor" },
   ),
@@ -167,7 +179,7 @@ candidatesWriteApp.patch(
     responses: {
       200: {
         description: "Candidate updated",
-        content: { "application/json": { schema: resolver(v1ScheduleWriteResponseSchema) } },
+        content: { "application/json": { schema: resolver(v1CandidateWriteResponseSchema) } },
       },
       400: {
         description: "Invalid request body",
@@ -217,10 +229,15 @@ candidatesWriteApp.patch(
         throw new ApiV1Error(404, "not_found", "Candidate not found in this trip");
       }
 
+      // Fetch the current schedule count for _meta before branching on no-op /
+      // update: the count is included in both paths and does not change on PATCH.
+      const scheduleCount = await getScheduleCount(db, tripId);
+      const meta = { count: scheduleCount, max: MAX_SCHEDULES_PER_TRIP };
+
       // No-op update: skip the write and the activity log entirely (mirrors the
       // internal candidate route, which guards with hasChanges).
       if (!hasChanges(existing, parsed.data)) {
-        return c.json(serializeScheduleDto(existing));
+        return c.json({ ...serializeScheduleDto(existing), _meta: meta });
       }
 
       const [updated] = await db
@@ -238,7 +255,7 @@ candidatesWriteApp.patch(
         entityName: updated.name,
       });
 
-      return c.json(serializeScheduleDto(updated));
+      return c.json({ ...serializeScheduleDto(updated), _meta: meta });
     },
     { minRole: "editor" },
   ),

--- a/apps/api/src/routes/v1/index.ts
+++ b/apps/api/src/routes/v1/index.ts
@@ -1,4 +1,4 @@
-import { and, count, desc, eq, inArray, isNull, ne, or } from "drizzle-orm";
+import { and, count, desc, eq, ilike, inArray, isNull, ne, or } from "drizzle-orm";
 import { Hono } from "hono";
 import { describeRoute, resolver } from "hono-openapi";
 import { z } from "zod";
@@ -18,6 +18,7 @@ import { v1AuditLog } from "../../lib/external-api/audit-log";
 import { ApiV1Error, getApiKey, type V1Env, v1ErrorHandler } from "../../lib/external-api/errors";
 import { buildMemberNoMap } from "../../lib/external-api/member-no";
 import { v1RateLimit } from "../../lib/external-api/rate-limit";
+import { escapeLike } from "../../lib/like-escape";
 import { requireApiKey } from "../../middleware/require-api-key";
 import { articlesWriteApp } from "./articles-write";
 import { bookmarksWriteApp } from "./bookmarks-write";
@@ -76,6 +77,13 @@ const paginationSchema = z.object({
 
 const tripsQuerySchema = paginationSchema.extend({
   scope: z.enum(["owned", "shared"]).optional(),
+});
+
+// Common query schema for list endpoints that support ?q= name/title filtering.
+// Callers must normalise empty/whitespace values to undefined before safeParse
+// so that an empty q is treated as "no filter" rather than a validation error.
+const listQuerySchema = paginationSchema.extend({
+  q: z.string().trim().min(1).optional(),
 });
 
 // ---------- GET /api/v1/trips ----------
@@ -500,6 +508,13 @@ v1App.get(
         description: "Number of items to skip.",
         schema: { type: "integer", minimum: 0, default: 0 },
       },
+      {
+        name: "q",
+        in: "query",
+        description:
+          "Case-insensitive partial match on candidate name. Omit or leave empty to return all candidates.",
+        schema: { type: "string" },
+      },
     ],
     responses: {
       200: {
@@ -526,16 +541,23 @@ v1App.get(
   }),
   requireApiKey("trips:read"),
   withTripAccess("tripId", async (c, tripId) => {
-    const parsed = paginationSchema.safeParse({
+    const rawQ = c.req.query("q");
+    const parsed = listQuerySchema.safeParse({
       limit: c.req.query("limit"),
       offset: c.req.query("offset"),
+      q: rawQ?.trim() || undefined,
     });
     if (!parsed.success) {
       throw new ApiV1Error(400, "invalid_request", "Invalid query parameters");
     }
-    const { limit: queryLimit, offset: queryOffset } = parsed.data;
+    const { limit: queryLimit, offset: queryOffset, q } = parsed.data;
 
-    const candidateFilter = and(eq(schedules.tripId, tripId), isNull(schedules.dayPatternId));
+    const qFilter = q !== undefined ? ilike(schedules.name, `%${escapeLike(q)}%`) : undefined;
+    const candidateFilter = and(
+      eq(schedules.tripId, tripId),
+      isNull(schedules.dayPatternId),
+      qFilter,
+    );
 
     const countResult = await db.select({ total: count() }).from(schedules).where(candidateFilter);
     const total = countResult[0]?.total ?? 0;
@@ -588,6 +610,13 @@ v1App.get(
         description: "Number of items to skip.",
         schema: { type: "integer", minimum: 0, default: 0 },
       },
+      {
+        name: "q",
+        in: "query",
+        description:
+          "Case-insensitive partial match on souvenir name. Omit or leave empty to return all souvenirs.",
+        schema: { type: "string" },
+      },
     ],
     responses: {
       200: {
@@ -615,14 +644,16 @@ v1App.get(
   requireApiKey("souvenirs:read"),
   withTripAccess("tripId", async (c, tripId) => {
     const key = getApiKey(c);
-    const parsed = paginationSchema.safeParse({
+    const rawQ = c.req.query("q");
+    const parsed = listQuerySchema.safeParse({
       limit: c.req.query("limit"),
       offset: c.req.query("offset"),
+      q: rawQ?.trim() || undefined,
     });
     if (!parsed.success) {
       throw new ApiV1Error(400, "invalid_request", "Invalid query parameters");
     }
-    const { limit: queryLimit, offset: queryOffset } = parsed.data;
+    const { limit: queryLimit, offset: queryOffset, q } = parsed.data;
 
     const memberRows = await db.query.tripMembers.findMany({
       where: eq(tripMembers.tripId, tripId),
@@ -632,9 +663,11 @@ v1App.get(
 
     // Own items + other members' shared items. Both count and page queries use
     // this same filter so the pagination total matches the page contents.
+    const qFilter = q !== undefined ? ilike(souvenirItems.name, `%${escapeLike(q)}%`) : undefined;
     const souvenirFilter = and(
       eq(souvenirItems.tripId, tripId),
       or(eq(souvenirItems.userId, key.userId), eq(souvenirItems.isShared, true)),
+      qFilter,
     );
 
     const countResult = await db
@@ -787,6 +820,13 @@ v1App.get(
         description: "Number of items to skip.",
         schema: { type: "integer", minimum: 0, default: 0 },
       },
+      {
+        name: "q",
+        in: "query",
+        description:
+          "Case-insensitive partial match on bookmark name. Omit or leave empty to return all bookmarks.",
+        schema: { type: "string" },
+      },
     ],
     responses: {
       200: {
@@ -823,14 +863,16 @@ v1App.get(
     }
     const listId = parsedId.data;
 
-    const parsed = paginationSchema.safeParse({
+    const rawQ = c.req.query("q");
+    const parsed = listQuerySchema.safeParse({
       limit: c.req.query("limit"),
       offset: c.req.query("offset"),
+      q: rawQ?.trim() || undefined,
     });
     if (!parsed.success) {
       throw new ApiV1Error(400, "invalid_request", "Invalid query parameters");
     }
-    const { limit: queryLimit, offset: queryOffset } = parsed.data;
+    const { limit: queryLimit, offset: queryOffset, q } = parsed.data;
 
     // Verify ownership before exposing bookmark contents
     const list = await verifyListOwnership(listId, userId);
@@ -838,15 +880,15 @@ v1App.get(
       throw new ApiV1Error(404, "not_found", "Bookmark list not found or access denied");
     }
 
+    const qFilter = q !== undefined ? ilike(bookmarks.name, `%${escapeLike(q)}%`) : undefined;
+    const bookmarkFilter = and(eq(bookmarks.listId, listId), qFilter);
+
     // Count total bookmarks in this list
-    const countResult = await db
-      .select({ total: count() })
-      .from(bookmarks)
-      .where(eq(bookmarks.listId, listId));
+    const countResult = await db.select({ total: count() }).from(bookmarks).where(bookmarkFilter);
     const total = countResult[0]?.total ?? 0;
 
     const bookmarkRows = await db.query.bookmarks.findMany({
-      where: eq(bookmarks.listId, listId),
+      where: bookmarkFilter,
       columns: {
         id: true,
         name: true,
@@ -898,6 +940,13 @@ v1App.get(
         description: "Number of items to skip.",
         schema: { type: "integer", minimum: 0, default: 0 },
       },
+      {
+        name: "q",
+        in: "query",
+        description:
+          "Case-insensitive partial match on article title. Omit or leave empty to return all articles.",
+        schema: { type: "string" },
+      },
     ],
     responses: {
       200: {
@@ -923,25 +972,27 @@ v1App.get(
     const key = getApiKey(c);
     const userId = key.userId;
 
-    const parsed = paginationSchema.safeParse({
+    const rawQ = c.req.query("q");
+    const parsed = listQuerySchema.safeParse({
       limit: c.req.query("limit"),
       offset: c.req.query("offset"),
+      q: rawQ?.trim() || undefined,
     });
     if (!parsed.success) {
       throw new ApiV1Error(400, "invalid_request", "Invalid query parameters");
     }
-    const { limit: queryLimit, offset: queryOffset } = parsed.data;
+    const { limit: queryLimit, offset: queryOffset, q } = parsed.data;
+
+    const qFilter = q !== undefined ? ilike(articles.title, `%${escapeLike(q)}%`) : undefined;
+    const articleFilter = and(eq(articles.ownerId, userId), qFilter);
 
     // Total count
-    const countResult = await db
-      .select({ total: count() })
-      .from(articles)
-      .where(eq(articles.ownerId, userId));
+    const countResult = await db.select({ total: count() }).from(articles).where(articleFilter);
     const total = countResult[0]?.total ?? 0;
 
     // Fetch page of articles (no content) with linked trip ids
     const articleRows = await db.query.articles.findMany({
-      where: eq(articles.ownerId, userId),
+      where: articleFilter,
       columns: {
         id: true,
         title: true,

--- a/apps/api/src/routes/v1/souvenirs-write.ts
+++ b/apps/api/src/routes/v1/souvenirs-write.ts
@@ -139,7 +139,13 @@ souvenirsWriteApp.post(
       getActorName(key.userId),
     ]);
 
-    return c.json(serializeSouvenirDto({ ...inserted, userName }, memberNoMap), 201);
+    return c.json(
+      {
+        ...serializeSouvenirDto({ ...inserted, userName }, memberNoMap),
+        _meta: { count: itemCount + 1, max: MAX_SOUVENIRS_PER_USER_PER_TRIP },
+      },
+      201,
+    );
   }),
 );
 
@@ -241,11 +247,18 @@ souvenirsWriteApp.patch(
       .where(eq(souvenirItems.id, itemId))
       .returning();
 
-    const [memberNoMap, userName] = await Promise.all([
+    const [memberNoMap, userName, [{ itemCount }]] = await Promise.all([
       buildTripMemberNoMap(tripId),
       getActorName(key.userId),
+      db
+        .select({ itemCount: count() })
+        .from(souvenirItems)
+        .where(and(eq(souvenirItems.tripId, tripId), eq(souvenirItems.userId, key.userId))),
     ]);
 
-    return c.json(serializeSouvenirDto({ ...updated, userName }, memberNoMap));
+    return c.json({
+      ...serializeSouvenirDto({ ...updated, userName }, memberNoMap),
+      _meta: { count: itemCount, max: MAX_SOUVENIRS_PER_USER_PER_TRIP },
+    });
   }),
 );

--- a/apps/api/src/routes/v1/souvenirs-write.ts
+++ b/apps/api/src/routes/v1/souvenirs-write.ts
@@ -4,6 +4,7 @@
 //   POST   /trips/:tripId/souvenirs
 //   POST   /trips/:tripId/souvenirs/batch
 //   PATCH  /trips/:tripId/souvenirs/:itemId
+//   DELETE /trips/:tripId/souvenirs/:itemId
 //
 // Souvenirs are per-member items within a trip: any trip member (including
 // viewers) can create their own, and only the owner can update theirs. Unlike
@@ -27,6 +28,7 @@ import { getActorName, uuidSchema, withTripAccess } from "./shared";
 import {
   v1BatchCreateSouvenirSchema,
   v1CreateSouvenirSchema,
+  v1DeleteResponseSchema,
   v1SouvenirBatchWriteResponseSchema,
   v1SouvenirWriteResponseSchema,
   v1UpdateSouvenirSchema,
@@ -354,6 +356,100 @@ souvenirsWriteApp.patch(
     return c.json({
       ...serializeSouvenirDto({ ...updated, userName }, memberNoMap),
       _meta: { count: itemCount, max: MAX_SOUVENIRS_PER_USER_PER_TRIP },
+    });
+  }),
+);
+
+// ---------------------------------------------------------------------------
+// DELETE /trips/:tripId/souvenirs/:itemId
+// ---------------------------------------------------------------------------
+
+souvenirsWriteApp.delete(
+  "/trips/:tripId/souvenirs/:itemId",
+  describeRoute({
+    tags: ["Souvenirs"],
+    summary: "Delete a souvenir",
+    description:
+      "Physically deletes a souvenir owned by the API key user. Idempotent: returns 200 in all cases. deleted:true when the caller's item was found and removed; deleted:false when the id is unknown, already deleted, or the item belongs to a different trip member. Other members' items are never deleted and their existence is not revealed. remaining reflects the caller's per-user per-trip souvenir count after the operation. Any trip member (including viewers) may call this endpoint for their own items. Requires `souvenirs:write` scope.",
+    security: [{ bearerAuth: [] }],
+    parameters: [
+      {
+        name: "tripId",
+        in: "path",
+        required: true,
+        description: "Trip UUID.",
+        schema: { type: "string", format: "uuid" },
+      },
+      {
+        name: "itemId",
+        in: "path",
+        required: true,
+        description: "Souvenir item UUID.",
+        schema: { type: "string", format: "uuid" },
+      },
+    ],
+    responses: {
+      200: {
+        description:
+          "Deletion result (deleted:true when removed, deleted:false when already gone or owned by another member)",
+        content: { "application/json": { schema: resolver(v1DeleteResponseSchema) } },
+      },
+      400: {
+        description: "Invalid souvenir id",
+        content: { "application/json": { schema: resolver(errorResponseSchema) } },
+      },
+      401: {
+        description: "Missing or invalid API key",
+        content: { "application/json": { schema: resolver(errorResponseSchema) } },
+      },
+      403: {
+        description: "Insufficient scope",
+        content: { "application/json": { schema: resolver(errorResponseSchema) } },
+      },
+      404: {
+        description: "Trip not found or access denied",
+        content: { "application/json": { schema: resolver(errorResponseSchema) } },
+      },
+    },
+  }),
+  requireApiKey("souvenirs:write"),
+  withTripAccess("tripId", async (c, tripId) => {
+    const key = getApiKey(c);
+
+    const rawItemId = c.req.param("itemId");
+    const parsedItemId = uuidSchema.safeParse(rawItemId);
+    if (!parsedItemId.success) {
+      throw new ApiV1Error(400, "invalid_request", "Invalid souvenir id");
+    }
+    const itemId = parsedItemId.data;
+
+    // Atomic delete: ownership is enforced atomically in the WHERE clause
+    // (id + tripId + userId). Another user's item matches neither the userId
+    // condition nor any of the caller's own items, so it is never deleted and
+    // its existence is not revealed — deleted:false is returned either way.
+    const deletedRows = await db
+      .delete(souvenirItems)
+      .where(
+        and(
+          eq(souvenirItems.id, itemId),
+          eq(souvenirItems.tripId, tripId),
+          eq(souvenirItems.userId, key.userId),
+        ),
+      )
+      .returning({ id: souvenirItems.id });
+    const didDelete = deletedRows.length > 0;
+
+    // Post-operation count: the same query covers both paths (delete hit and
+    // no-op) so remaining always reflects the caller's current item total.
+    const [{ itemCount }] = await db
+      .select({ itemCount: count() })
+      .from(souvenirItems)
+      .where(and(eq(souvenirItems.tripId, tripId), eq(souvenirItems.userId, key.userId)));
+
+    return c.json({
+      id: itemId,
+      deleted: didDelete,
+      remaining: { count: itemCount, max: MAX_SOUVENIRS_PER_USER_PER_TRIP },
     });
   }),
 );

--- a/apps/api/src/routes/v1/souvenirs-write.ts
+++ b/apps/api/src/routes/v1/souvenirs-write.ts
@@ -2,6 +2,7 @@
 //
 // File layout:
 //   POST   /trips/:tripId/souvenirs
+//   POST   /trips/:tripId/souvenirs/batch
 //   PATCH  /trips/:tripId/souvenirs/:itemId
 //
 // Souvenirs are per-member items within a trip: any trip member (including
@@ -18,12 +19,15 @@ import { db } from "../../db";
 import { souvenirItems, tripMembers } from "../../db/schema";
 import { ApiV1Error, getApiKey, type V1Env } from "../../lib/external-api/errors";
 import { buildMemberNoMap } from "../../lib/external-api/member-no";
+import { batchCreateSouvenirsCore } from "../../lib/souvenir-service";
 import { requireApiKey } from "../../middleware/require-api-key";
 import { errorResponseSchema } from "./openapi-schemas";
 import { serializeSouvenirDto } from "./serializers";
 import { getActorName, uuidSchema, withTripAccess } from "./shared";
 import {
+  v1BatchCreateSouvenirSchema,
   v1CreateSouvenirSchema,
+  v1SouvenirBatchWriteResponseSchema,
   v1SouvenirWriteResponseSchema,
   v1UpdateSouvenirSchema,
 } from "./write-schemas";
@@ -143,6 +147,97 @@ souvenirsWriteApp.post(
       {
         ...serializeSouvenirDto({ ...inserted, userName }, memberNoMap),
         _meta: { count: itemCount + 1, max: MAX_SOUVENIRS_PER_USER_PER_TRIP },
+      },
+      201,
+    );
+  }),
+);
+
+// ---------------------------------------------------------------------------
+// POST /trips/:tripId/souvenirs/batch
+// ---------------------------------------------------------------------------
+
+souvenirsWriteApp.post(
+  "/trips/:tripId/souvenirs/batch",
+  describeRoute({
+    tags: ["Souvenirs"],
+    summary: "Batch create souvenirs",
+    description:
+      'Creates up to 50 souvenir items owned by the API key user in a single transaction. Items that exceed the per-user per-trip limit are returned in `skipped` with `reason: "limit_reached"`. When `onConflict` is `"skip"`, items whose name (trimmed, case-insensitive) matches an existing souvenir owned by the caller in the trip or an earlier item in the same batch are returned in `skipped` with `reason: "duplicate"`. Requires `souvenirs:write` scope.',
+    security: [{ bearerAuth: [] }],
+    parameters: [
+      {
+        name: "tripId",
+        in: "path",
+        required: true,
+        description: "Trip UUID.",
+        schema: { type: "string", format: "uuid" },
+      },
+    ],
+    requestBody: {
+      required: true,
+      content: { "application/json": { schema: { type: "object" } } },
+    },
+    responses: {
+      201: {
+        description: "Batch processed (partial success is normal — check `skipped`)",
+        content: {
+          "application/json": { schema: resolver(v1SouvenirBatchWriteResponseSchema) },
+        },
+      },
+      400: {
+        description: "Invalid request body",
+        content: { "application/json": { schema: resolver(errorResponseSchema) } },
+      },
+      401: {
+        description: "Missing or invalid API key",
+        content: { "application/json": { schema: resolver(errorResponseSchema) } },
+      },
+      403: {
+        description: "Insufficient scope",
+        content: { "application/json": { schema: resolver(errorResponseSchema) } },
+      },
+      404: {
+        description: "Trip not found or access denied",
+        content: { "application/json": { schema: resolver(errorResponseSchema) } },
+      },
+    },
+  }),
+  requireApiKey("souvenirs:write"),
+  withTripAccess("tripId", async (c, tripId) => {
+    const key = getApiKey(c);
+
+    const body = await c.req.json();
+    const parsed = v1BatchCreateSouvenirSchema.safeParse(body);
+    if (!parsed.success) {
+      throw new ApiV1Error(400, "invalid_request", "Invalid request body");
+    }
+
+    const { items, onConflict } = parsed.data;
+    const { created, skipped } = await batchCreateSouvenirsCore(
+      tripId,
+      key.userId,
+      items,
+      onConflict,
+    );
+
+    // Resolve memberNo map and actor name for serialization.
+    const [memberNoMap, userName] = await Promise.all([
+      buildTripMemberNoMap(tripId),
+      getActorName(key.userId),
+    ]);
+
+    // Post-batch user souvenir count for _meta.
+    const [{ itemCount }] = await db
+      .select({ itemCount: count() })
+      .from(souvenirItems)
+      .where(and(eq(souvenirItems.tripId, tripId), eq(souvenirItems.userId, key.userId)));
+
+    return c.json(
+      {
+        created: created.map((item) => serializeSouvenirDto({ ...item, userName }, memberNoMap)),
+        skipped,
+        _meta: { count: itemCount, max: MAX_SOUVENIRS_PER_USER_PER_TRIP },
       },
       201,
     );

--- a/apps/api/src/routes/v1/write-schemas.ts
+++ b/apps/api/src/routes/v1/write-schemas.ts
@@ -419,3 +419,18 @@ export const v1SouvenirBatchWriteResponseSchema = z.object({
   skipped: z.array(v1BatchSkippedItemSchema),
   _meta: v1WriteMetaSchema,
 });
+
+// ---------------------------------------------------------------------------
+// Delete response schema — shared by candidate and souvenir delete endpoints
+// ---------------------------------------------------------------------------
+
+// Idempotent delete: always returns 200. deleted:true when the item was found
+// and removed; deleted:false when the item was already gone, belongs to another
+// trip, or (for souvenirs) is owned by a different user. remaining carries the
+// same cap context as the create response for the same resource type, computed
+// after the operation.
+export const v1DeleteResponseSchema = z.object({
+  id: z.string(),
+  deleted: z.boolean(),
+  remaining: v1WriteMetaSchema,
+});

--- a/apps/api/src/routes/v1/write-schemas.ts
+++ b/apps/api/src/routes/v1/write-schemas.ts
@@ -232,6 +232,13 @@ export type V1UpdateExpenseInput = z.infer<typeof v1UpdateExpenseSchema>;
 // Response schemas — external DTO shapes for write operations
 // ---------------------------------------------------------------------------
 
+// _meta: count/limit context returned on write operations where callers need to
+// know the resulting item count relative to the per-resource cap.
+export const v1WriteMetaSchema = z.object({
+  count: z.number().int(),
+  max: z.number().int(),
+});
+
 // Trip write response: basic fields only, no ownerId or cover image internals.
 export const v1TripWriteResponseSchema = z.object({
   id: z.string(),
@@ -246,6 +253,7 @@ export const v1TripWriteResponseSchema = z.object({
 });
 
 // Schedule write response: all non-internal fields.
+// Used by trips-write (POST/PATCH /schedules) which are not cap-context aware.
 export const v1ScheduleWriteResponseSchema = z.object({
   id: z.string(),
   name: z.string(),
@@ -264,6 +272,13 @@ export const v1ScheduleWriteResponseSchema = z.object({
   sortOrder: z.number().int(),
   createdAt: z.string(),
   updatedAt: z.string(),
+});
+
+// Candidate write response = schedule DTO + _meta (count of ALL schedules in the
+// trip vs. MAX_SCHEDULES_PER_TRIP). Only candidate routes include _meta because
+// they write to the trip-wide schedule pool that callers need to track.
+export const v1CandidateWriteResponseSchema = v1ScheduleWriteResponseSchema.extend({
+  _meta: v1WriteMetaSchema,
 });
 
 // Expense write response: memberNo-based references, no internal userId exposure.
@@ -342,4 +357,5 @@ export const v1SouvenirWriteResponseSchema = z.object({
   owner: v1SouvenirOwnerSchema,
   createdAt: z.string(),
   updatedAt: z.string(),
+  _meta: v1WriteMetaSchema,
 });

--- a/apps/api/src/routes/v1/write-schemas.ts
+++ b/apps/api/src/routes/v1/write-schemas.ts
@@ -343,7 +343,9 @@ const v1SouvenirOwnerSchema = z.object({
   displayName: z.string(),
 });
 
-export const v1SouvenirWriteResponseSchema = z.object({
+// Base souvenir DTO shape (without _meta) reused by both the single-create and
+// the batch-create response schemas.
+const v1SouvenirDtoSchema = z.object({
   id: z.string(),
   name: z.string(),
   recipient: z.string().nullable(),
@@ -357,5 +359,63 @@ export const v1SouvenirWriteResponseSchema = z.object({
   owner: v1SouvenirOwnerSchema,
   createdAt: z.string(),
   updatedAt: z.string(),
+});
+
+export const v1SouvenirWriteResponseSchema = v1SouvenirDtoSchema.extend({
+  _meta: v1WriteMetaSchema,
+});
+
+// ---------------------------------------------------------------------------
+// Batch write schemas — shared helpers
+// ---------------------------------------------------------------------------
+
+// Skipped-item type carried in both candidate and souvenir batch responses.
+const v1BatchSkippedItemSchema = z.object({
+  name: z.string(),
+  reason: z.enum(["duplicate", "limit_reached"]),
+});
+
+// Conflict resolution for batch creates.
+// "create" (default): always insert — matches single-create semantics.
+// "skip": items whose name (trim + toLowerCase) matches an existing entry in
+//   the trip/user scope OR an earlier item in the same batch are skipped with
+//   reason "duplicate". This is an exact-match check; unlike list q= which
+//   uses partial/case-insensitive substring matching.
+const v1BatchOnConflictSchema = z.enum(["create", "skip"]).default("create");
+
+// ---------------------------------------------------------------------------
+// Candidate batch schemas
+// ---------------------------------------------------------------------------
+
+export const v1BatchCreateCandidateSchema = z.object({
+  items: z.array(v1CreateScheduleSchema).min(1).max(50),
+  onConflict: v1BatchOnConflictSchema,
+});
+
+export type V1BatchCreateCandidateInput = z.infer<typeof v1BatchCreateCandidateSchema>;
+
+// Batch response: created carries plain schedule DTOs (no per-item _meta);
+// _meta at the response root reflects the post-batch trip-wide schedule count.
+export const v1CandidateBatchWriteResponseSchema = z.object({
+  created: z.array(v1ScheduleWriteResponseSchema),
+  skipped: z.array(v1BatchSkippedItemSchema),
+  _meta: v1WriteMetaSchema,
+});
+
+// ---------------------------------------------------------------------------
+// Souvenir batch schemas
+// ---------------------------------------------------------------------------
+
+export const v1BatchCreateSouvenirSchema = z.object({
+  items: z.array(createSouvenirSchema).min(1).max(50),
+  onConflict: v1BatchOnConflictSchema,
+});
+
+export type V1BatchCreateSouvenirInput = z.infer<typeof v1BatchCreateSouvenirSchema>;
+
+// Batch response: created items use the base souvenir DTO without per-item _meta.
+export const v1SouvenirBatchWriteResponseSchema = z.object({
+  created: z.array(v1SouvenirDtoSchema),
+  skipped: z.array(v1BatchSkippedItemSchema),
   _meta: v1WriteMetaSchema,
 });

--- a/apps/mcp/src/__tests__/client.test.ts
+++ b/apps/mcp/src/__tests__/client.test.ts
@@ -792,4 +792,106 @@ describe("ApiClient", () => {
       );
     });
   });
+
+  describe("batch methods — request assembly", () => {
+    const tripId = "550e8400-e29b-41d4-a716-446655440000";
+    const batchResponse = { created: [], skipped: [], _meta: { count: 0, max: 300 } };
+
+    it("batchCreateCandidates POSTs to /trips/:tripId/candidates/batch", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(makeResponse(batchResponse, 201));
+
+      // Act
+      await client.batchCreateCandidates(tripId, [{ name: "Tower", category: "sightseeing" }]);
+
+      // Assert
+      expect(getFirstCallMethod(mockFetch.mock.calls)).toBe("POST");
+      expect(getFirstCallUrl(mockFetch.mock.calls)).toContain(
+        `/api/v1/trips/${tripId}/candidates/batch`,
+      );
+    });
+
+    it("batchCreateCandidates sends items in the request body", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(makeResponse(batchResponse, 201));
+      const items = [{ name: "Tower", category: "sightseeing" }];
+
+      // Act
+      await client.batchCreateCandidates(tripId, items);
+
+      // Assert
+      const body = getFirstCallBody(mockFetch.mock.calls);
+      expect(body).toEqual({ items });
+    });
+
+    it("batchCreateCandidates includes onConflict when provided", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(makeResponse(batchResponse, 201));
+
+      // Act
+      await client.batchCreateCandidates(
+        tripId,
+        [{ name: "Tower", category: "sightseeing" }],
+        "skip",
+      );
+
+      // Assert
+      const body = getFirstCallBody(mockFetch.mock.calls);
+      expect(body).toMatchObject({ onConflict: "skip" });
+    });
+
+    it("batchCreateCandidates omits onConflict when not provided", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(makeResponse(batchResponse, 201));
+
+      // Act
+      await client.batchCreateCandidates(tripId, [{ name: "Tower", category: "sightseeing" }]);
+
+      // Assert
+      const body = getFirstCallBody(mockFetch.mock.calls) as Record<string, unknown>;
+      expect(body).not.toHaveProperty("onConflict");
+    });
+
+    it("batchCreateSouvenirs POSTs to /trips/:tripId/souvenirs/batch", async () => {
+      // Arrange
+      const souvenirBatchResponse = { created: [], skipped: [], _meta: { count: 0, max: 50 } };
+      mockFetch.mockResolvedValue(makeResponse(souvenirBatchResponse, 201));
+
+      // Act
+      await client.batchCreateSouvenirs(tripId, [{ name: "KitKat" }]);
+
+      // Assert
+      expect(getFirstCallMethod(mockFetch.mock.calls)).toBe("POST");
+      expect(getFirstCallUrl(mockFetch.mock.calls)).toContain(
+        `/api/v1/trips/${tripId}/souvenirs/batch`,
+      );
+    });
+
+    it("batchCreateSouvenirs sends items in the request body", async () => {
+      // Arrange
+      const souvenirBatchResponse = { created: [], skipped: [], _meta: { count: 0, max: 50 } };
+      mockFetch.mockResolvedValue(makeResponse(souvenirBatchResponse, 201));
+      const items = [{ name: "KitKat" }, { name: "Pocky" }];
+
+      // Act
+      await client.batchCreateSouvenirs(tripId, items);
+
+      // Assert
+      const body = getFirstCallBody(mockFetch.mock.calls);
+      expect(body).toEqual({ items });
+    });
+
+    it("batchCreateSouvenirs includes onConflict when provided", async () => {
+      // Arrange
+      const souvenirBatchResponse = { created: [], skipped: [], _meta: { count: 0, max: 50 } };
+      mockFetch.mockResolvedValue(makeResponse(souvenirBatchResponse, 201));
+
+      // Act
+      await client.batchCreateSouvenirs(tripId, [{ name: "KitKat" }], "skip");
+
+      // Assert
+      const body = getFirstCallBody(mockFetch.mock.calls);
+      expect(body).toMatchObject({ onConflict: "skip" });
+    });
+  });
 });

--- a/apps/mcp/src/__tests__/client.test.ts
+++ b/apps/mcp/src/__tests__/client.test.ts
@@ -894,4 +894,84 @@ describe("ApiClient", () => {
       expect(body).toMatchObject({ onConflict: "skip" });
     });
   });
+
+  describe("deleteCandidate — request assembly", () => {
+    const tripId = "550e8400-e29b-41d4-a716-446655440000";
+    const scheduleId = "550e8400-e29b-41d4-a716-446655440001";
+
+    it("uses DELETE method", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(
+        makeResponse({ id: scheduleId, deleted: true, remaining: { count: 0, max: 300 } }, 200),
+      );
+
+      // Act
+      await client.deleteCandidate(tripId, scheduleId);
+
+      // Assert
+      expect(getFirstCallMethod(mockFetch.mock.calls)).toBe("DELETE");
+    });
+
+    it("sends to /api/v1/trips/:tripId/candidates/:scheduleId", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(
+        makeResponse({ id: scheduleId, deleted: true, remaining: { count: 0, max: 300 } }, 200),
+      );
+
+      // Act
+      await client.deleteCandidate(tripId, scheduleId);
+
+      // Assert
+      expect(getFirstCallUrl(mockFetch.mock.calls)).toContain(
+        `/api/v1/trips/${tripId}/candidates/${scheduleId}`,
+      );
+    });
+
+    it("does not send a Content-Type header (no body)", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(
+        makeResponse({ id: scheduleId, deleted: false, remaining: { count: 0, max: 300 } }, 200),
+      );
+
+      // Act
+      await client.deleteCandidate(tripId, scheduleId);
+
+      // Assert
+      const headers = getFirstCallHeaders(mockFetch.mock.calls);
+      expect(headers["Content-Type"]).toBeUndefined();
+    });
+  });
+
+  describe("deleteSouvenir — request assembly", () => {
+    const tripId = "550e8400-e29b-41d4-a716-446655440000";
+    const itemId = "550e8400-e29b-41d4-a716-446655440002";
+
+    it("uses DELETE method", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(
+        makeResponse({ id: itemId, deleted: true, remaining: { count: 0, max: 30 } }, 200),
+      );
+
+      // Act
+      await client.deleteSouvenir(tripId, itemId);
+
+      // Assert
+      expect(getFirstCallMethod(mockFetch.mock.calls)).toBe("DELETE");
+    });
+
+    it("sends to /api/v1/trips/:tripId/souvenirs/:itemId", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(
+        makeResponse({ id: itemId, deleted: true, remaining: { count: 0, max: 30 } }, 200),
+      );
+
+      // Act
+      await client.deleteSouvenir(tripId, itemId);
+
+      // Assert
+      expect(getFirstCallUrl(mockFetch.mock.calls)).toContain(
+        `/api/v1/trips/${tripId}/souvenirs/${itemId}`,
+      );
+    });
+  });
 });

--- a/apps/mcp/src/__tests__/client.test.ts
+++ b/apps/mcp/src/__tests__/client.test.ts
@@ -699,6 +699,66 @@ describe("ApiClient", () => {
     });
   });
 
+  describe("q (name search) parameter", () => {
+    const tripId = "550e8400-e29b-41d4-a716-446655440000";
+    const listId = "880e8400-e29b-41d4-a716-446655440000";
+
+    it("listCandidates appends q to the URL when provided", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(makeResponse({ data: [], pagination: {} }, 200));
+
+      // Act
+      await client.listCandidates(tripId, { q: "Tower" });
+
+      // Assert
+      expect(getFirstCallUrl(mockFetch.mock.calls)).toContain("q=Tower");
+    });
+
+    it("listCandidates does not append q when absent", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(makeResponse({ data: [], pagination: {} }, 200));
+
+      // Act
+      await client.listCandidates(tripId);
+
+      // Assert
+      expect(getFirstCallUrl(mockFetch.mock.calls)).not.toContain("q=");
+    });
+
+    it("listSouvenirs appends q to the URL when provided", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(makeResponse({ data: [], pagination: {} }, 200));
+
+      // Act
+      await client.listSouvenirs(tripId, { q: "Matcha" });
+
+      // Assert
+      expect(getFirstCallUrl(mockFetch.mock.calls)).toContain("q=Matcha");
+    });
+
+    it("listArticles appends q to the URL when provided", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(makeResponse({ data: [], pagination: {} }, 200));
+
+      // Act
+      await client.listArticles({ q: "Kyoto" });
+
+      // Assert
+      expect(getFirstCallUrl(mockFetch.mock.calls)).toContain("q=Kyoto");
+    });
+
+    it("listBookmarks appends q to the URL when provided", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(makeResponse({ data: [], pagination: {} }, 200));
+
+      // Act
+      await client.listBookmarks(listId, { q: "Senso" });
+
+      // Assert
+      expect(getFirstCallUrl(mockFetch.mock.calls)).toContain("q=Senso");
+    });
+  });
+
   describe("souvenir methods — request assembly", () => {
     const tripId = "550e8400-e29b-41d4-a716-446655440000";
     const itemId = "770e8400-e29b-41d4-a716-446655440000";

--- a/apps/mcp/src/__tests__/server.test.ts
+++ b/apps/mcp/src/__tests__/server.test.ts
@@ -243,12 +243,12 @@ describe("MCP server — tools/list", () => {
     await mcpServer.close();
   });
 
-  it("returns exactly 25 tools", async () => {
+  it("returns exactly 27 tools", async () => {
     // Arrange + Act
     const result = await mcpClient.listTools();
 
     // Assert
-    expect(result.tools).toHaveLength(25);
+    expect(result.tools).toHaveLength(27);
   });
 
   it("includes all 19 expected tool names", async () => {

--- a/apps/mcp/src/__tests__/server.test.ts
+++ b/apps/mcp/src/__tests__/server.test.ts
@@ -51,7 +51,7 @@ const FAKE_CREATED_TRIP = {
   updatedAt: "2025-01-01T00:00:00.000Z",
 };
 
-// The 25 tool names that registerTools must expose.
+// The 29 tool names that registerTools must expose.
 const EXPECTED_TOOL_NAMES = [
   "list_trips",
   "get_trip",
@@ -78,6 +78,10 @@ const EXPECTED_TOOL_NAMES = [
   "update_candidate",
   "create_souvenir",
   "update_souvenir",
+  "batch_create_candidates",
+  "batch_create_souvenirs",
+  "delete_candidate",
+  "delete_souvenir",
 ] as const;
 
 /**
@@ -181,6 +185,14 @@ class FakeApiClient extends ApiClient {
   override async updateArticle(_id: string, _body: unknown): Promise<unknown> {
     return { id: "00000000-0000-0000-0000-000000000050", title: "Updated Story" };
   }
+
+  override async deleteCandidate(_tripId: string, _scheduleId: string): Promise<unknown> {
+    return { id: _scheduleId, deleted: true, remaining: { count: 0, max: 300 } };
+  }
+
+  override async deleteSouvenir(_tripId: string, _itemId: string): Promise<unknown> {
+    return { id: _itemId, deleted: true, remaining: { count: 0, max: 30 } };
+  }
 }
 
 /**
@@ -243,15 +255,15 @@ describe("MCP server — tools/list", () => {
     await mcpServer.close();
   });
 
-  it("returns exactly 27 tools", async () => {
+  it("returns exactly 29 tools", async () => {
     // Arrange + Act
     const result = await mcpClient.listTools();
 
     // Assert
-    expect(result.tools).toHaveLength(27);
+    expect(result.tools).toHaveLength(29);
   });
 
-  it("includes all 19 expected tool names", async () => {
+  it("includes all 27 expected tool names", async () => {
     // Arrange + Act
     const result = await mcpClient.listTools();
     const names = result.tools.map((t) => t.name);

--- a/apps/mcp/src/__tests__/tools.test.ts
+++ b/apps/mcp/src/__tests__/tools.test.ts
@@ -3,12 +3,12 @@ import { z } from "zod";
 import { INPUT_SHAPES } from "../tools.js";
 
 describe("INPUT_SHAPES", () => {
-  it("defines 27 tools", () => {
+  it("defines 29 tools", () => {
     // Arrange + Act
     const toolNames = Object.keys(INPUT_SHAPES);
 
     // Assert
-    expect(toolNames).toHaveLength(27);
+    expect(toolNames).toHaveLength(29);
   });
 
   it("includes the candidate and souvenir tools including batch variants", () => {
@@ -24,6 +24,8 @@ describe("INPUT_SHAPES", () => {
         "create_souvenir",
         "update_souvenir",
         "batch_create_souvenirs",
+        "delete_candidate",
+        "delete_souvenir",
       ]),
     );
   });
@@ -769,6 +771,38 @@ describe("batch_create_candidates input schema", () => {
       onConflict: "create",
     });
     expect(result.success).toBe(true);
+  });
+});
+
+describe("delete_candidate input schema", () => {
+  const schema = z.object(INPUT_SHAPES.delete_candidate);
+
+  it("requires tripId and scheduleId", () => {
+    expect(schema.safeParse({ tripId: crypto.randomUUID() }).success).toBe(false);
+    expect(
+      schema.safeParse({ tripId: crypto.randomUUID(), scheduleId: crypto.randomUUID() }).success,
+    ).toBe(true);
+  });
+
+  it("rejects non-UUID scheduleId", () => {
+    const result = schema.safeParse({ tripId: crypto.randomUUID(), scheduleId: "not-uuid" });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("delete_souvenir input schema", () => {
+  const schema = z.object(INPUT_SHAPES.delete_souvenir);
+
+  it("requires tripId and itemId", () => {
+    expect(schema.safeParse({ tripId: crypto.randomUUID() }).success).toBe(false);
+    expect(
+      schema.safeParse({ tripId: crypto.randomUUID(), itemId: crypto.randomUUID() }).success,
+    ).toBe(true);
+  });
+
+  it("rejects non-UUID itemId", () => {
+    const result = schema.safeParse({ tripId: crypto.randomUUID(), itemId: "not-uuid" });
+    expect(result.success).toBe(false);
   });
 });
 

--- a/apps/mcp/src/__tests__/tools.test.ts
+++ b/apps/mcp/src/__tests__/tools.test.ts
@@ -655,3 +655,60 @@ describe("update_article input schema", () => {
     expect(result.success).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// q (name/title search) parameter in list schemas
+// ---------------------------------------------------------------------------
+
+describe("list_candidates q parameter", () => {
+  const schema = z.object(INPUT_SHAPES.list_candidates);
+
+  it("preserves q in parsed output so the tool handler can forward it", () => {
+    // Zod strips unknown keys by default, so q must be declared in the schema
+    // for it to survive parsing. This test would fail without q in INPUT_SHAPES.
+    const result = schema.safeParse({ tripId: crypto.randomUUID(), q: "Tokyo" });
+
+    expect(result.success).toBe(true);
+    expect(result.data?.q).toBe("Tokyo");
+  });
+
+  it("preserves q as undefined when absent", () => {
+    const result = schema.safeParse({ tripId: crypto.randomUUID() });
+
+    expect(result.success).toBe(true);
+    expect(result.data?.q).toBeUndefined();
+  });
+});
+
+describe("list_souvenirs q parameter", () => {
+  const schema = z.object(INPUT_SHAPES.list_souvenirs);
+
+  it("preserves q in parsed output", () => {
+    const result = schema.safeParse({ tripId: crypto.randomUUID(), q: "Matcha" });
+
+    expect(result.success).toBe(true);
+    expect(result.data?.q).toBe("Matcha");
+  });
+});
+
+describe("list_articles q parameter", () => {
+  const schema = z.object(INPUT_SHAPES.list_articles);
+
+  it("preserves q in parsed output", () => {
+    const result = schema.safeParse({ q: "Kyoto" });
+
+    expect(result.success).toBe(true);
+    expect(result.data?.q).toBe("Kyoto");
+  });
+});
+
+describe("list_bookmarks q parameter", () => {
+  const schema = z.object(INPUT_SHAPES.list_bookmarks);
+
+  it("preserves q in parsed output alongside listId", () => {
+    const result = schema.safeParse({ listId: crypto.randomUUID(), q: "Senso" });
+
+    expect(result.success).toBe(true);
+    expect(result.data?.q).toBe("Senso");
+  });
+});

--- a/apps/mcp/src/__tests__/tools.test.ts
+++ b/apps/mcp/src/__tests__/tools.test.ts
@@ -3,15 +3,15 @@ import { z } from "zod";
 import { INPUT_SHAPES } from "../tools.js";
 
 describe("INPUT_SHAPES", () => {
-  it("defines 25 tools", () => {
+  it("defines 27 tools", () => {
     // Arrange + Act
     const toolNames = Object.keys(INPUT_SHAPES);
 
     // Assert
-    expect(toolNames).toHaveLength(25);
+    expect(toolNames).toHaveLength(27);
   });
 
-  it("includes the candidate and souvenir tools", () => {
+  it("includes the candidate and souvenir tools including batch variants", () => {
     const toolNames = Object.keys(INPUT_SHAPES);
 
     expect(toolNames).toEqual(
@@ -19,9 +19,11 @@ describe("INPUT_SHAPES", () => {
         "list_candidates",
         "create_candidate",
         "update_candidate",
+        "batch_create_candidates",
         "list_souvenirs",
         "create_souvenir",
         "update_souvenir",
+        "batch_create_souvenirs",
       ]),
     );
   });
@@ -710,5 +712,105 @@ describe("list_bookmarks q parameter", () => {
 
     expect(result.success).toBe(true);
     expect(result.data?.q).toBe("Senso");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Batch create schemas
+// ---------------------------------------------------------------------------
+
+describe("batch_create_candidates input schema", () => {
+  const schema = z.object(INPUT_SHAPES.batch_create_candidates);
+  const validItem = { name: "Tokyo Tower", category: "sightseeing" as const };
+
+  it("requires tripId and at least one item", () => {
+    expect(schema.safeParse({ tripId: crypto.randomUUID(), items: [] }).success).toBe(false);
+    expect(schema.safeParse({ tripId: crypto.randomUUID(), items: [validItem] }).success).toBe(
+      true,
+    );
+  });
+
+  it("rejects more than 50 items", () => {
+    const items = Array.from({ length: 51 }, () => validItem);
+    const result = schema.safeParse({ tripId: crypto.randomUUID(), items });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an invalid category in items", () => {
+    const result = schema.safeParse({
+      tripId: crypto.randomUUID(),
+      items: [{ name: "Tower", category: "nope" }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an invalid onConflict value", () => {
+    const result = schema.safeParse({
+      tripId: crypto.randomUUID(),
+      items: [validItem],
+      onConflict: "upsert",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts onConflict skip", () => {
+    const result = schema.safeParse({
+      tripId: crypto.randomUUID(),
+      items: [validItem],
+      onConflict: "skip",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts onConflict create", () => {
+    const result = schema.safeParse({
+      tripId: crypto.randomUUID(),
+      items: [validItem],
+      onConflict: "create",
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("batch_create_souvenirs input schema", () => {
+  const schema = z.object(INPUT_SHAPES.batch_create_souvenirs);
+  const validItem = { name: "Matcha KitKat" };
+
+  it("requires tripId and at least one item", () => {
+    expect(schema.safeParse({ tripId: crypto.randomUUID(), items: [] }).success).toBe(false);
+    expect(schema.safeParse({ tripId: crypto.randomUUID(), items: [validItem] }).success).toBe(
+      true,
+    );
+  });
+
+  it("rejects more than 50 items", () => {
+    const items = Array.from({ length: 51 }, () => validItem);
+    const result = schema.safeParse({ tripId: crypto.randomUUID(), items });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an invalid shareStyle in items", () => {
+    const result = schema.safeParse({
+      tripId: crypto.randomUUID(),
+      items: [{ name: "KitKat", shareStyle: "gift" }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an invalid priority in items", () => {
+    const result = schema.safeParse({
+      tripId: crypto.randomUUID(),
+      items: [{ name: "KitKat", priority: "low" }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts onConflict skip", () => {
+    const result = schema.safeParse({
+      tripId: crypto.randomUUID(),
+      items: [validItem],
+      onConflict: "skip",
+    });
+    expect(result.success).toBe(true);
   });
 });

--- a/apps/mcp/src/client.ts
+++ b/apps/mcp/src/client.ts
@@ -253,7 +253,32 @@ export class ApiClient {
     return this.request(`/trips/${encodeURIComponent(tripId)}/souvenirs`, params);
   }
 
-  // --- Write methods (12 endpoints, 1:1 with v1 write routes) ---
+  // Sends a DELETE request with no body. Used for idempotent resource removal.
+  // The API always returns 200 + JSON (never 204) so response.json() is always valid.
+  private async remove(path: string): Promise<unknown> {
+    const url = new URL(`${this.baseUrl}/api/v1${path}`);
+
+    let response: Response;
+    try {
+      response = await this._fetch(url.toString(), {
+        method: "DELETE",
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+          Accept: "application/json",
+        },
+      });
+    } catch {
+      throw new Error("SUGARA_API_URL に接続できません");
+    }
+
+    if (!response.ok) {
+      throw await buildApiError(response);
+    }
+
+    return response.json();
+  }
+
+  // --- Write methods (14 endpoints, 1:1 with v1 write routes) ---
 
   async createTrip(body: unknown): Promise<unknown> {
     return this.mutate("POST", "/trips", body);
@@ -364,5 +389,17 @@ export class ApiClient {
       items,
       ...(onConflict !== undefined && { onConflict }),
     });
+  }
+
+  async deleteCandidate(tripId: string, scheduleId: string): Promise<unknown> {
+    return this.remove(
+      `/trips/${encodeURIComponent(tripId)}/candidates/${encodeURIComponent(scheduleId)}`,
+    );
+  }
+
+  async deleteSouvenir(tripId: string, itemId: string): Promise<unknown> {
+    return this.remove(
+      `/trips/${encodeURIComponent(tripId)}/souvenirs/${encodeURIComponent(itemId)}`,
+    );
   }
 }

--- a/apps/mcp/src/client.ts
+++ b/apps/mcp/src/client.ts
@@ -343,4 +343,26 @@ export class ApiClient {
       body,
     );
   }
+
+  async batchCreateCandidates(
+    tripId: string,
+    items: unknown[],
+    onConflict?: "create" | "skip",
+  ): Promise<unknown> {
+    return this.mutate("POST", `/trips/${encodeURIComponent(tripId)}/candidates/batch`, {
+      items,
+      ...(onConflict !== undefined && { onConflict }),
+    });
+  }
+
+  async batchCreateSouvenirs(
+    tripId: string,
+    items: unknown[],
+    onConflict?: "create" | "skip",
+  ): Promise<unknown> {
+    return this.mutate("POST", `/trips/${encodeURIComponent(tripId)}/souvenirs/batch`, {
+      items,
+      ...(onConflict !== undefined && { onConflict }),
+    });
+  }
 }

--- a/apps/mcp/src/client.ts
+++ b/apps/mcp/src/client.ts
@@ -109,9 +109,18 @@ export type PaginationOptions = {
   offset?: number;
 };
 
+// Extended options for list endpoints that support ?q= partial-match filtering.
+export type ListWithSearchOptions = PaginationOptions & {
+  q?: string;
+};
+
 function addPagination(params: URLSearchParams, limit?: number, offset?: number): void {
   if (limit !== undefined) params.set("limit", String(limit));
   if (offset !== undefined) params.set("offset", String(offset));
+}
+
+function addSearch(params: URLSearchParams, q: string | undefined): void {
+  if (q !== undefined) params.set("q", q);
 }
 
 /**
@@ -212,15 +221,17 @@ export class ApiClient {
     return this.request("/bookmark-lists", params);
   }
 
-  async listBookmarks(listId: string, opts?: PaginationOptions): Promise<unknown> {
+  async listBookmarks(listId: string, opts?: ListWithSearchOptions): Promise<unknown> {
     const params = new URLSearchParams();
     addPagination(params, opts?.limit, opts?.offset);
+    addSearch(params, opts?.q);
     return this.request(`/bookmark-lists/${encodeURIComponent(listId)}/bookmarks`, params);
   }
 
-  async listArticles(opts?: PaginationOptions): Promise<unknown> {
+  async listArticles(opts?: ListWithSearchOptions): Promise<unknown> {
     const params = new URLSearchParams();
     addPagination(params, opts?.limit, opts?.offset);
+    addSearch(params, opts?.q);
     return this.request("/articles", params);
   }
 
@@ -228,15 +239,17 @@ export class ApiClient {
     return this.request(`/articles/${encodeURIComponent(id)}`);
   }
 
-  async listCandidates(tripId: string, opts?: PaginationOptions): Promise<unknown> {
+  async listCandidates(tripId: string, opts?: ListWithSearchOptions): Promise<unknown> {
     const params = new URLSearchParams();
     addPagination(params, opts?.limit, opts?.offset);
+    addSearch(params, opts?.q);
     return this.request(`/trips/${encodeURIComponent(tripId)}/candidates`, params);
   }
 
-  async listSouvenirs(tripId: string, opts?: PaginationOptions): Promise<unknown> {
+  async listSouvenirs(tripId: string, opts?: ListWithSearchOptions): Promise<unknown> {
     const params = new URLSearchParams();
     addPagination(params, opts?.limit, opts?.offset);
+    addSearch(params, opts?.q);
     return this.request(`/trips/${encodeURIComponent(tripId)}/souvenirs`, params);
   }
 

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -81,7 +81,7 @@ export const INPUT_SHAPES = {
     q: z.string().optional(),
   },
 
-  // --- Write tools (16) ---
+  // --- Write tools (18) ---
 
   // POST /trips — caller becomes the owner member.
   create_trip: {
@@ -298,6 +298,66 @@ export const INPUT_SHAPES = {
     isShared: z.boolean().optional(),
     shareStyle: z.enum(["recommend", "errand"]).nullable().optional(),
   },
+
+  // POST /trips/:tripId/candidates/batch — up to 50 candidates in one transaction.
+  // onConflict="skip": items whose name (trimmed, lowercase exact match) matches an
+  // existing schedule in the trip OR an earlier item in the same batch are returned
+  // in `skipped` with reason "duplicate". This is NOT a partial match — unlike the
+  // q= search parameter which does case-insensitive substring matching.
+  // Items that exceed the per-trip limit are returned in `skipped` with reason
+  // "limit_reached"; items that fit are always created (partial success is normal).
+  // Requires trips:write scope and editor/owner role.
+  batch_create_candidates: {
+    tripId: z.string().uuid(),
+    items: z
+      .array(
+        z.object({
+          name: z.string().min(1).max(200),
+          category: scheduleCategorySchema,
+          address: z.string().max(500).optional(),
+          startTime: z.string().optional(),
+          endTime: z.string().optional(),
+          memo: z.string().max(2000).optional(),
+          urls: z.array(z.string()).max(5).optional(),
+          departurePlace: z.string().max(200).optional(),
+          arrivalPlace: z.string().max(200).optional(),
+          transportMethod: transportMethodSchema.optional(),
+          cost: z.number().int().nonnegative().max(99999999).optional(),
+          color: scheduleColorSchema.optional(),
+          endDayOffset: z.number().int().min(1).max(30).optional(),
+        }),
+      )
+      .min(1)
+      .max(50),
+    // "create" (default): always insert — matches single-create semantics.
+    // "skip": skip items whose name (trim+lowercase) collides with existing or batch-prior entries.
+    onConflict: z.enum(["create", "skip"]).optional(),
+  },
+
+  // POST /trips/:tripId/souvenirs/batch — up to 50 souvenir items in one transaction.
+  // Dedup scope (onConflict="skip"): caller's own items in the trip only, NOT other
+  // members' items. This differs from the candidate dedup which is trip-wide.
+  // Partial success semantics and limit_reached behaviour are the same as batch_create_candidates.
+  // Requires souvenirs:write scope; any member (including viewers) may call this.
+  batch_create_souvenirs: {
+    tripId: z.string().uuid(),
+    items: z
+      .array(
+        z.object({
+          name: z.string().min(1).max(200),
+          recipient: z.string().max(100).nullable().optional(),
+          urls: z.array(z.string()).max(5).optional(),
+          addresses: z.array(z.string().max(500)).max(5).optional(),
+          memo: z.string().nullable().optional(),
+          priority: z.enum(["high", "medium"]).nullable().optional(),
+          isShared: z.boolean().optional(),
+          shareStyle: z.enum(["recommend", "errand"]).nullable().optional(),
+        }),
+      )
+      .min(1)
+      .max(50),
+    onConflict: z.enum(["create", "skip"]).optional(),
+  },
 } as const;
 
 function toolError(message: string) {
@@ -331,7 +391,7 @@ const UPDATE_ANNOTATIONS = {
 } as const;
 
 /**
- * Registers all 25 sugara v1 tools with the MCP server.
+ * Registers all 27 sugara v1 tools with the MCP server.
  * Each tool maps 1:1 to a v1 endpoint and returns the raw JSON response.
  * On client errors, returns an isError result with a human-readable message.
  *
@@ -549,7 +609,7 @@ export function registerTools(server: McpServer, client: ApiClient): void {
   );
 
   // ---------------------------------------------------------------------------
-  // Write tools (16)
+  // Write tools (18)
   // ---------------------------------------------------------------------------
 
   server.registerTool(
@@ -901,6 +961,67 @@ export function registerTools(server: McpServer, client: ApiClient): void {
       const { tripId, itemId, ...body } = args;
       try {
         const result = await client.updateSouvenir(tripId, itemId, body);
+        return toolResult(result);
+      } catch (err) {
+        return toolError(err instanceof Error ? err.message : "Unexpected error");
+      }
+    },
+  );
+
+  server.registerTool(
+    "batch_create_candidates",
+    {
+      description:
+        "Create up to 50 candidates in a single transaction. " +
+        "Returns { created, skipped, _meta } — partial success is normal. " +
+        "onConflict='skip': items whose name (trimmed, lowercase EXACT match) collides with an " +
+        "existing schedule name in the trip OR an earlier item in the same batch are put in " +
+        "`skipped` with reason 'duplicate'. " +
+        "NOTE: this is an exact match after trim+lowercase, NOT the partial substring match " +
+        "used by list_candidates q= search. " +
+        "onConflict='create' (default): all items are always inserted regardless of name collisions. " +
+        "Items that exceed the per-trip schedule limit go to `skipped` with reason 'limit_reached'; " +
+        "items that fit are created. No 409 is returned for limit overflow. " +
+        "Writing to a shared trip requires editor or owner role. " +
+        "Requires trips:write scope.",
+      inputSchema: INPUT_SHAPES.batch_create_candidates,
+      annotations: CREATE_ANNOTATIONS,
+    },
+    async (args) => {
+      const { tripId, items, onConflict } = args;
+      try {
+        const result = await client.batchCreateCandidates(tripId, items, onConflict);
+        return toolResult(result);
+      } catch (err) {
+        return toolError(err instanceof Error ? err.message : "Unexpected error");
+      }
+    },
+  );
+
+  server.registerTool(
+    "batch_create_souvenirs",
+    {
+      description:
+        "Create up to 50 souvenir items in a single transaction. " +
+        "Returns { created, skipped, _meta } — partial success is normal. " +
+        "onConflict='skip': items whose name (trimmed, lowercase EXACT match) collides with an " +
+        "existing souvenir owned by the caller in the trip OR an earlier item in the same batch " +
+        "are put in `skipped` with reason 'duplicate'. " +
+        "Dedup scope is the caller's own items only — other members' items are NOT compared. " +
+        "NOTE: this is an exact match after trim+lowercase, NOT the partial substring match " +
+        "used by list_souvenirs q= search. " +
+        "onConflict='create' (default): all items are always inserted regardless of name collisions. " +
+        "Items that exceed the per-user per-trip souvenir limit go to `skipped` with reason " +
+        "'limit_reached'; items that fit are created. No 409 is returned for limit overflow. " +
+        "Any trip member (including viewers) may call this tool. " +
+        "Requires souvenirs:write scope.",
+      inputSchema: INPUT_SHAPES.batch_create_souvenirs,
+      annotations: CREATE_ANNOTATIONS,
+    },
+    async (args) => {
+      const { tripId, items, onConflict } = args;
+      try {
+        const result = await client.batchCreateSouvenirs(tripId, items, onConflict);
         return toolResult(result);
       } catch (err) {
         return toolError(err instanceof Error ? err.message : "Unexpected error");

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -32,7 +32,7 @@ const lineItemShape = z.object({
 });
 
 export const INPUT_SHAPES = {
-  // --- Read tools (7) ---
+  // --- Read tools (9) ---
   list_trips: {
     scope: z.enum(["owned", "shared"]).optional(),
     limit: z.number().int().min(1).max(100).optional(),
@@ -81,7 +81,7 @@ export const INPUT_SHAPES = {
     q: z.string().optional(),
   },
 
-  // --- Write tools (18) ---
+  // --- Write tools (20) ---
 
   // POST /trips — caller becomes the owner member.
   create_trip: {
@@ -358,6 +358,18 @@ export const INPUT_SHAPES = {
       .max(50),
     onConflict: z.enum(["create", "skip"]).optional(),
   },
+
+  // DELETE /trips/:tripId/candidates/:scheduleId — idempotent; assigned schedules return deleted:false.
+  delete_candidate: {
+    tripId: z.string().uuid(),
+    scheduleId: z.string().uuid(),
+  },
+
+  // DELETE /trips/:tripId/souvenirs/:itemId — idempotent; other users' items return deleted:false.
+  delete_souvenir: {
+    tripId: z.string().uuid(),
+    itemId: z.string().uuid(),
+  },
 } as const;
 
 function toolError(message: string) {
@@ -389,9 +401,16 @@ const UPDATE_ANNOTATIONS = {
   idempotentHint: true,
   openWorldHint: false,
 } as const;
+// delete: idempotent (same delete applied twice yields the same state), destructive
+const DELETE_ANNOTATIONS = {
+  readOnlyHint: false,
+  destructiveHint: true,
+  idempotentHint: true,
+  openWorldHint: false,
+} as const;
 
 /**
- * Registers all 27 sugara v1 tools with the MCP server.
+ * Registers all 29 sugara v1 tools with the MCP server.
  * Each tool maps 1:1 to a v1 endpoint and returns the raw JSON response.
  * On client errors, returns an isError result with a human-readable message.
  *
@@ -402,11 +421,10 @@ const UPDATE_ANNOTATIONS = {
  * editor or owner role on that trip — verify with get_trip beforehand
  * (souvenir tools are the exception: any trip member, including viewers, may
  * manage their own souvenirs).
- * Delete operations are not exposed; there are no delete tools.
  */
 export function registerTools(server: McpServer, client: ApiClient): void {
   // ---------------------------------------------------------------------------
-  // Read tools (7)
+  // Read tools (9)
   // ---------------------------------------------------------------------------
 
   server.registerTool(
@@ -609,7 +627,7 @@ export function registerTools(server: McpServer, client: ApiClient): void {
   );
 
   // ---------------------------------------------------------------------------
-  // Write tools (18)
+  // Write tools (20)
   // ---------------------------------------------------------------------------
 
   server.registerTool(
@@ -665,7 +683,6 @@ export function registerTools(server: McpServer, client: ApiClient): void {
         "Writing to a shared trip requires editor or owner role. " +
         "Returns 409 when the trip is in scheduling/poll mode (no days) " +
         "or when the per-trip schedule limit is reached. " +
-        "Delete tools do not exist; schedules cannot be removed via MCP. " +
         "Requires trips:write scope.",
       inputSchema: INPUT_SHAPES.create_schedule,
       annotations: CREATE_ANNOTATIONS,
@@ -1022,6 +1039,53 @@ export function registerTools(server: McpServer, client: ApiClient): void {
       const { tripId, items, onConflict } = args;
       try {
         const result = await client.batchCreateSouvenirs(tripId, items, onConflict);
+        return toolResult(result);
+      } catch (err) {
+        return toolError(err instanceof Error ? err.message : "Unexpected error");
+      }
+    },
+  );
+
+  server.registerTool(
+    "delete_candidate",
+    {
+      description:
+        "Permanently delete an unassigned candidate from a trip's planning pool. " +
+        "Idempotent: always returns 200. deleted:true when the item was removed; " +
+        "deleted:false when the id is unknown, already deleted, or the schedule has been assigned to a day. " +
+        "remaining reflects the trip-wide schedule count after the operation. " +
+        "Writing to a shared trip requires editor or owner role. " +
+        "Requires trips:write scope.",
+      inputSchema: INPUT_SHAPES.delete_candidate,
+      annotations: DELETE_ANNOTATIONS,
+    },
+    async (args) => {
+      try {
+        const result = await client.deleteCandidate(args.tripId, args.scheduleId);
+        return toolResult(result);
+      } catch (err) {
+        return toolError(err instanceof Error ? err.message : "Unexpected error");
+      }
+    },
+  );
+
+  server.registerTool(
+    "delete_souvenir",
+    {
+      description:
+        "Permanently delete a souvenir owned by the API key user. " +
+        "Idempotent: always returns 200. deleted:true when the caller's item was removed; " +
+        "deleted:false when the id is unknown, already deleted, or owned by a different member. " +
+        "Other members' items are never deleted and their existence is not revealed. " +
+        "remaining reflects the caller's per-user per-trip souvenir count after the operation. " +
+        "Any trip member (including viewers) may call this tool for their own items. " +
+        "Requires souvenirs:write scope.",
+      inputSchema: INPUT_SHAPES.delete_souvenir,
+      annotations: DELETE_ANNOTATIONS,
+    },
+    async (args) => {
+      try {
+        const result = await client.deleteSouvenir(args.tripId, args.itemId);
         return toolResult(result);
       } catch (err) {
         return toolError(err instanceof Error ? err.message : "Unexpected error");

--- a/apps/mcp/src/tools.ts
+++ b/apps/mcp/src/tools.ts
@@ -54,10 +54,14 @@ export const INPUT_SHAPES = {
     listId: z.string().uuid(),
     limit: z.number().int().min(1).max(100).optional(),
     offset: z.number().int().min(0).optional(),
+    // Case-insensitive partial match on bookmark name; omit to return all.
+    q: z.string().optional(),
   },
   list_articles: {
     limit: z.number().int().min(1).max(100).optional(),
     offset: z.number().int().min(0).optional(),
+    // Case-insensitive partial match on article title; omit to return all.
+    q: z.string().optional(),
   },
   get_article: {
     id: z.string().uuid(),
@@ -66,11 +70,15 @@ export const INPUT_SHAPES = {
     tripId: z.string().uuid(),
     limit: z.number().int().min(1).max(100).optional(),
     offset: z.number().int().min(0).optional(),
+    // Case-insensitive partial match on candidate name; omit to return all.
+    q: z.string().optional(),
   },
   list_souvenirs: {
     tripId: z.string().uuid(),
     limit: z.number().int().min(1).max(100).optional(),
     offset: z.number().int().min(0).optional(),
+    // Case-insensitive partial match on souvenir name; omit to return all.
+    q: z.string().optional(),
   },
 
   // --- Write tools (16) ---
@@ -433,7 +441,7 @@ export function registerTools(server: McpServer, client: ApiClient): void {
       description:
         "List bookmarks inside a specific bookmark list. " +
         "Only lists owned by the API key holder are accessible. " +
-        "Supports limit/offset pagination.",
+        "Supports limit/offset pagination and optional q for partial name matching.",
       inputSchema: INPUT_SHAPES.list_bookmarks,
       annotations: READ_ANNOTATIONS,
     },
@@ -442,6 +450,7 @@ export function registerTools(server: McpServer, client: ApiClient): void {
         const result = await client.listBookmarks(args.listId, {
           limit: args.limit,
           offset: args.offset,
+          q: args.q,
         });
         return toolResult(result);
       } catch (err) {
@@ -456,7 +465,7 @@ export function registerTools(server: McpServer, client: ApiClient): void {
       description:
         "List articles owned by the API key holder (without content body). " +
         "Use get_article to fetch the full content of a specific article. " +
-        "Supports limit/offset pagination.",
+        "Supports limit/offset pagination and optional q for partial title matching.",
       inputSchema: INPUT_SHAPES.list_articles,
       annotations: READ_ANNOTATIONS,
     },
@@ -495,7 +504,8 @@ export function registerTools(server: McpServer, client: ApiClient): void {
       description:
         "List a trip's candidates — unassigned spots in the planning pool " +
         "(schedules not yet placed on a specific day). Ordered by sortOrder. " +
-        "Supports limit/offset pagination. Requires trips:read scope.",
+        "Supports limit/offset pagination and optional q for partial name matching. " +
+        "Requires trips:read scope.",
       inputSchema: INPUT_SHAPES.list_candidates,
       annotations: READ_ANNOTATIONS,
     },
@@ -504,6 +514,7 @@ export function registerTools(server: McpServer, client: ApiClient): void {
         const result = await client.listCandidates(args.tripId, {
           limit: args.limit,
           offset: args.offset,
+          q: args.q,
         });
         return toolResult(result);
       } catch (err) {
@@ -518,7 +529,8 @@ export function registerTools(server: McpServer, client: ApiClient): void {
       description:
         "List a trip's souvenirs: the API key user's own items plus other members' shared items. " +
         "The owner is identified by memberNo (consistent with get_trip's member list). " +
-        "Supports limit/offset pagination. Requires souvenirs:read scope.",
+        "Supports limit/offset pagination and optional q for partial name matching. " +
+        "Requires souvenirs:read scope.",
       inputSchema: INPUT_SHAPES.list_souvenirs,
       annotations: READ_ANNOTATIONS,
     },
@@ -527,6 +539,7 @@ export function registerTools(server: McpServer, client: ApiClient): void {
         const result = await client.listSouvenirs(args.tripId, {
           limit: args.limit,
           offset: args.offset,
+          q: args.q,
         });
         return toolResult(result);
       } catch (err) {

--- a/docs/architecture/external-api.md
+++ b/docs/architecture/external-api.md
@@ -170,7 +170,7 @@ v1 エンドポイントの OpenAPI 3.1 仕様と Scalar UI を提供する。
 
 **認証**: `requireAuth` + `requireNonGuest`（Cookie セッション + 本登録ユーザー限定）。ゲストアカウントや未認証ユーザーには公開しない。
 
-**spec の内容**: v1 の 27 エンドポイント（read 9 + write 18）のみ記載。Bearer セキュリティスキーム（`type: http, scheme: bearer`）を `components.securitySchemes.bearerAuth` に定義し、全操作に適用。`servers: [{ url: "/api/v1" }]` でベースパスを明示。
+**spec の内容**: v1 の 29 エンドポイント（read 9 + write 20）のみ記載。Bearer セキュリティスキーム（`type: http, scheme: bearer`）を `components.securitySchemes.bearerAuth` に定義し、全操作に適用。`servers: [{ url: "/api/v1" }]` でベースパスを明示。
 
 **Scalar UI のアセット**: `@scalar/api-reference` を `apps/web` の devDependency として固定バージョン管理する。`apps/web/scripts/copy-scalar-assets.ts` が dev サーバ起動時（`predev`）とビルド時（`prebuild`）に standalone バンドルを `apps/web/public/scalar/standalone.js` へコピーし、Next.js が同一オリジン（`/scalar/standalone.js`）から配信する。第三者オリジン依存ゼロ。生成物は `.gitignore` で除外済み（3.5 MB をリポジトリにコミットしない）。
 
@@ -183,7 +183,7 @@ v1 エンドポイントの OpenAPI 3.1 仕様と Scalar UI を提供する。
 v1 REST を LLM（Claude Desktop / Claude Code 等）から扱うための MCP サーバ。`apps/mcp`（`private`、未公開）に置き、**stdio トランスポート**で動作する（LLM クライアントが子プロセスとして起動）。
 
 - 認証: API キーを環境変数 `SUGARA_API_KEY` で受け取り `Authorization: Bearer` で v1 を叩く。接続先は `SUGARA_API_URL`。生キーはログ・エラーに出さない
-- ツール: v1 の 27 エンドポイントに 1:1 対応する 29 ツール（batch 2 つを含む）。read 9 つ（`list_trips` / `get_trip` / `list_trip_expenses` / `list_bookmark_lists` / `list_bookmarks` / `list_articles` / `get_article` / `list_candidates` / `list_souvenirs`）+ write 20（`create_trip` / `update_trip` / `create_schedule` / `update_schedule` / `create_expense` / `update_expense` / `create_bookmark_list` / `update_bookmark_list` / `create_bookmark` / `update_bookmark` / `create_article` / `update_article` / `create_candidate` / `update_candidate` / `create_souvenir` / `update_souvenir` / `batch_create_candidates` / `batch_create_souvenirs` / `delete_candidate` / `delete_souvenir`）。入力は zod で境界検証（limit 1–100 / offset 0+ / uuid / scope enum）
+- ツール: v1 の 29 エンドポイントに 1:1 対応する 29 ツール（batch 2 つを含む）。read 9 つ（`list_trips` / `get_trip` / `list_trip_expenses` / `list_bookmark_lists` / `list_bookmarks` / `list_articles` / `get_article` / `list_candidates` / `list_souvenirs`）+ write 20（`create_trip` / `update_trip` / `create_schedule` / `update_schedule` / `create_expense` / `update_expense` / `create_bookmark_list` / `update_bookmark_list` / `create_bookmark` / `update_bookmark` / `create_article` / `update_article` / `create_candidate` / `update_candidate` / `create_souvenir` / `update_souvenir` / `batch_create_candidates` / `batch_create_souvenirs` / `delete_candidate` / `delete_souvenir`）。入力は zod で境界検証（limit 1–100 / offset 0+ / uuid / scope enum）
 - annotations: read ツールは `readOnlyHint: true`、create 系は `destructiveHint: false`、update/delete 系は `destructiveHint: true, idempotentHint: true` を明示し、MCP クライアント側の確認 UI 判断に供する
 - エラー: v1 の `{ error: { code, message } }` を人間可読メッセージに写像（`isError: true`）
 - stdio のため公開ネットワーク面はなく、攻撃面は「キーを持つローカルプロセス」に限定

--- a/docs/architecture/external-api.md
+++ b/docs/architecture/external-api.md
@@ -82,6 +82,11 @@ write は read を**含意しない**（最小権限。read と write は独立�
 - GET レスポンスの `amount` / `splits[].amount` は **minor units**（例: USD なら $12.50 が `1250`）。equal 分割の splits は旅行通貨建て、custom/itemized は費用通貨建て
 - memberNo はメンバー増減で振り直されるため、書き込み直前に `GET /trips/:id` で最新の対応を確認すること
 - 作成は `201`、更新は `200`。レスポンスは read 系と同じ外部 DTO（memberNo + displayName、内部 UUID 非公開）
+  - **例外**: `POST /trips/:tripId/candidates`、`PATCH /trips/:tripId/candidates/:scheduleId`、`POST /trips/:tripId/souvenirs`、`PATCH /trips/:tripId/souvenirs/:itemId` はトップレベルに `_meta: { count: number, max: number }` フィールドを追加で返す。他のエンドポイント（schedule write を含む）には付かない
+  - `_meta.count` の意味（リソースごとに異なる）
+    - **candidate**: 当該 trip 内の全 schedule 件数（割り当て済みと候補の合算）。`max` = `MAX_SCHEDULES_PER_TRIP`(300)
+    - **souvenir**: API キー所有者のこの trip における件数（共有アイテムは含めない自分のお土産のみ）。`max` = `MAX_SOUVENIRS_PER_USER_PER_TRIP`(100)
+  - **注意**: `_meta.count` は GET の `limit` / `offset` による候補一覧の総件数とは異なる。candidate は「割り当て済みも含めた全 schedule」、souvenir は「他メンバーの共有アイテムを除いた自分の件数」。上限チェック（409 conflict）のロジックと同じフィルタが使われる
 - 共有ロジック: 旅行更新・費用作成/更新は内部 API と同一のサービス関数（`apps/api/src/lib/trip-service.ts` / `expense-service.ts`）を経由し、検証・通知・アクティビティログの挙動を揃える
 
 **外部 DTO**:

--- a/docs/architecture/external-api.md
+++ b/docs/architecture/external-api.md
@@ -30,7 +30,7 @@
 | `bookmarks:write` | ブックマークリスト・ブックマークの作成・更新（自分のリストのみ） |
 | `souvenirs:write` | お土産の作成・更新（自分のお土産のみ） |
 
-write は read を**含意しない**（最小権限。read と write は独立に付与する）。削除（DELETE）は外部 API では提供しない（誤削除リスクを避け Web UI に限定）。既存の read のみのキーは write スコープを保有しないため挙動不変（後方互換）。
+write は read を**含意しない**（最小権限。read と write は独立に付与する）。`trips:write` は候補の削除、`souvenirs:write` はお土産の削除にも使用する。既存の read のみのキーは write スコープを保有しないため挙動不変（後方互換）。
 
 ## エンドポイント一覧
 
@@ -60,9 +60,11 @@ write は read を**含意しない**（最小権限。read と write は独立�
 | GET | `/trips/:tripId/candidates` | `trips:read` | 旅行の候補（未割り当てスポット）一覧 |
 | POST | `/trips/:tripId/candidates` | `trips:write` | 候補作成（上限超過は 409） |
 | PATCH | `/trips/:tripId/candidates/:scheduleId` | `trips:write` | 候補更新（割り当て済みは 404） |
+| DELETE | `/trips/:tripId/candidates/:scheduleId` | `trips:write` | 候補削除（冪等。未割り当て候補のみ対象。割り当て済み・不明は `deleted: false`） |
 | GET | `/trips/:tripId/souvenirs` | `souvenirs:read` | 旅行のお土産一覧（自分のもの + 共有アイテム） |
 | POST | `/trips/:tripId/souvenirs` | `souvenirs:write` | お土産作成（上限超過は 409） |
 | PATCH | `/trips/:tripId/souvenirs/:itemId` | `souvenirs:write` | お土産更新（自分のお土産のみ） |
+| DELETE | `/trips/:tripId/souvenirs/:itemId` | `souvenirs:write` | お土産削除（冪等。自分のお土産のみ対象。他ユーザーのもの・不明は `deleted: false`） |
 
 候補は schedules テーブルの行（`dayPatternId = NULL`）であり、専用スコープではなく既存の `trips:*` を用いる（予定 write が `trips:write` を使う前例に揃える）。お土産は旅行構造に属さない独立リソースのため専用の `souvenirs:*` スコープを持つ。
 
@@ -82,7 +84,7 @@ write は read を**含意しない**（最小権限。read と write は独立�
 - GET レスポンスの `amount` / `splits[].amount` は **minor units**（例: USD なら $12.50 が `1250`）。equal 分割の splits は旅行通貨建て、custom/itemized は費用通貨建て
 - memberNo はメンバー増減で振り直されるため、書き込み直前に `GET /trips/:id` で最新の対応を確認すること
 - 作成は `201`、更新は `200`。レスポンスは read 系と同じ外部 DTO（memberNo + displayName、内部 UUID 非公開）
-  - **例外**: `POST /trips/:tripId/candidates`、`PATCH /trips/:tripId/candidates/:scheduleId`、`POST /trips/:tripId/souvenirs`、`PATCH /trips/:tripId/souvenirs/:itemId` はトップレベルに `_meta: { count: number, max: number }` フィールドを追加で返す。他のエンドポイント（schedule write を含む）には付かない
+  - **例外**: `POST /trips/:tripId/candidates`、`PATCH /trips/:tripId/candidates/:scheduleId`、`POST /trips/:tripId/souvenirs`、`PATCH /trips/:tripId/souvenirs/:itemId` はトップレベルに `_meta: { count: number, max: number }` フィールドを追加で返す。`DELETE` 系（候補・お土産）は `{ id, deleted, remaining: { count, max } }` 形式で同等の残余情報を返す（冪等: 常に 200）。他のエンドポイント（schedule write を含む）には付かない
   - `_meta.count` の意味（リソースごとに異なる）
     - **candidate**: 当該 trip 内の全 schedule 件数（割り当て済みと候補の合算）。`max` = `MAX_SCHEDULES_PER_TRIP`(300)
     - **souvenir**: API キー所有者のこの trip における件数（共有アイテムは含めない自分のお土産のみ）。`max` = `MAX_SOUVENIRS_PER_USER_PER_TRIP`(100)
@@ -168,7 +170,7 @@ v1 エンドポイントの OpenAPI 3.1 仕様と Scalar UI を提供する。
 
 **認証**: `requireAuth` + `requireNonGuest`（Cookie セッション + 本登録ユーザー限定）。ゲストアカウントや未認証ユーザーには公開しない。
 
-**spec の内容**: v1 の 25 エンドポイント（read 9 + write 16）のみ記載。Bearer セキュリティスキーム（`type: http, scheme: bearer`）を `components.securitySchemes.bearerAuth` に定義し、全操作に適用。`servers: [{ url: "/api/v1" }]` でベースパスを明示。
+**spec の内容**: v1 の 27 エンドポイント（read 9 + write 18）のみ記載。Bearer セキュリティスキーム（`type: http, scheme: bearer`）を `components.securitySchemes.bearerAuth` に定義し、全操作に適用。`servers: [{ url: "/api/v1" }]` でベースパスを明示。
 
 **Scalar UI のアセット**: `@scalar/api-reference` を `apps/web` の devDependency として固定バージョン管理する。`apps/web/scripts/copy-scalar-assets.ts` が dev サーバ起動時（`predev`）とビルド時（`prebuild`）に standalone バンドルを `apps/web/public/scalar/standalone.js` へコピーし、Next.js が同一オリジン（`/scalar/standalone.js`）から配信する。第三者オリジン依存ゼロ。生成物は `.gitignore` で除外済み（3.5 MB をリポジトリにコミットしない）。
 
@@ -181,10 +183,10 @@ v1 エンドポイントの OpenAPI 3.1 仕様と Scalar UI を提供する。
 v1 REST を LLM（Claude Desktop / Claude Code 等）から扱うための MCP サーバ。`apps/mcp`（`private`、未公開）に置き、**stdio トランスポート**で動作する（LLM クライアントが子プロセスとして起動）。
 
 - 認証: API キーを環境変数 `SUGARA_API_KEY` で受け取り `Authorization: Bearer` で v1 を叩く。接続先は `SUGARA_API_URL`。生キーはログ・エラーに出さない
-- ツール: v1 の 25 エンドポイントに 1:1 対応する 25 ツール。read 9 つ（`list_trips` / `get_trip` / `list_trip_expenses` / `list_bookmark_lists` / `list_bookmarks` / `list_articles` / `get_article` / `list_candidates` / `list_souvenirs`）+ write 16（`create_trip` / `update_trip` / `create_schedule` / `update_schedule` / `create_expense` / `update_expense` / `create_bookmark_list` / `update_bookmark_list` / `create_bookmark` / `update_bookmark` / `create_article` / `update_article` / `create_candidate` / `update_candidate` / `create_souvenir` / `update_souvenir`）。入力は zod で境界検証（limit 1–100 / offset 0+ / uuid / scope enum）
-- annotations: read ツールは `readOnlyHint: true`、create 系は `destructiveHint: false`、update 系は既存データを上書きするため `destructiveHint: true` を明示し、MCP クライアント側の確認 UI 判断に供する
+- ツール: v1 の 27 エンドポイントに 1:1 対応する 29 ツール（batch 2 つを含む）。read 9 つ（`list_trips` / `get_trip` / `list_trip_expenses` / `list_bookmark_lists` / `list_bookmarks` / `list_articles` / `get_article` / `list_candidates` / `list_souvenirs`）+ write 20（`create_trip` / `update_trip` / `create_schedule` / `update_schedule` / `create_expense` / `update_expense` / `create_bookmark_list` / `update_bookmark_list` / `create_bookmark` / `update_bookmark` / `create_article` / `update_article` / `create_candidate` / `update_candidate` / `create_souvenir` / `update_souvenir` / `batch_create_candidates` / `batch_create_souvenirs` / `delete_candidate` / `delete_souvenir`）。入力は zod で境界検証（limit 1–100 / offset 0+ / uuid / scope enum）
+- annotations: read ツールは `readOnlyHint: true`、create 系は `destructiveHint: false`、update/delete 系は `destructiveHint: true, idempotentHint: true` を明示し、MCP クライアント側の確認 UI 判断に供する
 - エラー: v1 の `{ error: { code, message } }` を人間可読メッセージに写像（`isError: true`）
-- stdio のため公開ネットワーク面はなく、攻撃面は「キーを持つローカルプロセス」に限定。削除ツールは提供しない
+- stdio のため公開ネットワーク面はなく、攻撃面は「キーを持つローカルプロセス」に限定
 - SDK: `@modelcontextprotocol/sdk`。実行はビルドせず `bun run src/index.ts`（モノレポの TS 直接実行規約に準拠）
 - セットアップ手順は `apps/mcp/README.md`
 


### PR DESCRIPTION
## Summary

Claude アプリでの実運用フィードバックを受け、外部 API(v1)/MCP に 4 つの改善を追加した。

### Phase 0: フィードバック「201 成功なのに list に消えた」の真因調査
実運用データを MCP で実測し、**データ損失ではなく閲覧時の view 起因**と確定。

- souvenir 一覧は所有者フィルタ(`userId` 一致 or `isShared`)があるが、今回は同一アカウント運用のため無罪。
- candidate を日程に割り当てると候補プール(`dayPatternId IS NULL`)から外れ「消えた」ように見える(仕様)+ list の default `limit=50` でのページング。
- → 「消えたデータを delete で消し直す」必要は無いと判明したため、**delete を最優先せず**、可観測性(件数返却)と重複予防(search/batch)を先に入れ、delete は冪等・最小スコープで最後に追加する方針に再設定した。

### Phase 2: write 応答に件数/上限メタ `_meta`
candidate/souvenir の create(201)/update(200) に `_meta: { count, max }` を追加。

- `count` は **上限(cap)と同じフィルタ**で集計(candidate=trip 内の全 schedule 合算、souvenir=自分の per-user-per-trip)。list の total とは別物。
- schedule write と共有する `v1ScheduleWriteResponseSchema` を壊さないよう candidate 専用に `v1CandidateWriteResponseSchema` を分離(OpenAPI と実体の不一致を回避)。

### Phase 4: 一覧の名前部分一致検索 `?q=`
candidates/souvenirs/articles/bookmarks の list に任意の `q` を追加(`ilike`、name/title)。

- LIKE メタ文字(`% _ \`)を `escapeLike` でエスケープしワイルドカード注入を防止。count(total)も q 込みの同一フィルタで計算。

### Phase 3: 一括作成 batch
`POST /trips/:tripId/{candidates,souvenirs}/batch`(最大 50 件・1 トランザクション)。

- `onConflict="skip"` で同名(trim + 小文字の完全一致、バッチ内重複も)を skip。既定 `"create"` は後方互換。
- 上限超過は部分成功とし超過分を `skipped(reason:"limit_reached")` で返す。candidate は advisory lock で sortOrder を連番採番。
- search(部分一致)と dedup(正規化後の完全一致)の差異はツール説明に明記。

### Phase 1: 削除 DELETE(冪等・最小スコープ)
「削除は外部 API では提供しない」方針を改定し、candidate/souvenir のみ物理削除を追加。

- **冪等**: 対象不在/削除済みでも 404 ではなく 200 `{ id, deleted, remaining }`。LLM 駆動 MCP の retry が再作成/誤削除を起こさないようにする。
- candidate は `dayPatternId IS NULL` のガードを DELETE の WHERE に畳み込み `.returning()` で判定(**findFirst+delete の TOCTOU を排除**し、並行割り当てされた確定スケジュールを消さない)。削除時は `candidate_deleted` を通知。
- souvenir は userId+trip の三重ガードで他人の item を消さない。
- expense/schedule/article/bookmark は子レコード・集計の波及検証が必要なため今回は対象外。

### 変更点
- v1: `candidates-write.ts` / `souvenirs-write.ts` に batch/delete ルート、`index.ts` の list に `q`、`write-schemas.ts` にメタ/batch/delete スキーマ、`candidate-service.ts` / `souvenir-service.ts`(新規)に batch core、`lib/like-escape.ts`(新規)
- MCP: `batch_create_*` / `delete_*` の4ツール追加(計 29 ツール)、list ツールに `q`
- ドキュメント: `docs/architecture/external-api.md`(削除方針・エンドポイント表・件数・`_meta`・`q`)

### レビュー
- 各 Phase を implementer 実装 → code-reviewer/メインのレビュー → 修正 の単層連鎖で実施。
- 検出・修正した主な不具合: Phase 2 の `_meta` 分母ズレ、schedule schema 共有による OpenAPI 回帰、**Phase 1 candidate 削除の TOCTOU データ破壊バグ**、batch の競合増幅(soft cap として許容・コメント記録)、候補削除の通知非対称。

## Test plan
- [x] `bun run check-types`(5 パッケージ green)
- [x] `bun run --filter @sugara/api check` / `--filter @sugara/mcp check`(green)
- [x] `bun run --filter @sugara/api test`(928 passed)
- [x] `bun run --filter @sugara/mcp test`(151 passed)
- [x] `bun run --filter @sugara/api test:integration`(145 passed)
- [x] `bun run build`(web 含め green)
- 追加テスト: `_meta.count` が cap 同フィルタ(assigned schedule 込み)・schedule write に `_meta` が付かない回帰、`q` の一致/total/メタ文字エスケープ、batch の同名 skip/上限部分成功/sortOrder 連番/権限、delete の冪等(2回目 deleted:false)/割り当て済み candidate 不削除(DB 行残存)/他人 souvenir 不削除(DB 検証)/他 trip 不削除/権限 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)