### PR TITLE
fix: 天気詳細で地図が表より先に出るちらつきを解消

### DIFF
--- a/apps/web/components/weather-detail.test.tsx
+++ b/apps/web/components/weather-detail.test.tsx
@@ -1,0 +1,86 @@
+import type { WeatherDetailResponse } from "@sugara/shared";
+import { useIsRestoring, useQuery } from "@tanstack/react-query";
+import { cleanup, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { renderWithIntl } from "@/lib/test-utils";
+import { WeatherDetail } from "./weather-detail";
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: vi.fn(),
+  useIsRestoring: vi.fn(() => false),
+}));
+
+// Hokkaido (Sapporo) — present in WEATHER_MAP_PATHS, so the map renders a layout.
+const OFFICE_CODE = "011000";
+
+function baseResponse(days: WeatherDetailResponse["days"]): WeatherDetailResponse {
+  return {
+    officeCode: OFFICE_CODE,
+    name: "札幌",
+    centerName: "北海道地方",
+    reportDatetime: "2026-06-20T05:00:00+09:00",
+    days,
+  };
+}
+
+function mockQuery(state: {
+  data?: WeatherDetailResponse;
+  isLoading: boolean;
+  isFetching: boolean;
+}) {
+  vi.mocked(useQuery).mockReturnValue({
+    data: state.data,
+    isLoading: state.isLoading,
+    isError: false,
+    isFetching: state.isFetching,
+  } as ReturnType<typeof useQuery>);
+}
+
+function render() {
+  return renderWithIntl(<WeatherDetail officeCode={OFFICE_CODE} basePath="/tools/weather" />);
+}
+
+afterEach(() => {
+  cleanup();
+  vi.mocked(useIsRestoring).mockReturnValue(false);
+});
+
+const sampleDay: WeatherDetailResponse["days"][number] = {
+  date: "2026-06-20",
+  weatherCode: "100",
+  tempMax: 25,
+  tempMin: 18,
+  pop: 10,
+  reliability: null,
+};
+
+describe("WeatherDetail", () => {
+  it("does not paint the static map alone while a refetch fills empty days", () => {
+    // The regression: data exists with no days yet and a background refetch is in
+    // flight. The map needs no network, so it must not appear before the table.
+    mockQuery({ data: baseResponse([]), isLoading: false, isFetching: true });
+    render();
+
+    expect(screen.queryByRole("img", { name: /日本地図/ })).toBeNull();
+    expect(screen.queryByRole("table")).toBeNull();
+  });
+
+  it("renders the table and the map together once forecast days arrive", () => {
+    mockQuery({ data: baseResponse([sampleDay]), isLoading: false, isFetching: false });
+    render();
+
+    expect(screen.queryByRole("table")).not.toBeNull();
+    expect(screen.queryByRole("img", { name: /日本地図/ })).not.toBeNull();
+  });
+
+  it("shows the empty notice when the fetch settles on no forecast", () => {
+    mockQuery({ data: baseResponse([]), isLoading: false, isFetching: false });
+    render();
+
+    expect(
+      screen.queryByText(
+        "この地域の天気はまだ取得されていません。しばらくしてから再度お試しください。",
+      ),
+    ).not.toBeNull();
+  });
+});

--- a/apps/web/components/weather-detail.tsx
+++ b/apps/web/components/weather-detail.tsx
@@ -31,6 +31,12 @@ export function WeatherDetail({ officeCode, basePath }: { officeCode: string; ba
   });
   const today = jstToday();
 
+  // Until the forecast rows are actually present, keep the whole content behind
+  // the skeleton. Otherwise the static map (which needs no network) would paint
+  // alone during a background refetch while data.days is still empty, so the map
+  // appears first and the table pops in afterward.
+  const showLoading = isLoading || (isFetching && (!data || data.days.length === 0));
+
   const backLink = (
     <Link
       href={basePath}
@@ -43,7 +49,7 @@ export function WeatherDetail({ officeCode, basePath }: { officeCode: string; ba
 
   return (
     <LoadingBoundary
-      isLoading={isLoading}
+      isLoading={showLoading}
       error={isError ? new Error("weather detail") : null}
       errorFallback={
         <div className="space-y-3">
@@ -81,11 +87,9 @@ export function WeatherDetail({ officeCode, basePath }: { officeCode: string; ba
           </div>
 
           {data.days.length === 0 ? (
-            // Suppress the empty notice while a (background) refetch is in flight
-            // so it doesn't flash before the forecast arrives.
-            isFetching ? null : (
-              <p className="text-sm text-muted-foreground">{t("detailEmpty")}</p>
-            )
+            // A refetch over empty days is treated as loading (see showLoading),
+            // so reaching here means the fetch settled on a genuinely empty result.
+            <p className="text-sm text-muted-foreground">{t("detailEmpty")}</p>
           ) : (
             <div className="overflow-hidden rounded-lg border">
               <table className="w-full text-sm">


### PR DESCRIPTION
## Summary

天気詳細ページで、地図だけが先に表示され天気予報の表が後から入るちらつきを修正する。

### 原因
表は API データ（`useQuery`）依存・地図は静的データで、両者は同じ `data &&` ブロックにある。しかし `data` はあるが `data.days` がまだ空のまま背景リフェッチ中（`isFetching`）のとき、表側は `null` を返す一方で**地図だけが描画される**ため、「地図が先に出て天気が後から入る」状態になっていた。既存コードは空文言のフラッシュは抑止していたが、地図単独描画は抑止できていなかった。

### 修正
「データはあるが日次が空＋フェッチ中」の区間をローディング扱いにし、表スケルトンと地図スケルトンが揃った状態を表示することで、**表と地図を常に同時に表示**する。

```tsx
const showLoading = isLoading || (isFetching && (!data || data.days.length === 0));
```

併せて、上流ガードにより不要になった内側の `isFetching ? null` 分岐（デッドコード）を削除。

## Test plan

- [x] `bun run --filter @sugara/web check`（lint + format + import sort）green
- [x] `bun run --filter @sugara/web check-types` green
- [x] `bun run --filter @sugara/web test weather-detail` — 再現テスト3件 green
  - 空 days + リフェッチ中に地図が単独描画されないこと（旧コードでは fail する内容）
  - days 到着後に表と地図が同時に表示されること
  - フェッチ確定後に空の場合は空文言が出ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)