### PR TITLE
fix: 天気更新の全件完了を修正しadmin手動更新を追加

### DIFF
--- a/apps/api/src/__tests__/admin-weather-refresh.test.ts
+++ b/apps/api/src/__tests__/admin-weather-refresh.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestApp, TEST_USER } from "./test-helpers";
+
+const mockGetSession = vi.fn();
+const mockRefreshAllWeather = vi.fn();
+
+vi.mock("../lib/auth", () => ({
+  auth: {
+    api: {
+      getSession: (...args: unknown[]) => mockGetSession(...args),
+    },
+  },
+}));
+
+vi.mock("../lib/weather-refresh", () => ({
+  refreshAllWeather: (...args: unknown[]) => mockRefreshAllWeather(...args),
+  WEATHER_REFRESH_BUDGET_MS: 45_000,
+}));
+
+import { adminRoutes } from "../routes/admin";
+
+const ADMIN_USER = {
+  ...TEST_USER,
+  username: "adminuser",
+  isAnonymous: false,
+  guestExpiresAt: null,
+};
+
+const app = createTestApp(adminRoutes, "/");
+
+function post(body?: unknown) {
+  return app.request("/api/admin/weather/refresh", {
+    method: "POST",
+    ...(body === undefined
+      ? {}
+      : { body: JSON.stringify(body), headers: { "Content-Type": "application/json" } }),
+  });
+}
+
+describe("POST /api/admin/weather/refresh", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.ADMIN_USERNAME = "adminuser";
+    mockRefreshAllWeather.mockResolvedValue({ updated: 58, skipped: 0, remaining: 0, total: 58 });
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetSession.mockResolvedValue(null);
+    const res = await post();
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when not admin", async () => {
+    mockGetSession.mockResolvedValue({
+      user: { ...ADMIN_USER, username: "notadmin" },
+      session: { id: "session-1" },
+    });
+    const res = await post();
+    expect(res.status).toBe(403);
+  });
+
+  it("does not run the refresh for a non-admin", async () => {
+    mockGetSession.mockResolvedValue({
+      user: { ...ADMIN_USER, username: "notadmin" },
+      session: { id: "session-1" },
+    });
+    await post();
+    expect(mockRefreshAllWeather).not.toHaveBeenCalled();
+  });
+
+  it("returns the refresh result for an admin", async () => {
+    mockGetSession.mockResolvedValue({ user: ADMIN_USER, session: { id: "session-1" } });
+    const res = await post();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ updated: 58, skipped: 0, remaining: 0, total: 58 });
+  });
+
+  it("refreshes only stale offices by default", async () => {
+    mockGetSession.mockResolvedValue({ user: ADMIN_USER, session: { id: "session-1" } });
+    await post();
+    expect(mockRefreshAllWeather).toHaveBeenCalledWith(
+      expect.objectContaining({ onlyStale: true }),
+    );
+  });
+
+  it("re-pulls every office when force is true", async () => {
+    mockGetSession.mockResolvedValue({ user: ADMIN_USER, session: { id: "session-1" } });
+    await post({ force: true });
+    expect(mockRefreshAllWeather).toHaveBeenCalledWith(
+      expect.objectContaining({ onlyStale: false }),
+    );
+  });
+
+  it("treats a missing body as a stale-only refresh", async () => {
+    mockGetSession.mockResolvedValue({ user: ADMIN_USER, session: { id: "session-1" } });
+    await post(); // no JSON body -> parse fallback to {}
+    expect(mockRefreshAllWeather).toHaveBeenCalledWith(
+      expect.objectContaining({ onlyStale: true }),
+    );
+  });
+});

