### PR TITLE
fix: 天気地図を表の下に移動しクレジットを1段組みに

### DIFF
--- a/apps/web/components/japan-weather-map.tsx
+++ b/apps/web/components/japan-weather-map.tsx
@@ -148,35 +148,36 @@ export function JapanWeatherMapSkeleton({ officeCode }: { officeCode: string }) 
   );
 }
 
-// Attribution for the map data. Kept separate from JapanWeatherMap so the credit
-// can sit at the bottom of the page (under the table) rather than directly below
-// the map. Renders nothing when there is no map to credit.
+// Attribution for the map data, rendered right after the map. A separate
+// component so it can be placed independently and renders nothing when there is
+// no map to credit. One flowing paragraph keeps the license trailing the source
+// inline (wrapping naturally on narrow screens) instead of orphaning it on its
+// own line.
 export function WeatherMapCredit({ officeCode }: { officeCode: string }) {
   const t = useTranslations("weatherTool");
   if (!Object.hasOwn(WEATHER_MAP_PATHS, officeCode)) return null;
   return (
     <p className="text-center text-[0.6875rem] leading-relaxed text-muted-foreground/80">
-      <span className="block">
-        {t.rich("mapCredit", {
-          source: (chunks) => (
-            <a
-              href={MAP_SOURCE_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label={t("mapCreditSourceAria")}
-              className="underline-offset-2 hover:text-foreground hover:underline"
-            >
-              {chunks}
-            </a>
-          ),
-        })}
-      </span>
+      {t.rich("mapCredit", {
+        source: (chunks) => (
+          <a
+            href={MAP_SOURCE_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={t("mapCreditSourceAria")}
+            className="underline-offset-2 hover:text-foreground hover:underline"
+          >
+            {chunks}
+          </a>
+        ),
+      })}
+      <span aria-hidden="true"> · </span>
       <a
         href={CC_BY_URL}
         target="_blank"
         rel="noopener noreferrer"
         aria-label={t("mapCreditLicenseAria")}
-        className="inline-block underline-offset-2 hover:text-foreground hover:underline"
+        className="whitespace-nowrap underline-offset-2 hover:text-foreground hover:underline"
       >
         {t("mapCreditLicense")}
       </a>

--- a/apps/web/components/weather-detail.tsx
+++ b/apps/web/components/weather-detail.tsx
@@ -57,12 +57,12 @@ export function WeatherDetail({ officeCode, basePath }: { officeCode: string; ba
             {backLink}
             <Skeleton className="h-6 w-44" />
           </div>
-          <JapanWeatherMapSkeleton officeCode={officeCode} />
           <div className="space-y-2">
             {SKELETON_ROWS.map((row) => (
               <Skeleton key={row} className="h-12 w-full rounded-lg" />
             ))}
           </div>
+          <JapanWeatherMapSkeleton officeCode={officeCode} />
         </div>
       }
     >
@@ -79,8 +79,6 @@ export function WeatherDetail({ officeCode, basePath }: { officeCode: string; ba
               </span>
             </h1>
           </div>
-
-          <JapanWeatherMap officeCode={officeCode} />
 
           {data.days.length === 0 ? (
             // Suppress the empty notice while a (background) refetch is in flight
@@ -140,6 +138,7 @@ export function WeatherDetail({ officeCode, basePath }: { officeCode: string; ba
             </div>
           )}
 
+          <JapanWeatherMap officeCode={officeCode} />
           <WeatherMapCredit officeCode={officeCode} />
         </div>
       )}


### PR DESCRIPTION
## Summary

天気詳細ページのレイアウト微調整(マージ済み地図機能へのフォローアップ)。

### 変更内容

1. **地図を表の上から下へ移動** — 7日分の予報テーブルが最初に表示され、予報を見るためのスクロールが不要に。地図は補助情報として表の下に配置(スケルトンの地図プレースホルダも下に揃え、CLS を回避)
2. **クレジットを1段組みの自然折り返しに** — 従来の「block 2段組み + ライセンスが孤立行」をやめ、`出典 · CC BY 4.0` の連続した1段落に変更。SP 幅(360px)で従来3行だったのが**2行に収まり**、ライセンスが孤立した3行目に来なくなった
   - NII 指定の出典文(`『気象庁防災情報発表区域データセット』（NII作成）「GISデータ」（気象庁）を加工`)はライセンス上短縮できないため、SP では出典部分の折り返しは残るが、連続した脚注として読める
   - リンク(出典 / CC BY 4.0)と aria-label は維持

### 確認

SP 幅 360px でのレンダリング結果:
```
地図データ: 『気象庁防災情報発表区域データセット』（NII作成）
        「GISデータ」（気象庁）を加工 · CC BY 4.0
```

## Test plan

- [x] `bun run check` / `bun run check-types`
- [x] `bun run --filter @sugara/web test`(83 files / 852 tests passed)
- [x] SP 幅 360px でクレジットが2行に収まることを確認(headless Chrome レンダリング)
- [ ] 実機 SP で表が先頭表示・地図が下・クレジット2行を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