--- a/apps/api/src/lib/weather-refresh.test.ts
+++ b/apps/api/src/lib/weather-refresh.test.ts
@@ -1,10 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockFetchOfficeForecast, mockInsertValues, mockTransaction } = vi.hoisted(() => ({
-  mockFetchOfficeForecast: vi.fn(),
-  mockInsertValues: vi.fn(),
-  mockTransaction: vi.fn(),
-}));
+const { mockFetchOfficeForecast, mockInsertValues, mockTransaction, mockFreshRows } = vi.hoisted(
+  () => ({
+    mockFetchOfficeForecast: vi.fn(),
+    mockInsertValues: vi.fn(),
+    mockTransaction: vi.fn(),
+    mockFreshRows: vi.fn(),
+  }),
+);
 
 vi.mock("./jma-weather", () => ({
   fetchOfficeForecast: (...args: unknown[]) => mockFetchOfficeForecast(...args),
@@ -12,6 +15,8 @@ vi.mock("./jma-weather", () => ({
 
 // db.transaction runs the callback with a tx that records insert().values()
 // and delete().where(); mockTransaction lets a test force a DB failure.
+// selectDistinct(...).from(...).where(...) resolves to the "fresh" office rows
+// for onlyStale runs.
 const tx = {
   insert: () => ({
     values: (...args: unknown[]) => {
@@ -25,6 +30,7 @@ const tx = {
 vi.mock("../db/index", () => ({
   db: {
     transaction: (fn: (t: typeof tx) => Promise<unknown>) => mockTransaction(fn),
+    selectDistinct: () => ({ from: () => ({ where: () => mockFreshRows() }) }),
   },
 }));
 
@@ -57,6 +63,7 @@ const parsed = () => ({
 beforeEach(() => {
   vi.clearAllMocks();
   mockTransaction.mockImplementation((fn: (t: typeof tx) => Promise<unknown>) => fn(tx));
+  mockFreshRows.mockResolvedValue([]);
 });
 
 describe("refreshAllWeather", () => {
@@ -67,20 +74,24 @@ describe("refreshAllWeather", () => {
       .mockResolvedValueOnce(parsed());
 
     const result = await refreshAllWeather({
-      delayMs: 0,
       areas: [area("130000"), area("016000"), area("270000")],
     });
 
-    expect(result).toEqual({ updated: 2, skipped: 1, total: 3 });
+    expect(result).toEqual({ updated: 2, skipped: 1, remaining: 0, total: 3 });
+  });
+
+  it("writes one row set per office that parsed", async () => {
+    mockFetchOfficeForecast.mockResolvedValueOnce(parsed()).mockResolvedValueOnce(parsed());
+
+    await refreshAllWeather({ areas: [area("130000"), area("270000")] });
+
     expect(mockInsertValues).toHaveBeenCalledTimes(2);
-    expect(mockFetchOfficeForecast).toHaveBeenCalledTimes(3);
   });
 
   it("fetches sub-area offices from their parent file with the area code", async () => {
     mockFetchOfficeForecast.mockResolvedValue(parsed());
 
     await refreshAllWeather({
-      delayMs: 0,
       areas: [area("014030", { forecastOffice: "014100", areaCode: "014030" })],
     });
 
@@ -93,22 +104,28 @@ describe("refreshAllWeather", () => {
       days: [],
     });
 
-    const result = await refreshAllWeather({ delayMs: 0, areas: [area("130000")] });
+    const result = await refreshAllWeather({ areas: [area("130000")] });
 
-    expect(result).toEqual({ updated: 0, skipped: 1, total: 1 });
+    expect(result).toEqual({ updated: 0, skipped: 1, remaining: 0, total: 1 });
+  });
+
+  it("does not write a row set for an office with no days", async () => {
+    mockFetchOfficeForecast.mockResolvedValue({
+      reportDatetime: "2026-06-19T11:00:00+09:00",
+      days: [],
+    });
+
+    await refreshAllWeather({ areas: [area("130000")] });
+
     expect(mockInsertValues).not.toHaveBeenCalled();
   });
 
   it("does not let one fetch failure abort the whole run", async () => {
     mockFetchOfficeForecast.mockResolvedValueOnce(null).mockResolvedValueOnce(parsed());
 
-    const result = await refreshAllWeather({
-      delayMs: 0,
-      areas: [area("a"), area("b")],
-    });
+    const result = await refreshAllWeather({ areas: [area("a"), area("b")] });
 
-    expect(result.updated).toBe(1);
-    expect(result.skipped).toBe(1);
+    expect(result).toMatchObject({ updated: 1, skipped: 1 });
   });
 
   it("counts a DB failure as a skip without aborting other offices", async () => {
@@ -119,11 +136,67 @@ describe("refreshAllWeather", () => {
       .mockRejectedValueOnce(new Error("pooler down"))
       .mockImplementationOnce((fn: (t: typeof tx) => Promise<unknown>) => fn(tx));
 
-    const result = await refreshAllWeather({
-      delayMs: 0,
-      areas: [area("a"), area("b")],
+    const result = await refreshAllWeather({ areas: [area("a"), area("b")] });
+
+    expect(result).toEqual({ updated: 1, skipped: 1, remaining: 0, total: 2 });
+  });
+
+  describe("onlyStale", () => {
+    it("skips offices already refreshed today", async () => {
+      mockFreshRows.mockResolvedValue([{ officeCode: "130000" }]);
+      mockFetchOfficeForecast.mockResolvedValue(parsed());
+
+      await refreshAllWeather({ onlyStale: true, areas: [area("130000"), area("270000")] });
+
+      expect(mockFetchOfficeForecast).toHaveBeenCalledExactlyOnceWith("270000", undefined);
     });
 
-    expect(result).toEqual({ updated: 1, skipped: 1, total: 2 });
+    it("reports total against all offices, not just the stale subset", async () => {
+      mockFreshRows.mockResolvedValue([{ officeCode: "130000" }]);
+      mockFetchOfficeForecast.mockResolvedValue(parsed());
+
+      const result = await refreshAllWeather({
+        onlyStale: true,
+        areas: [area("130000"), area("270000")],
+      });
+
+      expect(result).toEqual({ updated: 1, skipped: 0, remaining: 0, total: 2 });
+    });
+  });
+
+  describe("deadlineMs", () => {
+    it("leaves all offices as remaining when the budget is already spent", async () => {
+      mockFetchOfficeForecast.mockResolvedValue(parsed());
+
+      const result = await refreshAllWeather({
+        areas: [area("a"), area("b")],
+        deadlineMs: Date.now() - 1,
+      });
+
+      expect(result).toEqual({ updated: 0, skipped: 0, remaining: 2, total: 2 });
+    });
+
+    it("does not fetch any office once the budget is spent", async () => {
+      mockFetchOfficeForecast.mockResolvedValue(parsed());
+
+      await refreshAllWeather({ areas: [area("a")], deadlineMs: Date.now() - 1 });
+
+      expect(mockFetchOfficeForecast).not.toHaveBeenCalled();
+    });
+
+    it("counts only stale-and-unprocessed offices as remaining", async () => {
+      // 130000 is fresh (skipped before the budget check); of the two stale
+      // offices the budget is already spent, so both stay remaining.
+      mockFreshRows.mockResolvedValue([{ officeCode: "130000" }]);
+      mockFetchOfficeForecast.mockResolvedValue(parsed());
+
+      const result = await refreshAllWeather({
+        onlyStale: true,
+        areas: [area("130000"), area("270000"), area("016000")],
+        deadlineMs: Date.now() - 1,
+      });
+
+      expect(result).toEqual({ updated: 0, skipped: 0, remaining: 2, total: 3 });
+    });
   });
 });

--- a/apps/api/src/lib/weather-refresh.ts
+++ b/apps/api/src/lib/weather-refresh.ts
@@ -1,45 +1,53 @@
-import { and, eq, lt, sql } from "drizzle-orm";
+import type { WeatherRefreshResult } from "@sugara/shared";
+import { and, eq, gte, lt, sql } from "drizzle-orm";
 import { db } from "../db/index";
 import { weatherForecasts } from "../db/schema";
 import { WEATHER_AREAS, type WeatherAreaSeed } from "../db/weather-areas-data";
+import type { ParsedForecast } from "./jma-weather";
 import { fetchOfficeForecast } from "./jma-weather";
 import { logger } from "./logger";
 
-export type RefreshResult = { updated: number; skipped: number; total: number };
+export type { WeatherRefreshResult };
 
 // Fetch a handful of offices at a time: bounded enough to stay polite to the
 // unofficial JMA endpoint, parallel enough to finish well inside the function
-// timeout even if several offices hit the per-request timeout.
-const CONCURRENCY = 6;
+// timeout even if several offices hit the per-request timeout. Only the network
+// fetch is parallel — the DB writes are strictly sequential (see persistOffice).
+const FETCH_CONCURRENCY = 6;
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+// Time budget for a single run, well under the route's 60s maxDuration. The
+// deadline is only checked between batches, so a run can overshoot by one batch
+// (~8s fetch timeout + ~3s sequential writes ≈ 11s); 45s + 11s stays < 60s.
+export const WEATHER_REFRESH_BUDGET_MS = 45_000;
+
+// Fetch one office's forecast (network only, no DB). Returns null on any fetch /
+// parse failure so the office is simply skipped and keeps its prior stored data.
+async function fetchOffice(area: WeatherAreaSeed): Promise<ParsedForecast | null> {
+  return fetchOfficeForecast(area.forecastOffice ?? area.officeCode, area.areaCode);
 }
 
-// Refresh one office: fetch + upsert + prune stale rows. Returns whether it was
-// updated. All failures (fetch, parse, or DB) are swallowed and counted as a
-// skip so one office can never abort the whole run, and the office keeps its
-// previously stored forecast.
-async function refreshOffice(area: WeatherAreaSeed): Promise<boolean> {
-  const officeCode = area.officeCode;
+// Persist one office's forecast: upsert this week + prune older rows in a single
+// transaction. Returns whether it was written. Runs ONE AT A TIME: concurrent
+// transactions through Supabase's Transaction Pooler (Supavisor) stall in
+// ClientRead and hang the whole run (same gotcha documented in admin.ts), which
+// is what was leaving the daily refresh stuck after only a few offices.
+async function persistOffice(officeCode: string, parsed: ParsedForecast): Promise<boolean> {
+  if (parsed.days.length === 0) return false;
+  const reportDatetime = new Date(parsed.reportDatetime);
+  const rows = parsed.days.map((d) => ({
+    officeCode,
+    forecastDate: d.date,
+    weatherCode: d.weatherCode,
+    pop: d.pop,
+    tempMin: d.tempMin,
+    tempMax: d.tempMax,
+    reliability: d.reliability,
+    reportDatetime,
+  }));
+
   try {
-    const parsed = await fetchOfficeForecast(area.forecastOffice ?? officeCode, area.areaCode);
-    if (!parsed || parsed.days.length === 0) return false;
-
-    const reportDatetime = new Date(parsed.reportDatetime);
-    const rows = parsed.days.map((d) => ({
-      officeCode,
-      forecastDate: d.date,
-      weatherCode: d.weatherCode,
-      pop: d.pop,
-      tempMin: d.tempMin,
-      tempMax: d.tempMax,
-      reliability: d.reliability,
-      reportDatetime,
-    }));
-
-    // Upsert this week and prune older rows in one transaction so a reader never
-    // sees a half-updated office and a mid-way DB error rolls back cleanly.
+    // One transaction so a reader never sees a half-updated office and a mid-way
+    // DB error rolls back cleanly.
     await db.transaction(async (tx) => {
       await tx
         .insert(weatherForecasts)
@@ -72,28 +80,69 @@ async function refreshOffice(area: WeatherAreaSeed): Promise<boolean> {
   }
 }
 
-// Refresh every office's weekly forecast from JMA and upsert into the DB.
+// Start of the current day in JST, as a UTC Date. An office whose rows were
+// updated at/after this instant has already been refreshed today.
+function jstStartOfTodayUtc(): Date {
+  const jstNow = new Date(Date.now() + 9 * 60 * 60 * 1000);
+  const utcMidnight = Date.UTC(jstNow.getUTCFullYear(), jstNow.getUTCMonth(), jstNow.getUTCDate());
+  return new Date(utcMidnight - 9 * 60 * 60 * 1000);
+}
+
+// Office codes already refreshed today (so onlyStale runs can skip them).
+async function freshOfficeCodes(since: Date): Promise<Set<string>> {
+  const rows = await db
+    .selectDistinct({ officeCode: weatherForecasts.officeCode })
+    .from(weatherForecasts)
+    .where(gte(weatherForecasts.updatedAt, since));
+  return new Set(rows.map((r) => r.officeCode));
+}
+
+// Refresh offices' weekly forecasts from JMA and upsert into the DB.
 //
 // Iterates the office master constant (so the fetch mapping for sub-area offices
-// is available) in small concurrent batches. An office that fails to fetch,
-// parse, or persist is skipped; one failure never aborts the run.
+// is available), fetching in small concurrent batches but writing sequentially.
+// An office that fails to fetch, parse, or persist is skipped; one failure never
+// aborts the run.
+//
+// onlyStale: skip offices already refreshed today (used by the daily cron and
+//   the admin "continue" action so re-runs converge on the leftovers).
+// deadlineMs: epoch ms to stop starting new offices by, leaving the rest as
+//   `remaining`. Keeps a single run inside the function's maxDuration; the next
+//   run (cron or admin) finishes the rest.
 export async function refreshAllWeather({
-  delayMs = 300,
   areas = WEATHER_AREAS,
+  onlyStale = false,
+  deadlineMs,
 }: {
-  delayMs?: number;
   areas?: WeatherAreaSeed[];
-} = {}): Promise<RefreshResult> {
-  let updated = 0;
-
-  for (let i = 0; i < areas.length; i += CONCURRENCY) {
-    const batch = areas.slice(i, i + CONCURRENCY);
-    const results = await Promise.all(batch.map(refreshOffice));
-    updated += results.filter(Boolean).length;
-    if (delayMs > 0 && i + CONCURRENCY < areas.length) await sleep(delayMs);
+  onlyStale?: boolean;
+  deadlineMs?: number;
+} = {}): Promise<WeatherRefreshResult> {
+  let target = areas;
+  if (onlyStale) {
+    const fresh = await freshOfficeCodes(jstStartOfTodayUtc());
+    target = areas.filter((a) => !fresh.has(a.officeCode));
   }
 
-  const skipped = areas.length - updated;
-  logger.info({ updated, skipped, total: areas.length }, "weather refresh complete");
-  return { updated, skipped, total: areas.length };
+  let updated = 0;
+  let processed = 0;
+  for (let i = 0; i < target.length; i += FETCH_CONCURRENCY) {
+    if (deadlineMs !== undefined && Date.now() >= deadlineMs) break;
+    const batch = target.slice(i, i + FETCH_CONCURRENCY);
+    const fetched = await Promise.all(batch.map(fetchOffice));
+    // Sequential DB writes (see persistOffice) — never Promise.all these.
+    for (let j = 0; j < batch.length; j++) {
+      const parsed = fetched[j];
+      processed++;
+      if (parsed && (await persistOffice(batch[j].officeCode, parsed))) updated++;
+    }
+  }
+
+  const skipped = processed - updated;
+  const remaining = target.length - processed;
+  logger.info(
+    { updated, skipped, remaining, total: areas.length, onlyStale },
+    "weather refresh complete",
+  );
+  return { updated, skipped, remaining, total: areas.length };
 }

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -16,6 +16,7 @@ import { getAppSettings, isValidMapsMode } from "../lib/app-settings";
 import { logger } from "../lib/logger";
 import { getParam } from "../lib/params";
 import { hashPassword } from "../lib/password";
+import { refreshAllWeather, WEATHER_REFRESH_BUDGET_MS } from "../lib/weather-refresh";
 import { requireAuth } from "../middleware/auth";
 import { requireAdmin } from "../middleware/require-admin";
 import type { AppEnv } from "../types";
@@ -316,6 +317,22 @@ adminRoutes.post("/api/admin/users/:userId/temp-password", requireAuth, requireA
   }
 
   return c.json({ tempPassword });
+});
+
+// POST /api/admin/weather/refresh — manually refresh JMA forecasts (admin only).
+// Default refreshes only offices not yet updated today (converges on the daily
+// cron's leftovers); force=true re-pulls every office. Time-budgeted like the
+// cron so it stays inside maxDuration; the response's `remaining` tells the
+// admin whether another run is needed.
+adminRoutes.post("/api/admin/weather/refresh", requireAuth, requireAdmin, async (c) => {
+  const body = await c.req.json<{ force?: unknown }>().catch(() => ({}) as { force?: unknown });
+  const force = body.force === true;
+
+  const result = await refreshAllWeather({
+    onlyStale: !force,
+    deadlineMs: Date.now() + WEATHER_REFRESH_BUDGET_MS,
+  });
+  return c.json(result);
 });
 
 adminRoutes.post("/api/admin/announcement", requireAuth, requireAdmin, async (c) => {

--- a/apps/api/src/routes/cron.test.ts
+++ b/apps/api/src/routes/cron.test.ts
@@ -13,6 +13,7 @@ vi.mock("../lib/cleanup-guests", () => ({
 const refreshAllWeather = vi.fn();
 vi.mock("../lib/weather-refresh", () => ({
   refreshAllWeather: (...args: unknown[]) => refreshAllWeather(...args),
+  WEATHER_REFRESH_BUDGET_MS: 45_000,
 }));
 
 // getRedis returns redisState.client; null (the default) exercises the

--- a/apps/api/src/routes/cron.ts
+++ b/apps/api/src/routes/cron.ts
@@ -5,7 +5,7 @@ import { deleteExpiredGuests } from "../lib/cleanup-guests";
 import { env } from "../lib/env";
 import { logger } from "../lib/logger";
 import { getRedis } from "../lib/redis";
-import { refreshAllWeather } from "../lib/weather-refresh";
+import { refreshAllWeather, WEATHER_REFRESH_BUDGET_MS } from "../lib/weather-refresh";
 
 export const cronRoutes = new Hono();
 
@@ -76,7 +76,13 @@ cronRoutes.get("/cron/refresh-weather", async (c) => {
   // Always return 200, even on unexpected failure, so Vercel Cron does not
   // retry-storm a transient outage into overlapping runs.
   try {
-    const result = await refreshAllWeather();
+    // onlyStale so a re-run (or the admin button) converges on the leftovers;
+    // deadline keeps the run inside the route's maxDuration (60s), leaving any
+    // unprocessed offices stale for the next run.
+    const result = await refreshAllWeather({
+      onlyStale: true,
+      deadlineMs: Date.now() + WEATHER_REFRESH_BUDGET_MS,
+    });
     return c.json(result, 200);
   } catch (err) {
     logger.error({ err }, "cron: weather refresh threw unexpectedly");

--- a/apps/web/app/admin/_components/admin-client.tsx
+++ b/apps/web/app/admin/_components/admin-client.tsx
@@ -1,8 +1,16 @@
 "use client";
 
-import { type AdminStatsResponse, MAX_TRIP_LIMIT } from "@sugara/shared";
+import { type AdminStatsResponse, MAX_TRIP_LIMIT, type WeatherRefreshResult } from "@sugara/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ExternalLink, KeyRound, Save, SlidersHorizontal, X } from "lucide-react";
+import {
+  CloudSun,
+  ExternalLink,
+  KeyRound,
+  RefreshCw,
+  Save,
+  SlidersHorizontal,
+  X,
+} from "lucide-react";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -138,6 +146,59 @@ function AnnouncementSection() {
         <Button size="sm" disabled={save.isPending} onClick={() => save.mutate(draft)}>
           <Save className="h-3.5 w-3.5" />
           {save.isPending ? "保存中..." : "保存"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function WeatherRefreshSection() {
+  const [result, setResult] = useState<WeatherRefreshResult | null>(null);
+
+  const refresh = useMutation({
+    mutationFn: (force: boolean) =>
+      api<WeatherRefreshResult>("/api/admin/weather/refresh", {
+        method: "POST",
+        body: JSON.stringify({ force }),
+      }),
+    onSuccess: (r) => {
+      setResult(r);
+      toast.success(
+        r.remaining > 0
+          ? `天気を更新しました（更新 ${r.updated}件 / 残り ${r.remaining}件）`
+          : `天気を更新しました（更新 ${r.updated}件）`,
+      );
+    },
+    onError: () => toast.error("天気の更新に失敗しました"),
+  });
+
+  return (
+    <div className="rounded-lg border bg-card p-4 space-y-3">
+      <div>
+        <p className="font-medium text-sm">天気データ</p>
+        <p className="text-xs text-muted-foreground mt-0.5">
+          気象庁の週間天気予報を手動で更新します（通常は1日1回自動更新）。「更新」は未更新の地域のみ、「全件再取得」は全地域を取得します。残りがある場合はもう一度実行してください。
+        </p>
+      </div>
+      {result && (
+        <p className="text-xs text-muted-foreground tabular-nums">
+          前回: 更新 {result.updated} / スキップ {result.skipped} / 残り {result.remaining} / 全{" "}
+          {result.total}
+        </p>
+      )}
+      <div className="flex justify-end gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={refresh.isPending}
+          onClick={() => refresh.mutate(true)}
+        >
+          <RefreshCw className="h-3.5 w-3.5" />
+          全件再取得
+        </Button>
+        <Button size="sm" disabled={refresh.isPending} onClick={() => refresh.mutate(false)}>
+          <CloudSun className="h-3.5 w-3.5" />
+          {refresh.isPending ? "更新中..." : "更新"}
         </Button>
       </div>
     </div>
@@ -566,6 +627,7 @@ export default function AdminPage() {
                 </>
               )}
               <AnnouncementSection />
+              <WeatherRefreshSection />
             </TabsContent>
           </Tabs>
         </main>

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -441,3 +441,13 @@ export type AdminStatsResponse = {
     dbSizeBytes: number;
   };
 };
+
+// Result of a weather refresh run (daily cron or admin manual trigger).
+// total = all offices; remaining = stale offices left unprocessed when the run
+// stopped at its time budget. remaining === 0 means nothing stale is left today.
+export type WeatherRefreshResult = {
+  updated: number;
+  skipped: number;
+  remaining: number;
+  total: number;
+};


### PR DESCRIPTION
## Summary

本番 cron(06:00 JST)で天気更新が全58 office中、序盤数件(北海道の数地方)で止まっていた問題を修正し、あわせて admin から手動更新できるようにします。

### 根本原因
`refreshAllWeather` が `Promise.all` で **並列 DB トランザクション**を Supabase Transaction Pooler(Supavisor)に流していた。並列クエリは Supavisor で ClientRead wait → パイプラインストール → 無限ハングを起こす(`admin.ts` に記録済みの落とし穴)。結果、先頭数件だけ commit して `maxDuration`(60s)で関数が打ち切られていた。

### 変更
- **DB 書き込みを逐次化**(fetch は並列のまま)— 根本対策。`fetchOffice`(ネットワーク並列)と `persistOffice`(逐次 tx)に分離
- **差分更新 + 時間バジェットで再開可能化**: `onlyStale`(当日未更新の office のみ)+ `deadlineMs`(45s バジェット、バッチ境界で判定し1バッチ分のオーバーシュートを許容して 60s 内に収める)。戻り値に `remaining` を追加し、1回で終わらなくても次の cron / 手動更新で残りが埋まる
- **cron**: `onlyStale` + 時間バジェットで実行
- **admin 手動更新**: `POST /api/admin/weather/refresh`(`requireAuth` + `requireAdmin`、`{ force?: boolean }`。force で全件再取得)
- **admin UI**: 設定タブに「天気データ」更新ボタン(更新 / 全件再取得・残り件数表示)
- `WeatherRefreshResult` を `@sugara/shared` に集約

## Test plan
- [x] `bun run check` / `bun run check-types` 全 pass
- [x] `bun run test`: api 993 / shared 267 / web 845 全 pass
  - weather-refresh: 逐次 persist・stale フィルタ・時間バジェットで remaining・DB 失敗分離
  - admin route: 401/403/200・stale/force 分岐・body 省略時の fallback
  - cron: 既存の lock/異常系を維持

## レビュー観点(対応済み)
コードレビューの指摘(deadline オーバーシュートで maxDuration 超過の可能性 → バジェット 45s + コメント明記、集計セマンティクスの明記、stale+deadline 複合テスト追加、型の shared 集約)を反映済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)